### PR TITLE
Notification list

### DIFF
--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -1,4 +1,3 @@
-const DirtyComponent = require('../dirty-component');
 const h = require('react-hyperscript');
 const _ = require('lodash');
 const { tippyTopZIndex } = require('../../defs');
@@ -38,7 +37,16 @@ module.exports = function({ controller, document, bus }){
   if( document.editable() ){
     grs.push([
       h(Tooltip, _.assign({}, baseTooltipProps,  { description: 'Tasks' }), [
-        h(TaskListButton, { controller, document, bus })
+        h(Toggle, {
+          className: 'editor-button plain-button task-list-button',
+          controller,
+          document,
+          bus,
+          onToggle: () => controller.toggleTaskListMode(),
+          getState: () => controller.taskListMode()
+        }, [
+          h(TaskListButton, { controller, document, bus })
+        ])
       ])
     ]);
 

--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -7,35 +7,7 @@ const Toggle = require('../toggle');
 const Popover = require('../popover/popover');
 const Linkout = require('../document-linkout');
 
-class TaskListButton extends DirtyComponent {
-  constructor(props){
-    super(props);
-  }
-
-  shouldComponentUpdate() {
-    return true;
-  }
-
-  componentDidMount(){
-    this.onAdd = () => this.dirty();
-    this.onRemove = () => this.dirty();
-    this.props.document.on('add', this.onAdd);
-    this.props.document.on('remove', this.onRemove);
-  }
-
-  componentWillUnmount(){
-    this.props.document.removeListener(this.onAdd);
-    this.props.document.removeListener(this.onRemove);
-  }
-
-  render() {
-    let numIncompleteEntities = this.props.document.entities().filter(ent => !ent.completed()).length;
-    return h('button.editor-button.plain-button', { onClick: () => this.props.bus.emit('toggletasklist') }, [
-      numIncompleteEntities !== 0 ? h('div.num-tasks', this.props.document.entities().filter(ent => !ent.completed()).length) : null,
-      h('i.material-icons', 'format_list_bulleted')
-    ]);
-  }
-}
+const { TaskListButton } = require('./task-list');
 
 module.exports = function({ controller, document, bus }){
   let grs = [];

--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -1,3 +1,4 @@
+const React = require('react');
 const h = require('react-hyperscript');
 const _ = require('lodash');
 const { tippyTopZIndex } = require('../../defs');
@@ -8,92 +9,99 @@ const Linkout = require('../document-linkout');
 
 const { TaskListButton } = require('./task-list');
 
-module.exports = function({ controller, document, bus }){
-  let grs = [];
 
+class EditorButtons extends React.Component {
+  render(){
+    let { bus, className, document, controller } = this.props;
+    let grs = [];
 
-  let baseTooltipProps = {
-    show: showNow => {
-      bus.on('showtips', showNow);
-    },
-    hide: hideNow => {
-      bus.on('hidetips', hideNow);
-    },
-    tippy: {
-      zIndex: tippyTopZIndex,
-      hideOnClick: false,
-      events: 'mouseenter manual'
-    }
-  };
-
-  grs.push([
-    h(Tooltip, { description: 'Help' }, [
-      h('button.editor-button.plain-button', { onClick: () => bus.emit('togglehelp') }, [
-        h('i.material-icons', 'info')
-      ])
-    ])
-  ]);
-
-  if( document.editable() ){
-    grs.push([
-      h(Tooltip, _.assign({}, baseTooltipProps,  { description: 'Tasks' }), [
-        h(Toggle, {
-          className: 'editor-button plain-button task-list-button',
-          controller,
-          document,
-          bus,
-          onToggle: () => controller.toggleTaskListMode(),
-          getState: () => controller.taskListMode()
-        }, [
-          h(TaskListButton, { controller, document, bus })
-        ])
-      ])
-    ]);
-
-    grs.push([
-      h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add an entity', shortcut: 'e' }), [
-        h('button.editor-button.plain-button', { onClick: () => controller.addElement().then( el => bus.emit('opentip', el) )  }, [
-          h('i.material-icons', 'add_circle')
-        ])
-      ]),
-
-      h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Draw an interaction', shortcut: 'd' }), [
-        h(Toggle, { className: 'editor-button plain-button', onToggle: () => controller.toggleDrawMode(), getState: () => controller.drawMode()  }, [
-          h('i.material-icons', 'arrow_forward')
-        ])
-      ]),
-
-      h(Tooltip, _.assign({}, baseTooltipProps, {  description: 'Delete selected', shortcut: 'del' }), [
-        h('button.editor-button.plain-button', { onClick: () => controller.removeSelected()  }, [
-          h('i.material-icons', 'clear')
-        ])
-      ])
-
-    ]);
-  }
-
-  grs.push([
-    h(Tooltip, _.assign({}, baseTooltipProps, {  description: 'Fit to screen', shortcut: 'f' }), [
-      h('button.editor-button.plain-button', { onClick: () => controller.fit()  }, [
-        h('i.material-icons', 'zoom_out_map')
-      ])
-    ]),
-
-    h(Popover, {
+    let baseTooltipProps = {
+      show: showNow => {
+        bus.on('showtips', showNow);
+      },
+      hide: hideNow => {
+        bus.on('hidetips', hideNow);
+      },
       tippy: {
-        position: 'right',
-        html: h('div.editor-linkout', [
-          h(Linkout, { document })
-        ])
+        zIndex: tippyTopZIndex,
+        hideOnClick: false,
+        events: 'mouseenter manual'
       }
-    }, [
-      h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Share link' }), [
-        h('button.editor-button.plain-button', [
-          h('i.material-icons', 'link')
+    };
+
+    grs.push([
+      h(Tooltip, { description: 'Help' }, [
+        h('button.editor-button.plain-button', { onClick: () => bus.emit('togglehelp') }, [
+          h('i.material-icons', 'info')
         ])
       ])
-    ])
-  ]);
+    ]);
 
-  return h('div.editor-buttons', grs.map( btns => h('div.editor-button-group', btns) ));
-};
+    if( document.editable() ){
+      grs.push([
+        h(Tooltip, _.assign({}, baseTooltipProps,  { description: 'Tasks' }), [
+          h(Toggle, {
+            className: 'editor-button plain-button task-list-button',
+            controller,
+            document,
+            bus,
+            onToggle: () => controller.toggleTaskListMode(),
+            getState: () => controller.taskListMode()
+          }, [
+            h(TaskListButton, { controller, document, bus })
+          ])
+        ])
+      ]);
+
+      grs.push([
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add an entity', shortcut: 'e' }), [
+          h('button.editor-button.plain-button', { onClick: () => controller.addElement().then( el => bus.emit('opentip', el) )  }, [
+            h('i.material-icons', 'add_circle')
+          ])
+        ]),
+
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Draw an interaction', shortcut: 'd' }), [
+          h(Toggle, { className: 'editor-button plain-button', onToggle: () => controller.toggleDrawMode(), getState: () => controller.drawMode()  }, [
+            h('i.material-icons', 'arrow_forward')
+          ])
+        ]),
+
+        h(Tooltip, _.assign({}, baseTooltipProps, {  description: 'Delete selected', shortcut: 'del' }), [
+          h('button.editor-button.plain-button', { onClick: () => controller.removeSelected()  }, [
+            h('i.material-icons', 'clear')
+          ])
+        ])
+
+      ]);
+    }
+
+    grs.push([
+      h(Tooltip, _.assign({}, baseTooltipProps, {  description: 'Fit to screen', shortcut: 'f' }), [
+        h('button.editor-button.plain-button', { onClick: () => controller.fit()  }, [
+          h('i.material-icons', 'zoom_out_map')
+        ])
+      ]),
+
+      h(Popover, {
+        tippy: {
+          position: 'right',
+          html: h('div.editor-linkout', [
+            h(Linkout, { document })
+          ])
+        }
+      }, [
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Share link' }), [
+          h('button.editor-button.plain-button', [
+            h('i.material-icons', 'link')
+          ])
+        ])
+      ])
+    ]);
+
+    return h(`div.${className}`, grs.map( btns => h('div.editor-button-group', btns) ));
+
+  }
+}
+
+module.exports = EditorButtons;
+

--- a/src/client/components/editor/help.js
+++ b/src/client/components/editor/help.js
@@ -76,10 +76,13 @@ class Help extends React.Component {
     let showHelp = this.data.showHelp;
     let editable = this.props.document.editable();
     let bus = this.props.bus;
-    let cy = this.props.controller.data.cy;
+    let controller = this.props.controller;
+    let cy = controller.data.cy;
 
     if( !showHelp ){
       bus.emit('showtips');
+
+      controller.resetMenuState();
 
       let ent = cy.nodes(node => !isInteractionNode(node)).first();
       if( !ent.empty() ){

--- a/src/client/components/editor/help.js
+++ b/src/client/components/editor/help.js
@@ -77,13 +77,10 @@ class Help extends React.Component {
     let editable = this.props.document.editable();
     let bus = this.props.bus;
     let controller = this.props.controller;
-    let cy = controller.data.cy;
+    let cy = this.props.cy;
 
-    if( !showHelp ){
+    let showTips = () => {
       bus.emit('showtips');
-
-      controller.resetMenuState();
-
       let ent = cy.nodes(node => !isInteractionNode(node)).first();
       if( !ent.empty() ){
         this.data.entTip = this.makeHelpTooltip( {
@@ -109,12 +106,19 @@ class Help extends React.Component {
         this.data.intnTip.show();
       }
       this.setData({ showHelp: true });
+    };
 
-    } else {
+    let hideTips = () => {
       bus.emit('hidetips');
       if( this.data.entTip ){ this.data.entTip.hide(); }
       if( this.data.intnTip ){ this.data.intnTip.hide(); }
       this.setData({ showHelp: false });
+    };
+
+    if( !showHelp ){
+      controller.resetMenuState().then( showTips );
+    } else {
+      hideTips();
     }
   }
 

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -342,6 +342,13 @@ class Editor extends React.Component {
     }
   }
 
+  resetMenuState(){
+    this.setData({
+      drawMode: false,
+      taskListMode: false
+    });
+  }
+
   render(){
     let { document, bus, incompleteNotification } = this.data;
     let controller = this;

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -346,13 +346,15 @@ class Editor extends React.Component {
     let { document, bus, incompleteNotification } = this.data;
     let controller = this;
 
+    let showTaskList = this.data.taskListMode;
+
     let editorContent = this.state.initted ? [
-      h(Buttons, { controller, document, bus }),
+      h(Buttons, { className: showTaskList ? 'editor-buttons.editor-buttons-shifted' : 'editor-buttons', controller, document, bus }),
       incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
-      h('div.editor-graph#editor-graph'),
+      h(`div.${showTaskList ? 'editor-graph-shifted#editor-graph' : 'editor-graph#editor-graph'}`),
       h(Help, { document, bus, controller }),
-      h(TaskList, { document, bus, controller, show: this.data.taskListMode })
+      h(TaskList, { document, bus, controller, show: showTaskList })
     ] : [];
 
     return h('div.editor' + ( this.state.initted ? '.editor-initted' : '' ), editorContent);

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -20,6 +20,7 @@ const defs = require('./defs');
 const Buttons = require('./buttons');
 const UndoRemove = require('./undo-remove');
 const Help = require('./help');
+const { TaskList } = require('./task-list');
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;
@@ -116,6 +117,7 @@ class Editor extends React.Component {
       bus: bus,
       document: doc,
       drawMode: false,
+      taskListMode: false,
       newElementShift: 0,
       mountDeferred: defer(),
       initted: false,
@@ -211,6 +213,17 @@ class Editor extends React.Component {
 
   drawMode(){
     return this.data.drawMode;
+  }
+
+  toggleTaskListMode( ){
+    this.data.bus.emit('toggletasklist');
+    this.setData({
+      taskListMode: !this.data.taskListMode
+    });
+  }
+
+  taskListMode(){
+    return this.data.taskListMode;
   }
 
   addElement( data = {} ){
@@ -338,7 +351,8 @@ class Editor extends React.Component {
       incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h('div.editor-graph#editor-graph'),
-      h(Help, { document, bus, controller })
+      h(Help, { document, bus, controller }),
+      h(TaskList, { document, bus, controller, show: this.data.taskListMode })
     ] : [];
 
     return h('div.editor' + ( this.state.initted ? '.editor-initted' : '' ), editorContent);

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -215,11 +215,14 @@ class Editor extends React.Component {
     return this.data.drawMode;
   }
 
-  toggleTaskListMode( ){
-    this.data.bus.emit('toggletasklist');
-    this.setData({
-      taskListMode: !this.data.taskListMode
-    });
+  toggleTaskListMode( toggle ){
+    if( !this.editable() ){ return; }
+
+    let on = toggle === undefined ? !this.taskListMode() : toggle;
+
+    this.data.bus.emit( on ? 'taskliston' : 'tasklistoff' );
+
+    return new Promise( resolve => this.setData({ taskListMode: on }, resolve) );
   }
 
   taskListMode(){
@@ -343,9 +346,9 @@ class Editor extends React.Component {
   }
 
   resetMenuState(){
-    this.setData({
-      drawMode: false,
-      taskListMode: false
+    return Promise.all([this.toggleTaskListMode(false),  this.toggleDrawMode(false)]).then( () => {
+      // wait for menu animations to complete
+      return new Promise( resolve => setTimeout(resolve, 250));
     });
   }
 
@@ -360,7 +363,7 @@ class Editor extends React.Component {
       incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h(`div.${showTaskList ? 'editor-graph-shifted#editor-graph' : 'editor-graph#editor-graph'}`),
-      h(Help, { document, bus, controller }),
+      h(Help, { document, bus, cy: this.data.cy, controller }),
       h(TaskList, { document, bus, controller, show: showTaskList })
     ] : [];
 

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -346,10 +346,7 @@ class Editor extends React.Component {
   }
 
   resetMenuState(){
-    return Promise.all([this.toggleTaskListMode(false),  this.toggleDrawMode(false)]).then( () => {
-      // wait for menu animations to complete
-      return new Promise( resolve => setTimeout(resolve, 250));
-    });
+    return Promise.all([this.toggleTaskListMode(false),  this.toggleDrawMode(false)]).delay(250);
   }
 
   render(){

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -346,6 +346,7 @@ class Editor extends React.Component {
   }
 
   resetMenuState(){
+    this.data.bus.emit('closetip');
     return Promise.all([this.toggleTaskListMode(false),  this.toggleDrawMode(false)]).delay(250);
   }
 

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -347,6 +347,7 @@ class Editor extends React.Component {
 
   resetMenuState(){
     this.data.bus.emit('closetip');
+    this.data.bus.emit('hidetips');
     return Promise.all([this.toggleTaskListMode(false),  this.toggleDrawMode(false)]).delay(250);
   }
 

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -85,22 +85,21 @@ class TaskList extends DirtyComponent {
 
   render(){
     let doc = this.props.document;
-    let ntfns = doc.entities().map(ent => {
-      return new Notification({
+    let ntfns = doc.entities().filter(ent => !ent.completed()).map(ent => {
+      let ntfn = new Notification({
         openable: true,
         openText: 'Show me',
         active: true,
         message: `Provide more information for incomplete entity ${ent.name() === '' ? 'unnamed entity' : ent.name()}.`
       });
+
+      ntfn.on('open', () => this.props.bus.emit('opentip', ent));
+
+      return ntfn;
     });
 
     let ntfnList = new NotificationList(ntfns);
     let ntfnPanel = h(NotificationPanel, { notificationList: ntfnList });
-    // let taskListContent = [
-    //   h('div.task-list-content', getIncompleteEntities(this.props.document).map(ent => {
-    //     return h('div', `complete ${ent.name() === '' ? 'unnamed entitiy' : ent.name()}`);
-    //   }))
-    // ];
 
     let taskListContent = [ntfnPanel];
 

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -10,9 +10,9 @@ const NotificationPanel = require('../notification/panel');
 const getIncompleteEntities = doc => doc.entities().filter(ent => !ent.completed());
 
 
-const eleEvts = [ 'rename', 'redescribe' ];
-const entEvts = [ 'modify', 'associated', 'unassociated', 'complete', 'uncomplete'];
-const intnEvts = [ 'retype' ];
+const eleEvts = [ 'rename' ];
+const entEvts = [ 'complete', 'uncomplete' ];
+const intnEvts = [ ];
 
 let bindEleEvts = (ele, cb) => {
   eleEvts.forEach(evt => {
@@ -91,7 +91,7 @@ class TaskList extends DirtyComponent {
         dismissable: false,
         openText: 'Show me',
         active: true,
-        message: `Provide more information for ${ent.name() === '' ? 'unnamed entity' : ent.name()}.`
+        message: `Provide more information for ${ent.name() === '' ? 'unnamed entity' : ent.name() + ' (?)'}.`
       });
 
       ntfn.on('open', () => this.props.bus.emit('opentip', ent));

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -61,7 +61,7 @@ class TaskList extends DirtyComponent {
 
   render(){
     let doc = this.props.document;
-    let ntfns = doc.elements().filter(ele => !ele.completed()).map(ele => {
+    let ntfns = doc.entities().concat(doc.interactions()).filter(ele => !ele.completed()).map(ele => {
       let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + ' (?)'}`;
       let innerMsg = entMsg(ele);
 

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -1,42 +1,23 @@
 const React = require('react');
 const DirtyComponent = require('../dirty-component');
 const h = require('react-hyperscript');
-const _ = require('lodash');
 
 const { makeClassList } = require('../../../util');
-const defs = require('../../defs');
 
-const NotificationPanel = require('../notification/panel');
 
+const getIncompleteEntities = doc => doc.entities().filter(ent => !ent.completed());
 
 class TaskList extends React.Component {
-  constructor(props){
-    super(props);
-
-    this.data = ({
-      showNotificationList: false
-    });
-
-    this.state = _.assign({}, this.data);
-
-    let toggleSideBar = () => this.toggleSideBar();
-    this.toggleSideBarHandler = toggleSideBar;
-    props.bus.on('toggletasklist', this.toggleSideBarHandler);
-  }
-
-  setData( obj, callback ){
-    _.assign( this.data, obj );
-
-    this.setState( obj, callback );
-  }
-
   render(){
     let taskListContent = [
-      h('div.task-list-content')
+      h('div.task-list-content', getIncompleteEntities(this.props.document).map(ent => {
+        return h('div', `complete ${ent.name() === '' ? 'unamed entitiy' : ent.name()}`);
+      }))
     ];
 
-
-    return h('div.task-list', taskListContent);
+    return h('div.task-list', {
+      className: makeClassList({ 'task-list-active': this.props.show })
+    }, taskListContent);
   }
 }
 
@@ -44,10 +25,6 @@ class TaskList extends React.Component {
 class TaskListButton extends DirtyComponent {
   constructor(props){
     super(props);
-  }
-
-  shouldComponentUpdate() {
-    return true;
   }
 
   componentDidMount(){
@@ -64,18 +41,12 @@ class TaskListButton extends DirtyComponent {
 
   render() {
 
-    let incompleteEnts = this.props.document.entities().filter(ent => !ent.completed());
+    let incompleteEnts = getIncompleteEntities(this.props.document);
     let numIncompleteEntities = incompleteEnts.length;
 
-    // let notifications = incompleteEnts.map(e => new Notification({
-    //   title: 'complete this entity',
-    //   message: 'entity'
-    // }));
-
-    return h('button.editor-button.plain-button.task-list-button', { onClick: () => this.props.bus.emit('toggletasklist') }, [
-      numIncompleteEntities !== 0 ? h('div.num-tasks-indicator', this.props.document.entities().filter(ent => !ent.completed()).length) : null,
-      h('i.material-icons', 'format_list_bulleted'),
-      // h(NotificationPanel, { notification: { id: 1 }, notificationList: [], show: true })
+    return h('div', [
+      numIncompleteEntities !== 0 ? h('div.num-tasks-indicator', incompleteEnts.length) : null,
+      h('i.material-icons', 'format_list_bulleted')
     ]);
   }
 }

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -88,9 +88,10 @@ class TaskList extends DirtyComponent {
     let ntfns = doc.entities().filter(ent => !ent.completed()).map(ent => {
       let ntfn = new Notification({
         openable: true,
+        dismissable: false,
         openText: 'Show me',
         active: true,
-        message: `Provide more information for incomplete entity ${ent.name() === '' ? 'unnamed entity' : ent.name()}.`
+        message: `Provide more information for ${ent.name() === '' ? 'unnamed entity' : ent.name()}.`
       });
 
       ntfn.on('open', () => this.props.bus.emit('opentip', ent));

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -7,8 +7,6 @@ const Notification = require('../notification');
 const NotificationList = require('../notification/list');
 const NotificationPanel = require('../notification/panel');
 
-const getIncompleteEntities = doc => doc.entities().filter(ent => !ent.completed());
-
 
 const eleEvts = [ 'rename', 'complete', 'uncomplete' ];
 
@@ -131,11 +129,11 @@ class TaskListButton extends DirtyComponent {
 
   render() {
 
-    let incompleteEnts = getIncompleteEntities(this.props.document);
-    let numIncompleteEntities = incompleteEnts.length;
+    let incompleteEles = this.props.document.elements().filter(ele => !ele.completed());
+    let numIncompleteEles = incompleteEles.length;
 
     return h('div', [
-      numIncompleteEntities !== 0 ? h('div.num-tasks-indicator', incompleteEnts.length) : null,
+      numIncompleteEles !== 0 ? h('div.num-tasks-indicator', numIncompleteEles) : null,
       h('i.material-icons', 'format_list_bulleted')
     ]);
   }

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -1,0 +1,84 @@
+const React = require('react');
+const DirtyComponent = require('../dirty-component');
+const h = require('react-hyperscript');
+const _ = require('lodash');
+
+const { makeClassList } = require('../../../util');
+const defs = require('../../defs');
+
+const NotificationPanel = require('../notification/panel');
+
+
+class TaskList extends React.Component {
+  constructor(props){
+    super(props);
+
+    this.data = ({
+      showNotificationList: false
+    });
+
+    this.state = _.assign({}, this.data);
+
+    let toggleSideBar = () => this.toggleSideBar();
+    this.toggleSideBarHandler = toggleSideBar;
+    props.bus.on('toggletasklist', this.toggleSideBarHandler);
+  }
+
+  setData( obj, callback ){
+    _.assign( this.data, obj );
+
+    this.setState( obj, callback );
+  }
+
+  render(){
+    let taskListContent = [
+      h('div.task-list-content')
+    ];
+
+
+    return h('div.task-list', taskListContent);
+  }
+}
+
+
+class TaskListButton extends DirtyComponent {
+  constructor(props){
+    super(props);
+  }
+
+  shouldComponentUpdate() {
+    return true;
+  }
+
+  componentDidMount(){
+    this.onAdd = () => this.dirty();
+    this.onRemove = () => this.dirty();
+    this.props.document.on('add', this.onAdd);
+    this.props.document.on('remove', this.onRemove);
+  }
+
+  componentWillUnmount(){
+    this.props.document.removeListener(this.onAdd);
+    this.props.document.removeListener(this.onRemove);
+  }
+
+  render() {
+
+    let incompleteEnts = this.props.document.entities().filter(ent => !ent.completed());
+    let numIncompleteEntities = incompleteEnts.length;
+
+    // let notifications = incompleteEnts.map(e => new Notification({
+    //   title: 'complete this entity',
+    //   message: 'entity'
+    // }));
+
+    return h('button.editor-button.plain-button.task-list-button', { onClick: () => this.props.bus.emit('toggletasklist') }, [
+      numIncompleteEntities !== 0 ? h('div.num-tasks-indicator', this.props.document.entities().filter(ent => !ent.completed()).length) : null,
+      h('i.material-icons', 'format_list_bulleted'),
+      // h(NotificationPanel, { notification: { id: 1 }, notificationList: [], show: true })
+    ]);
+  }
+}
+
+
+module.exports = { TaskListButton, TaskList };

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -3,6 +3,9 @@ const h = require('react-hyperscript');
 
 const { makeClassList } = require('../../../util');
 
+const Notification = require('../notification');
+const NotificationList = require('../notification/list');
+const NotificationPanel = require('../notification/panel');
 
 const getIncompleteEntities = doc => doc.entities().filter(ent => !ent.completed());
 
@@ -81,11 +84,25 @@ class TaskList extends DirtyComponent {
   }
 
   render(){
-    let taskListContent = [
-      h('div.task-list-content', getIncompleteEntities(this.props.document).map(ent => {
-        return h('div', `complete ${ent.name() === '' ? 'unamed entitiy' : ent.name()}`);
-      }))
-    ];
+    let doc = this.props.document;
+    let ntfns = doc.entities().map(ent => {
+      return new Notification({
+        openable: true,
+        openText: 'Show me',
+        active: true,
+        message: `Provide more information for incomplete entity ${ent.name() === '' ? 'unnamed entity' : ent.name()}.`
+      });
+    });
+
+    let ntfnList = new NotificationList(ntfns);
+    let ntfnPanel = h(NotificationPanel, { notificationList: ntfnList });
+    // let taskListContent = [
+    //   h('div.task-list-content', getIncompleteEntities(this.props.document).map(ent => {
+    //     return h('div', `complete ${ent.name() === '' ? 'unnamed entitiy' : ent.name()}`);
+    //   }))
+    // ];
+
+    let taskListContent = [ntfnPanel];
 
     return h('div.task-list', {
       className: makeClassList({ 'task-list-active': this.props.show })

--- a/src/client/components/notification/base.js
+++ b/src/client/components/notification/base.js
@@ -45,9 +45,9 @@ class NotificationBase extends DirtyComponent {
         h('div.notification-message', n.message())
       ].filter( v => v != null )),
       h('div.notification-actions', [
-        h('button.notification-action.notification-dismiss', { onClick: () => n.dismiss() }, [
+        n.options.dismissable ? h('button.notification-action.notification-dismiss', { onClick: () => n.dismiss() }, [
           'Dismiss'
-        ]),
+        ]) : null,
         h('button.notification-action.notification-open', { onClick: () => n.open() }, n.openText())
       ])
     ]) );

--- a/src/client/components/notification/list.js
+++ b/src/client/components/notification/list.js
@@ -1,7 +1,8 @@
-const EventEmitterMixin = require('./event-emitter-mixin');
-const { mixin } = require('../util');
 const _ = require('lodash');
 const uuid = require('uuid');
+
+const EventEmitterMixin = require('../../../model/event-emitter-mixin');
+const { mixin } = require('../../../util');
 
 class NotificationList {
   constructor( notifications = [], opts ){

--- a/src/client/components/notification/notification.js
+++ b/src/client/components/notification/notification.js
@@ -7,7 +7,8 @@ const defaults = {
   message: '',
   openText: 'Open',
   active: false,
-  openable: false
+  openable: false,
+  dismissable: true
 };
 
 const setOrGet = ( ntfn, name, value, eventName = name ) => {

--- a/src/client/components/notification/panel.js
+++ b/src/client/components/notification/panel.js
@@ -49,4 +49,5 @@ class NotificationPanel extends DataComponent {
   }
 }
 
-module.exports = props => h(NotificationPanel, Object.assign({ key: props.notification.id }, props) );
+module.exports = NotificationPanel;
+

--- a/src/client/components/notification/panel.js
+++ b/src/client/components/notification/panel.js
@@ -1,6 +1,7 @@
 const DataComponent = require('../data-component');
 const h = require('react-hyperscript');
-const NotificationBase = require('./base');
+
+const InlineNotification = require('./inline');
 const { makeClassList } = require('../../../util');
 
 // WIP
@@ -37,7 +38,9 @@ class NotificationPanel extends DataComponent {
     let { notificationList: nl } = this.props;
     let { open } = this.data;
 
-    let makeNtfn = notification => h(NotificationBase, { notification, key: notification.id() });
+    let makeNtfn = notification => h('div.notification-panel-entry', [
+      h(InlineNotification, { notification, key: notification.id() })
+    ]);
 
     return (
       h('div.notification-panel', {

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -6,6 +6,7 @@
   transition-duration: 300ms;
   transition-property: opacity;
   transition-timing-function: ease-out;
+  overflow-x: hidden;
 }
 
 .editor-initted {

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -21,6 +21,14 @@
   flex-direction: column;
   background: rgba(255, 255, 255, 0.5);
   border-bottom-right-radius: 8px;
+
+  transform: translate3d(0, 0, 0);
+  transition: transform 200ms ease-out;
+}
+
+.editor-buttons-shifted {
+  transform: translate3d(21.5em, 0, 0);
+  transition: transform 200ms ease-out;
 }
 
 .editor-button-group {
@@ -55,6 +63,15 @@
   top: 0;
   width: 100%;
   height: 100%;
+
+  transform: translate3d(0, 0, 0);
+  transition: transform 200ms ease-out;
+
+}
+
+.editor-graph-shifted {
+  transform: translate3d(21.5em, 0, 0);
+  transition: transform 200ms ease-out;
 }
 
 .editor-menu-content {

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -94,3 +94,18 @@
     margin-bottom: 0;
   }
 }
+
+.num-tasks {
+  position: absolute;
+  top: 80px;
+  left: 25px;
+  font-size: 0.666em;
+  color: white;
+  background-color: #ed4a31;
+  height: 15px;
+  line-height: 15px;
+  padding: 0 2px;
+  border: 2px solid;
+  border-radius: 15px;
+  text-align: center;
+}

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -95,10 +95,14 @@
   }
 }
 
-.num-tasks {
+.task-list-button {
+  position: relative;
+}
+
+.num-tasks-indicator {
   position: absolute;
-  top: 80px;
-  left: 25px;
+  top: -4px;
+  left: 18px;
   font-size: 0.666em;
   color: white;
   background-color: #ed4a31;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -24,3 +24,4 @@
 @import "./document-renamer.css";
 @import "./my-factoids.css";
 @import "./help.css";
+@import "./task-list.css";

--- a/src/styles/notification.css
+++ b/src/styles/notification.css
@@ -114,3 +114,7 @@
     font-size: var(--smallFontSize);
   }
 }
+
+.notification-panel-entry {
+  margin: 10px;
+}

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -8,6 +8,7 @@
   opacity: 0;
   z-index: -1;
   transition: opacity 200ms ease-out;
+  padding: 10px;
 }
 
 .task-list-active {

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -1,0 +1,8 @@
+.task-list {
+  position: absolute;
+  top: -83px;
+  left: 40px;
+  height: 100vh;
+  width: 20em;
+  background-color: red;
+}

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -11,6 +11,7 @@
   transition-property: transform, opacity;
   transition-duration: 200ms;
   padding: 10px;
+  overflow-y: scroll;
 }
 
 .task-list-active {

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -1,8 +1,16 @@
 .task-list {
   position: absolute;
-  top: -83px;
-  left: 40px;
+  top: 0;
+  left: 45px;
   height: 100vh;
   width: 20em;
-  background-color: red;
+  background-color: #eee;
+  opacity: 0;
+  z-index: -1;
+  transition: opacity 200ms ease-out;
+}
+
+.task-list-active {
+  opacity: 1;
+  z-index: 1000001;
 }

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -7,7 +7,6 @@
   background-color: #767676;
   z-index: -1;
   opacity: 0;
-
   transform: translate3d(0%, 0, 0);
   transition-property: transform, opacity;
   transition-duration: 200ms;

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -1,17 +1,21 @@
 .task-list {
   position: absolute;
   top: 0;
-  left: 45px;
+  left: -21.5em;
   height: 98vh;
   width: 20em;
   background-color: #767676;
-  opacity: 0;
   z-index: -1;
-  transition: opacity 200ms ease-out;
+  opacity: 0;
+
+  transform: translate3d(0%, 0, 0);
+  transition-property: transform, opacity;
+  transition-duration: 200ms;
   padding: 10px;
 }
 
 .task-list-active {
+  transform: translate3d(100%, 0, 0);
   opacity: 0.8;
   z-index: 3;
 }

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -2,9 +2,9 @@
   position: absolute;
   top: 0;
   left: 45px;
-  height: 100vh;
+  height: 98vh;
   width: 20em;
-  background-color: #eee;
+  background-color: #767676;
   opacity: 0;
   z-index: -1;
   transition: opacity 200ms ease-out;
@@ -12,6 +12,6 @@
 }
 
 .task-list-active {
-  opacity: 1;
-  z-index: 1000001;
+  opacity: 0.8;
+  z-index: 3;
 }


### PR DESCRIPTION
Implements the todo list as a notification list


![screen shot 2018-05-29 at 1 41 56 pm](https://user-images.githubusercontent.com/2328291/40675559-16df73c6-6346-11e8-8d47-094717edaf8e.png)

![screen shot 2018-05-29 at 1 27 34 pm](https://user-images.githubusercontent.com/2328291/40674894-14d81774-6344-11e8-8449-a43d38d494b6.png)

## Features
- new button in the menu that opens the task list.  Also has an indicator showing how many tasks (incomplete entities) are left
- task list that uses notification styles for each todo is shown when the button is clicked

## Major Changes
- Added TaskList component that is used by the main Editor Component
- implemented controller functions in the Editor component to control whether the task list is shown or not
- it didn't make sense to me to make task list notifications dismissible, so I added a notification option to configure whether notifications have a dismiss button or not.


## Controversial Changes
- additional css for the menu buttons and editor graph to handle the cases when the task list is closed or open
- to make the task list more compatible with the help list, the task list is closed before the help mode is activated
- I changed the editor buttons function to an actual react component and inject a className prop to help shift the buttons over when the task list is open

## Limitations
- Clicking the 'show me' for any todo only toggles the element info for that node.  e.g. clicking show me twice will open the node info and then close the node info.
- I also get this error when I toggle node info i.e. multiple calls to 
```js 
bus.emit('opentip', node)
```

![screen shot 2018-05-29 at 1 41 21 pm](https://user-images.githubusercontent.com/2328291/40675523-ff5973aa-6345-11e8-8280-a0153fa67132.png)
