### PR TITLE
Split editor and app buttons

### DIFF
--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -148,6 +148,55 @@ class EditorButtons extends React.Component {
       ])
     ]);
 
+    if( document.editable() ){
+      grs.push([
+        h(Popover, {
+          tippy: {
+            position: 'right',
+            html: h('div.editor-more-menu', [
+              h('div.editor-more-menu-items', [
+                h('button.editor-more-button.plain-button', {
+                  onClick: () => history.push('/new')
+                }, [
+                  h('span', ' New factoid')
+                ]),
+                h('button.editor-more-button.plain-button', {
+                  onClick: () => history.push('/documents')
+                }, [
+                  h('span', ' My factoids')
+                ]),
+                h('button.editor-more-button.plain-button', {
+                  onClick: () => {
+                    let id = document.id();
+                    let secret = document.secret();
+
+                    if( document.editable() ){
+                      history.push(`/form/${id}/${secret}`);
+                    } else {
+                      history.push(`/form/${id}`);
+                    }
+                  }
+                }, [
+                  h('span', ' Form-based editor')
+                ]),
+                h('button.editor-more-button.plain-button', {
+                  onClick: () => history.push('/')
+                }, [
+                  h('span', ' About & contact')
+                ])
+              ])
+            ])
+          }
+        }, [
+          h(Tooltip, _.assign({}, baseTooltipProps, { description: 'More tools' }), [
+            h('button.editor-button.plain-button', [
+              h('i.material-icons', 'more_vert')
+            ])
+          ])
+        ])
+      ]);
+    }
+
     return h(`div.${className}`, grs.map( btns => h('div.editor-button-group', btns) ));
 
   }

--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -13,7 +13,7 @@ const { TaskListButton } = require('./task-list');
 
 class EditorButtons extends React.Component {
   render(){
-    let { bus, className, document, controller, history } = this.props;
+    let { bus, className, document, controller } = this.props;
     let grs = [];
 
     let baseTooltipProps = {
@@ -148,6 +148,54 @@ class EditorButtons extends React.Component {
       ])
     ]);
 
+    return h(`div.${className}`, grs.map( btns => h('div.editor-button-group', btns) ));
+  }
+}
+
+class AppButtons extends React.Component {
+  render(){
+    let { bus, className, document, controller, history } = this.props;
+    let grs = [];
+
+    let baseTooltipProps = {
+      show: showNow => {
+        bus.on('showtips', showNow);
+      },
+      hide: hideNow => {
+        bus.on('hidetips', hideNow);
+      },
+      tippy: {
+        zIndex: tippyTopZIndex,
+        hideOnClick: false,
+        events: 'mouseenter manual'
+      }
+    };
+
+    let appButtons = [h(Tooltip, { description: 'Help' }, [
+      h('button.editor-button.plain-button', { onClick: () => bus.emit('togglehelp') }, [
+        h('i.material-icons', 'info')
+      ])
+    ])];
+
+    if( document.editable() ){
+      appButtons.push([
+        h(Tooltip, _.assign({}, baseTooltipProps,  { description: 'Tasks' }), [
+          h(Toggle, {
+            className: 'editor-button plain-button task-list-button',
+            controller,
+            document,
+            bus,
+            onToggle: () => controller.toggleTaskListMode(),
+            getState: () => controller.taskListMode()
+          }, [
+            h(TaskListButton, { controller, document, bus })
+          ])
+        ])
+      ]);
+    }
+
+    grs.push(appButtons);
+
     if( document.editable() ){
       grs.push([
         h(Popover, {
@@ -188,7 +236,7 @@ class EditorButtons extends React.Component {
             ])
           }
         }, [
-          h(Tooltip, _.assign({}, baseTooltipProps, { description: 'More tools' }), [
+          h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Menu' }), [
             h('button.editor-button.plain-button', [
               h('i.material-icons', 'more_vert')
             ])
@@ -197,9 +245,12 @@ class EditorButtons extends React.Component {
       ]);
     }
 
+
     return h(`div.${className}`, grs.map( btns => h('div.editor-button-group', btns) ));
 
   }
+
 }
 
-module.exports = EditorButtons;
+module.exports = { AppButtons, EditorButtons };
+

--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -61,93 +61,6 @@ class EditorButtons extends React.Component {
       ]),
     ]);
 
-    grs.push([
-      h(Tooltip, { description: 'Help' }, [
-        h('button.editor-button.plain-button', { onClick: () => bus.emit('togglehelp') }, [
-          h('i.material-icons', 'info')
-        ])
-      ]),
-
-      h(Tooltip, _.assign({}, baseTooltipProps,  { description: 'Tasks' }), [
-        h(Toggle, {
-          className: 'editor-button plain-button task-list-button',
-          controller,
-          document,
-          bus,
-          onToggle: () => controller.toggleTaskListMode(),
-          getState: () => controller.taskListMode()
-        }, [
-          h(TaskListButton, { controller, document, bus })
-        ])
-      ]),
-
-      h(Popover, {
-        tippy: {
-          position: 'right',
-          html: h('div.editor-linkout', [
-            h(Linkout, { document })
-          ])
-        }
-      }, [
-        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Share link' }), [
-          h('button.editor-button.plain-button', [
-            h('i.material-icons', 'link')
-          ])
-        ])
-      ]),
-
-      h(Tooltip, _.assign( {}, baseTooltipProps, { description: 'Export to Biopax' }), [
-        h('button.editor-button.plain-button', { onClick: () => exportDocumentToOwl(document.id()) }, [
-          h('i.material-icons', 'save_alt')
-        ])
-      ]),
-
-      h(Popover, {
-        tippy: {
-          position: 'right',
-          html: h('div.editor-more-menu', [
-            h('div.editor-more-menu-items', [
-              h('button.editor-more-button.plain-button', {
-                onClick: () => history.push('/new')
-              }, [
-                h('span', ' New factoid')
-              ]),
-              h('button.editor-more-button.plain-button', {
-                onClick: () => history.push('/documents')
-              }, [
-                h('span', ' My factoids')
-              ]),
-              h('button.editor-more-button.plain-button', {
-                onClick: () => {
-                  let id = document.id();
-                  let secret = document.secret();
-
-                  if( document.editable() ){
-                    history.push(`/form/${id}/${secret}`);
-                  } else {
-                    history.push(`/form/${id}`);
-                  }
-                }
-              }, [
-                h('span', ' Form-based editor')
-              ]),
-              h('button.editor-more-button.plain-button', {
-                onClick: () => history.push('/')
-              }, [
-                h('span', ' About & contact')
-              ])
-            ])
-          ])
-        }
-      }, [
-        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'More tools' }), [
-          h('button.editor-button.plain-button', [
-            h('i.material-icons', 'more_vert')
-          ])
-        ])
-      ])
-    ]);
-
     return h(`div.${className}`, grs.map( btns => h('div.editor-button-group', btns) ));
   }
 }
@@ -195,9 +108,31 @@ class AppButtons extends React.Component {
     }
 
     grs.push(appButtons);
+    appButtons.push([
+      h(Popover, {
+        tippy: {
+          position: 'right',
+          html: h('div.editor-linkout', [
+            h(Linkout, { document })
+          ])
+        }
+      }, [
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Share link' }), [
+          h('button.editor-button.plain-button', [
+            h('i.material-icons', 'link')
+          ])
+        ])
+      ]),
+
+      h(Tooltip, _.assign( {}, baseTooltipProps, { description: 'Export to Biopax' }), [
+        h('button.editor-button.plain-button', { onClick: () => exportDocumentToOwl(document.id()) }, [
+          h('i.material-icons', 'save_alt')
+        ])
+      ]),
+    ]);
 
     if( document.editable() ){
-      grs.push([
+      appButtons.push([
         h(Popover, {
           tippy: {
             position: 'right',

--- a/src/client/components/editor/help.js
+++ b/src/client/components/editor/help.js
@@ -77,7 +77,9 @@ class Help extends React.Component {
     let editable = this.props.document.editable();
     let bus = this.props.bus;
     let controller = this.props.controller;
-    let cy = this.props.cy;
+    // termporarily access cy from the controller because
+    // cy is undefined as props in read-only mode in the editor
+    let cy = this.props.controller.data.cy;
 
     let showTips = () => {
       bus.emit('showtips');

--- a/src/client/components/editor/help.js
+++ b/src/client/components/editor/help.js
@@ -132,14 +132,6 @@ class Help extends React.Component {
       )
     ];
 
-    if( this.state.showHelp ){
-      helpContent.push(
-        h('div.editor-button.help-close-button', { onClick: () => this.toggleHelp()}, [
-          h('i.material-icons', 'close')
-        ])
-      );
-    }
-
     return h('div.help', helpContent);
   }
 }

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -361,7 +361,7 @@ class Editor extends React.Component {
     let editorContent = this.state.initted ? [
       h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),
       h(AppButtons, { className: showTaskList ? 'editor-buttons-right.editor-buttons-right-shifted' : 'editor-buttons-right', controller, document, bus, history } ),
-      // incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
+      incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h(`div.${showTaskList ? 'editor-graph-shifted#editor-graph' : 'editor-graph#editor-graph'}`),
       h(Help, { document, bus, controller }),

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -361,7 +361,7 @@ class Editor extends React.Component {
     let editorContent = this.state.initted ? [
       h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),
       h(AppButtons, { className: showTaskList ? 'editor-buttons-right.editor-buttons-right-shifted' : 'editor-buttons-right', controller, document, bus, history } ),
-      incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
+      // incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h(`div.${showTaskList ? 'editor-graph-shifted#editor-graph' : 'editor-graph#editor-graph'}`),
       h(Help, { document, bus, controller }),

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -17,7 +17,7 @@ const debug = require('../../debug');
 
 const makeCytoscape = require('./cy');
 const defs = require('./defs');
-const Buttons = require('./buttons');
+const { EditorButtons, AppButtons } = require('./buttons');
 const UndoRemove = require('./undo-remove');
 const Help = require('./help');
 const { TaskList } = require('./task-list');
@@ -359,11 +359,12 @@ class Editor extends React.Component {
     let showTaskList = this.data.taskListMode;
 
     let editorContent = this.state.initted ? [
-      h(Buttons, { className: showTaskList ? 'editor-buttons.editor-buttons-shifted' : 'editor-buttons', controller, document, bus, history }),
+      h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),
+      h(AppButtons, { className: showTaskList ? 'editor-buttons-right.editor-buttons-right-shifted' : 'editor-buttons-right', controller, document, bus, history } ),
       incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h(`div.${showTaskList ? 'editor-graph-shifted#editor-graph' : 'editor-graph#editor-graph'}`),
-      h(Help, { document, bus, cy: this.data.cy, controller }),
+      h(Help, { document, bus, cy: this.state.cy, controller }),
       h(TaskList, { document, bus, controller, show: showTaskList })
     ] : [];
 

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -364,7 +364,7 @@ class Editor extends React.Component {
       incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h(`div.${showTaskList ? 'editor-graph-shifted#editor-graph' : 'editor-graph#editor-graph'}`),
-      h(Help, { document, bus, cy: this.state.cy, controller }),
+      h(Help, { document, bus, controller }),
       h(TaskList, { document, bus, controller, show: showTaskList })
     ] : [];
 

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -132,7 +132,7 @@ class TaskListButton extends DirtyComponent {
     let incompleteEles = this.props.document.elements().filter(ele => !ele.completed());
     let numIncompleteEles = incompleteEles.length;
     let indicatorContent = numIncompleteEles;
-    if( 50 <= numIncompleteEles ){
+    if( 50 < numIncompleteEles ){
       indicatorContent = '50+';
     }
 

--- a/src/client/components/editor/task-list.js
+++ b/src/client/components/editor/task-list.js
@@ -131,9 +131,13 @@ class TaskListButton extends DirtyComponent {
 
     let incompleteEles = this.props.document.elements().filter(ele => !ele.completed());
     let numIncompleteEles = incompleteEles.length;
+    let indicatorContent = numIncompleteEles;
+    if( 50 <= numIncompleteEles ){
+      indicatorContent = '50+';
+    }
 
     return h('div', [
-      numIncompleteEles !== 0 ? h('div.num-tasks-indicator', numIncompleteEles) : null,
+      numIncompleteEles !== 0 ? h('div.num-tasks-indicator', indicatorContent) : null,
       h('i.material-icons', 'format_list_bulleted')
     ]);
   }

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -10,6 +10,8 @@ const debug = require('../../debug');
 const Document = require('../../../model/document');
 const { exportDocumentToOwl } = require('../../../util');
 
+const Popover = require('../popover/popover');
+
 // const DocumentWizardStepper = require('../document-wizard-stepper');
 // const AppBar = require('../app-bar');
 // const ActionLogger = require('../action-logger');
@@ -225,6 +227,9 @@ class FormEditor extends DirtyComponent {
   render(){
     let doc = this.state.document;
 
+    let { history } = this.props;
+
+
     this.state.dirty = false;
 
     const forms = [
@@ -272,7 +277,51 @@ class FormEditor extends DirtyComponent {
 //      h(AppBar, { document: this.data.document, bus: this.data.bus }),
  //     h(ActionLogger, { document: this.data.document, bus: this.data.bus }),
       h('div.page-content', [
-        h('h1.form-editor-title', 'Insert Pathway Information As Text'),
+        h('div.app-bar', [
+          h('h2', 'Factoid - Form Editor'),
+          h(Popover, {
+            tippy: {
+              position: 'right',
+              followCursor: false,
+              html: h('div.editor-more-menu', [
+                h('div.editor-more-menu-items', [
+                  h('button.editor-more-button.plain-button', {
+                    onClick: () => history.push('/new')
+                  }, [
+                    h('span', ' New factoid')
+                  ]),
+                  h('button.editor-more-button.plain-button', {
+                    onClick: () => history.push('/documents')
+                  }, [
+                    h('span', ' My factoids')
+                  ]),
+                  h('button.editor-more-button.plain-button', {
+                    onClick: () => {
+                      if( doc.editable() ){
+                        history.push(`/document/${doc.id()}/${doc.secret()}`);
+                      } else {
+                        history.push(`/document/${doc.id()}`);
+                      }
+                    }
+                  }, [
+                    h('span', ' Network editor')
+                  ]),
+                  h('button.editor-more-button.plain-button', {
+                    onClick: () => history.push('/')
+                  }, [
+                    h('span', ' About & contact')
+                  ])
+                ])
+              ])
+            }
+            }, [
+            // h(Tooltip, { description: 'More tools' }, [
+              h('button.editor-button.plain-button', [
+                h('i.material-icons', 'more_vert')
+              ])
+            // ])
+          ])
+        ]),
         h('div.form-templates', [
           ...hArr
         ]),

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -90,22 +90,18 @@ let routes = [
   {
     path: '/form/:id',
     render: props => {
-      let params = props.match.params;
+      let { id } = props.match.params;
 
-      return h( FormEditor, {
-        id: params.id
-      } );
+      return h( FormEditor, { id } );
     }
   },
   {
     path: '/form/:id/:secret',
     render: props => {
-      let params = props.match.params;
+      let { id, secret } = props.match.params;
+      let { history } = props;
 
-      return h( FormEditor, {
-        id: params.id,
-        secret: params.secret
-      } );
+      return h( FormEditor, { id, secret, history } );
     }
   },
   {

--- a/src/styles/app-bar.css
+++ b/src/styles/app-bar.css
@@ -9,6 +9,7 @@
     font-size: 20pt;
     margin-right: 50px;
   }
+
   & h2 {
     font-size: 20pt;
   }

--- a/src/styles/app-bar.css
+++ b/src/styles/app-bar.css
@@ -1,0 +1,15 @@
+.app-bar {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+
+  & button {
+    font-size: 20pt;
+    margin-right: 50px;
+  }
+  & h2 {
+    font-size: 20pt;
+  }
+}

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -22,13 +22,29 @@
   flex-direction: column;
   background: rgba(255, 255, 255, 0.5);
   border-bottom-right-radius: 8px;
-
-  transform: translate3d(0, 0, 0);
-  transition: transform 200ms ease-out;
+  border: 1px solid #767676;
+  border-top: 0;
+  border-left: 0;
 }
 
-.editor-buttons-shifted {
-  transform: translate3d(21.5em, 0, 0);
+.editor-buttons-right {
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 1;
+  display: inline-flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.5);
+  border-bottom-left-radius: 8px;
+  transform: translate3d(0, 0, 0);
+  transition: transform 200ms ease-out;
+  border: 1px solid #767676;
+  border-top: 0;
+  border-right: 0;
+}
+
+.editor-buttons-right-shifted {
+  transform: translate3d(-21.5em, 0, 0);
   transition: transform 200ms ease-out;
 }
 
@@ -71,7 +87,7 @@
 }
 
 .editor-graph-shifted {
-  transform: translate3d(21.5em, 0, 0);
+  transform: translate3d(-21.5em, 0, 0);
   transition: transform 200ms ease-out;
 }
 

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -136,7 +136,7 @@
 .num-tasks-indicator {
   position: absolute;
   top: -4px;
-  left: 18px;
+  right: 18px;
   font-size: 0.666em;
   color: white;
   background-color: #ed4a31;

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -22,9 +22,6 @@
   flex-direction: column;
   background: rgba(255, 255, 255, 0.5);
   border-bottom-right-radius: 8px;
-  border: 1px solid #767676;
-  border-top: 0;
-  border-left: 0;
 }
 
 .editor-buttons-right {
@@ -38,9 +35,6 @@
   border-bottom-left-radius: 8px;
   transform: translate3d(0, 0, 0);
   transition: transform 200ms ease-out;
-  border: 1px solid #767676;
-  border-top: 0;
-  border-right: 0;
 }
 
 .editor-buttons-right-shifted {

--- a/src/styles/form-editor/form-editor.css
+++ b/src/styles/form-editor/form-editor.css
@@ -1,3 +1,7 @@
+.form-editor {
+  overflow: hidden;
+}
+
 .form-editor-title {
   text-align: center;
   color: #212F3D;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,3 +25,4 @@
 @import "./my-factoids.css";
 @import "./help.css";
 @import "./task-list.css";
+@import "./app-bar.css";

--- a/src/styles/notification.css
+++ b/src/styles/notification.css
@@ -84,8 +84,8 @@
 .corner-notification {
   z-index: 3;
   position: fixed;
-  right: 0;
-  top: 0;
+  right: 100px;
+  top: 20px;
   margin: 1em;
   background: #333;
   border-radius: 0.25em;

--- a/src/styles/notification.css
+++ b/src/styles/notification.css
@@ -84,8 +84,8 @@
 .corner-notification {
   z-index: 3;
   position: fixed;
-  right: 100px;
-  top: 20px;
+  right: 0;
+  top: 0;
   margin: 1em;
   background: #333;
   border-radius: 0.25em;

--- a/src/styles/task-list.css
+++ b/src/styles/task-list.css
@@ -1,7 +1,7 @@
 .task-list {
   position: absolute;
   top: 0;
-  left: -21.5em;
+  right: -21.5em;
   height: 98vh;
   width: 20em;
   background-color: #767676;
@@ -15,7 +15,7 @@
 }
 
 .task-list-active {
-  transform: translate3d(100%, 0, 0);
+  transform: translate3d(-21.5em, 0, 0);
   opacity: 0.8;
   z-index: 3;
 }


### PR DESCRIPTION
- Editor buttons are on the left, app buttons placed on the right.  Each implemented as a separate react component
- Task list comes in from the right
- Show ```50+``` for the task list indicator once the number of todos passes 50
- Use props.controller.data.cy as a temp fix for the view mode only cy undefined error
- Add a minimal WIP app bar for the form editor (mostly the same as the network editor more button)



![screen shot 2018-06-04 at 5 31 35 pm](https://user-images.githubusercontent.com/2328291/40942757-2cc88bc4-681d-11e8-9d9a-a63917fbccd2.png)
