### PR TITLE
Add support for Pathway Commons linkouts on entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Services:
 - `PUBCHEM_CACHE_SIZE`: overrides default cache size of pubchem query cache,
 - `AGGREGATE_CACHE_SIZE`: overrides default cache size for aggregate searches across all entity types
 - `MAX_SEARCH_SIZE`: max number of entities returned for each entity lookup/search service
+- `PC_LINK_BASE_URL` : base url concatenated to id to generate a pc search linkout
 
 
 

--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -51,20 +51,28 @@ let chemical = (m, searchTerms) => {
 };
 
 let link = m => {
-  let url;
+  let pcQ = encodeURIComponent(m.name);
+  let url, nsName;
 
   switch( m.type ){
     case 'protein':
       url = UNIPROT_LINK_BASE_URL + m.id;
+      nsName = 'UniProt';
       break;
     case 'chemical':
       url = PUBCHEM_LINK_BASE_URL + m.id;
+      nsName = 'PubChem';
       break;
   }
 
-  return h('div.entity-info-section', [
-    h('a.plain-link', { href: url, target: '_blank' }, [
-      'More information ',
+  return h('div.entity-info-section.entity-info-linkouts', [
+    h('span.entity-info-title', 'More information'),
+    h('a.plain-link.entity-info-linkout', { href: url, target: '_blank' }, [
+      nsName + ' ',
+      h('i.material-icons', 'open_in_new')
+    ]),
+    h('a.plain-link.entity-info-linkout', { href: `http://apps.pathwaycommons.org/search?q=${pcQ}`, target: '_blank' }, [
+      'Pathway Commons ',
       h('i.material-icons', 'open_in_new')
     ])
   ]);

--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -3,6 +3,7 @@ const Organism = require('../../../model/organism');
 const Highlighter = require('../highlighter');
 const Formula = require('./chemical-formula');
 const Tooltip = require('../popover/tooltip');
+const { PC_LINK_BASE_URL } = require('../../../config');
 
 const { UNIPROT_LINK_BASE_URL, PUBCHEM_LINK_BASE_URL } = require('../../../config');
 
@@ -52,6 +53,8 @@ let chemical = (m, searchTerms) => {
 
 let link = m => {
   let pcQ = encodeURIComponent(m.name);
+  let pcUrl = `${PC_LINK_BASE_URL}${pcQ}`;
+  let pcName = 'Pathway Commons';
   let url, nsName;
 
   switch( m.type ){
@@ -65,16 +68,15 @@ let link = m => {
       break;
   }
 
+  let entry = (url, text) => h('a.plain-link.entity-info-linkout', { href: url, target: '_blank' }, [
+    text + ' ',
+    h('i.material-icons', 'open_in_new')
+  ]);
+
   return h('div.entity-info-section.entity-info-linkouts', [
     h('span.entity-info-title', 'More information'),
-    h('a.plain-link.entity-info-linkout', { href: url, target: '_blank' }, [
-      nsName + ' ',
-      h('i.material-icons', 'open_in_new')
-    ]),
-    h('a.plain-link.entity-info-linkout', { href: `http://apps.pathwaycommons.org/search?q=${pcQ}`, target: '_blank' }, [
-      'Pathway Commons ',
-      h('i.material-icons', 'open_in_new')
-    ])
+    entry(url, nsName),
+    entry(pcUrl, pcName)
   ]);
 };
 

--- a/src/config.js
+++ b/src/config.js
@@ -34,7 +34,8 @@ let defaults = {
   PUBCHEM_CACHE_SIZE: DEFAULT_CACHE_SIZE,
   AGGREGATE_CACHE_SIZE: DEFAULT_CACHE_SIZE,
   MAX_SEARCH_SIZE: 50,
-  BIOPAX_CONVERTER_URL: 'http://causalpath.org:9090/FactoidToBiopaxServer/ConvertToOwl'
+  BIOPAX_CONVERTER_URL: 'http://causalpath.org:9090/FactoidToBiopaxServer/ConvertToOwl',
+  PC_LINK_BASE_URL: 'http://apps.pathwaycommons.org/search?q='
 };
 
 let envVars = _.pick( process.env, Object.keys( defaults ) );

--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -148,3 +148,7 @@ button.entity-info-edit {
 .entity-info-notification {
   margin-bottom: 0.75em;
 }
+
+.entity-info-linkout {
+  margin-right: 0.5em;
+}


### PR DESCRIPTION
- PC search uses `q=${fullOfficialName}`, since PC UI does not yet support `q=${ns:id}` queries for `uniprot` and `chebi` namespaces.
- Use PubChem linkouts for chemicals, even though we use Chebi grounding for now.  It works OK, and the PubChem page is a bit nicer.

Ref : PC entity linkouts #299