### PR TITLE
Doc title seeder

### DIFF
--- a/src/client/components/document-seeder.js
+++ b/src/client/components/document-seeder.js
@@ -29,7 +29,7 @@ class DocumentSeeder extends React.Component {
   }
 
   getDocumentTitleTextVal(){
-    return this.docName.docTitle;
+    return this.state.docTitle;
   }
 
   getReachResponse(){

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -105,6 +105,14 @@ class Editor extends React.Component {
 
     doc.on('load', () => {
       doc.interactions().forEach( listenForRmPpt );
+  
+      let docs = JSON.parse(localStorage.getItem('my-factoids')) || [];
+      let docData = { id: doc.id(), secret: doc.secret(), name: doc.name() };
+
+      if( _.find(docs,  docData) == null ){
+        docs.push(docData);
+        localStorage.setItem('my-factoids', JSON.stringify(docs));
+      }
     });
 
     let bus = new EventEmitter();
@@ -373,14 +381,6 @@ class Editor extends React.Component {
 
   componentDidMount(){
     this.data.mountDeferred.resolve();
-    let doc = this.data.document;
-
-    let docs = JSON.parse(localStorage.getItem('my-factoids')) || [];
-    let docData = { id: doc.id(), secret: doc.secret(), name: doc.name() };
-    if( _.find(docs,  docData) == null ){
-      docs.push(docData);
-      localStorage.setItem('my-factoids', JSON.stringify(docs));
-    }
   }
 
   componentWillUnmount(){


### PR DESCRIPTION
- Fix typo in state accessor for docTitle in the doc seeder component
- Fix bug where factoid documents would have untitled name in the documents component/route.  I think it was due to the doc not being loaded before the component mounted causing the factoids to be stored with a empty name.