### PR TITLE
UI/UX improvements/tweaks/redesigns for form

### DIFF
--- a/src/client/components/form-editor/entity-form.js
+++ b/src/client/components/form-editor/entity-form.js
@@ -21,16 +21,16 @@ class EntityForm extends DirtyComponent {
     }, props );
 
 
-    this.hCompletedStatus = h('i.material-icons', 'help');
+    this.hCompletedStatus = this.getHelpIcon();
 
 
     if(this.data.entity){
       if(this.data.entity.completed())
-        this.hCompletedStatus = h('i.material-icons.entity-info-complete-icon', 'check_circle');
+        this.hCompletedStatus = this.getCompletedIcon();
 
 
       this.data.entity.on("complete", () => {
-        this.hCompletedStatus = h('i.material-icons.entity-info-complete-icon', 'check_circle');
+        this.hCompletedStatus = this.getCompletedIcon();
         this.mergeWithOtherEntities();
         if(this._isMounted)
           this.dirty();
@@ -89,6 +89,15 @@ class EntityForm extends DirtyComponent {
   componentWillUnmount(){
     this._isMounted = false;
   }
+
+  getHelpIcon(){
+    return h('i.material-icons', 'help');
+  }
+
+  getCompletedIcon(){
+    return h('i.material-icons.element-info-complete-icon', 'check_circle');
+  }
+
   mountTippy(){
 
     if(!this._tippyMounted) {
@@ -218,10 +227,10 @@ class EntityForm extends DirtyComponent {
 
     if(this.state.entity && this.state.entity.completed()) {
       this.state.entity.complete();
-      this.hCompletedStatus = h('i.material-icons.entity-info-complete-icon', 'check_circle');
+      this.hCompletedStatus = this.getCompletedIcon();
     }
     else
-      this.hCompletedStatus = h('i.material-icons', 'help');
+      this.hCompletedStatus = this.getHelpIcon();
 
 
     hFunc = h('div.form-interaction', [

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -241,8 +241,13 @@ class FormEditor extends DirtyComponent {
       association: form.association[0]
     };
 
+    let addInteractionRow = () => this.addInteractionRow( rowParam );
+    let applyLayout = () => doc.applyLayout();
+
     let button = h('button.form-interaction-adder-btn', {
-      onClick: () => this.addInteractionRow( rowParam )
+      onClick: () => {
+        Promise.try( addInteractionRow ).then( applyLayout );
+      }
     }, form.type);
 
     return button;

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -241,6 +241,7 @@ class FormEditor extends DirtyComponent {
       association: form.association[0]
     };
 
+    let doc = this.data.document;
     let addInteractionRow = () => this.addInteractionRow( rowParam );
     let applyLayout = () => doc.applyLayout();
 
@@ -251,7 +252,7 @@ class FormEditor extends DirtyComponent {
     }, form.type);
 
     return button;
-  };
+  }
 
   makeTooltip( children, description ) {
     let opts = {
@@ -263,20 +264,20 @@ class FormEditor extends DirtyComponent {
 
     let tooltip = h( Tooltip, opts, children );
     return tooltip;
-  };
+  }
 
   formToTooltipBtn( form ) {
     let btn = this.formToButton( form );
     let tooltipBtn = this.makeTooltip( [ btn ], form.description );
 
     return tooltipBtn;
-  };
+  }
 
   toggleIntnAdderVisibility() {
     this.setData( {
       showIntnAdder: !this.data.showIntnAdder
     } );
-  };
+  }
 
   render(){
     let doc = this.state.document;

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -1,4 +1,3 @@
-const DirtyComponent = require('../dirty-component');
 const h = require('react-hyperscript');
 const io = require('socket.io-client');
 const _ = require('lodash');
@@ -9,7 +8,10 @@ const logger = require('../../logger');
 const debug = require('../../debug');
 
 const Document = require('../../../model/document');
-const { exportDocumentToOwl } = require('../../../util');
+const { exportDocumentToOwl, makeClassList } = require('../../../util');
+const DirtyComponent = require('../dirty-component');
+const Tooltip = require('../popover/tooltip');
+const Toggle = require('../toggle');
 
 // const DocumentWizardStepper = require('../document-wizard-stepper');
 // const AppBar = require('../app-bar');
@@ -50,6 +52,7 @@ class FormEditor extends DirtyComponent {
     this.data = this.state = {
       document: doc,
       bus: bus,
+      showIntnAdder: false
     };
 
 
@@ -231,6 +234,45 @@ class FormEditor extends DirtyComponent {
 
   }
 
+  formToButton( form ) {
+    let rowParam = {
+      name: form.type,
+      pptTypes: form.pptTypes,
+      association: form.association[0]
+    };
+
+    let button = h('button.form-interaction-adder-btn', {
+      onClick: () => this.addInteractionRow( rowParam )
+    }, form.type);
+
+    return button;
+  };
+
+  makeTooltip( children, description ) {
+    let opts = {
+      description: description,
+      tippy: {
+        placement: 'bottom'
+      }
+    };
+
+    let tooltip = h( Tooltip, opts, children );
+    return tooltip;
+  };
+
+  formToTooltipBtn( form ) {
+    let btn = this.formToButton( form );
+    let tooltipBtn = this.makeTooltip( [ btn ], form.description );
+
+    return tooltipBtn;
+  };
+
+  toggleIntnAdderVisibility() {
+    this.setData( {
+      showIntnAdder: !this.data.showIntnAdder
+    } );
+  };
+
   render(){
     let doc = this.state.document;
 
@@ -273,28 +315,50 @@ class FormEditor extends DirtyComponent {
           else return null;
       });
 
+      let notNull = obj => {
+        return obj != null;
+      };
+
+      formContent = formContent.filter( notNull );
+
+      if ( formContent.length == 0 ) {
+        return;
+      }
 
       //update form
       let hFunc = h('div.form-template-entry', [
         h('h2', form.type),
         h('p', form.description),
-        ...formContent,
-        h('div.form-action-buttons', [
-          h('button.form-interaction-adder', {
-            onClick: () => this.addInteractionRow({name:form.type, pptTypes: form.pptTypes,  association: form.association[0]})}, [
-            h('i.material-icons.add-new-interaction-icon', 'add'),
-            'ADD INTERACTION'
-          ])])
+        ...formContent
       ]);
 
       hArr.push(hFunc);
     });
+
+    let interactionAdderButtons = forms.map( form => this.formToTooltipBtn( form ) );
 
     return h('div.form-editor', [
       h('div.page-content', [
         h('h1.form-editor-title', 'Insert Pathway Information As Text'),
         h('div.form-templates', [
           ...hArr
+        ]),
+        h('div.form-interaction-adder-area', [
+          h(Toggle, {
+            className: 'form-interaction-adder-toggle',
+            onToggle: () => this.toggleIntnAdderVisibility(),
+            getState: () => this.data.showIntnAdder
+          }, [
+            h('i.material-icons.add-new-interaction-icon', 'add'),
+            'ADD INTERACTION'
+          ]),
+          h('div.form-interaction-adder-slide', {
+            className: makeClassList({
+              'form-hidden': !this.data.showIntnAdder
+            })
+          }, [
+            ...interactionAdderButtons
+          ])
         ]),
         h('button.form-submit', { onClick: () => exportDocumentToOwl(doc.id()) }, [
           'Download BioPax'

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -267,7 +267,7 @@ class FormEditor extends DirtyComponent {
                     onClick: () => {
                       this.deleteInteractionRow({interaction: interaction});
                     }
-                  }, 'X'),
+                  }, h('i.material-icons', 'clear')),
                   h(form.clazz, {
                     key: interaction.id(),
                     document: doc,

--- a/src/styles/form-editor/form-editor.css
+++ b/src/styles/form-editor/form-editor.css
@@ -22,15 +22,27 @@
   justify-content: space-between;
 }
 
-.form-interaction-adder {
+.form-interaction-adder-toggle {
   color: #00ADB5;
   background-color: #EEEEEE;
   height: 2.5em;
-  margin-top: 1.5em;
-  margin-bottom: 4em;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
   padding: 0 20px;
   display: flex;
   flex-direction: row;
+}
+
+.form-interaction-adder-area {
+  margin-top: 4em;
+}
+
+.form-interaction-adder-area button {
+  margin-left: 0.3em;
+}
+
+.form-hidden {
+  display: none;
 }
 
 .delete-interaction {


### PR DESCRIPTION
To re-solve #296

Form editor seems as the following when there is no element in the document:

<img width="1439" alt="screen shot 2018-06-11 at 10 46 49 am" src="https://user-images.githubusercontent.com/6534865/41248225-36b0f6c4-6d65-11e8-910d-0d8d9f259d56.png">

``+ Add Interaction`` button is converted to a toggle as discussed in the issue. It looks like the following when the toggle is on:

<img width="1438" alt="screen shot 2018-06-11 at 10 47 05 am" src="https://user-images.githubusercontent.com/6534865/41248231-3ae5a410-6d65-11e8-9126-b9cd24efad54.png">

The following is how the form editor looks like after adding some elements:

<img width="1425" alt="screen shot 2018-06-11 at 10 47 28 am" src="https://user-images.githubusercontent.com/6534865/41248236-3e08c32a-6d65-11e8-91ce-72c37d1801c3.png">