### PR TITLE
Lock already existing elements on the layout performed after adding a new interaction from form editor

### DIFF
--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -214,6 +214,7 @@ class FormEditor extends DataComponent {
         h('button.form-interaction-adder-btn', {
           onClick: () => {
             let doc = this.data.document;
+            let existingEntities = doc.entities();
 
             let addInteractionRow = () => this.addInteractionRow( {
               name: formType.type,
@@ -221,7 +222,7 @@ class FormEditor extends DataComponent {
               association: formType.association[0]
             } );
 
-            let applyLayout = () => doc.applyLayout();
+            let applyLayout = () => doc.applyLayout( { elesToLock: existingEntities } );
 
             Promise.try( addInteractionRow ).then( applyLayout );
           }

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -289,13 +289,22 @@ class Document {
   }
 
   // applies layout positions after the layout is done running, mostly useful for serverside
-  applyLayout(){
+  applyLayout( options = {} ){
+    let { elesToLock } = options;
+
     let cy = new Cytoscape({
       headless: true,
       elements: makeCyEles( this.elements() ),
-      layout: { name: 'grid' },
+      layout: { name: 'preset' },
       styleEnabled: true
     });
+
+    let getIdSelector = el => '#' + el.id();
+    let lockSelector = elesToLock ? elesToLock.map( getIdSelector ).join( ',' ) : null;
+
+    if ( lockSelector ) {
+      cy.elements().filter( lockSelector ).lock();
+    }
 
     let runLayout = () => {
       let layout = cy.layout( _.assign( {}, getCyLayoutOpts(), {


### PR DESCRIPTION
To re-solve #328

**Changes**

- Updated ``document.applyLayout()`` by adding an option to specify the elements to lock before the layout.
- While calling ``document.applyLayout()`` from form editor used the already existing entities as ``elesToLock`` option. 
- Needed to change the layout that is specified while creating a ``cy`` instance inside ``document.applyLayout()`` from ``grid`` to ``preset`` as having a grid layout there updates cy nodes positions before locking the already existing ones. I suppose it must not break some feature since the function already performs a cose layout with random positions after cy is created. Is there a specific reason to have a grid layout there?

**Results**

From my debugging I can say that already existing entities are locked successfully and ``docEl.reposition()`` is called with correct parameters here (https://github.com/metincansiper/factoid/blob/a0dab526c0328e19c295c4fa6593d978c99e8b29/src/model/document/document.js#L325). However, network editor is not synched with exactly the same positions and that causes ugly layouts as long as network editor is not refreshed after adding interactions from form editor.

For example the following is how the network editor looks like after adding a few interactions from form editor (Positions are not synched correctly. Looks like this if I switch to network editor after adding each interaction. Does not look that terrible but still has wrong positions if I switch to network editor only once after adding all of the interactions.)

<img width="1440" alt="screen shot 2018-06-22 at 10 19 39 am" src="https://user-images.githubusercontent.com/6534865/41789977-f8a62634-7605-11e8-86f4-7c86f2428f2f.png">

The following is how it looks after refreshing (has the updated positions):

<img width="1440" alt="screen shot 2018-06-22 at 10 19 52 am" src="https://user-images.githubusercontent.com/6534865/41790003-0da3546c-7606-11e8-8989-0d048c7cc30f.png">

I decided to open the PR independant of the problem in network editor since I beleive that it is a different problem (#330).