### PR TITLE
Eliminate word duplications on textmining highlighter

### DIFF
--- a/src/client/components/document-seeder.js
+++ b/src/client/components/document-seeder.js
@@ -140,7 +140,7 @@ class DocumentSeeder extends React.Component {
     basicIntervals = basicIntervals.sort(cmp);
     complexIntervals = complexIntervals.sort(cmp);
 
-    let eleminateDuplication = sortedArr => {
+    let eliminateDuplication = sortedArr => {
       return sortedArr.filter( ( currVal, currIndex ) => {
         let compPrev = () => {
           let prevVal = sortedArr[ currIndex - 1 ];
@@ -154,8 +154,8 @@ class DocumentSeeder extends React.Component {
 
     // same intervals would be repeated based on text mining results
     // handle such cases by removing any duplication of intervals
-    basicIntervals = eleminateDuplication( basicIntervals );
-    complexIntervals = eleminateDuplication( complexIntervals );
+    basicIntervals = eliminateDuplication( basicIntervals );
+    complexIntervals = eliminateDuplication( complexIntervals );
 
     let basicIndex = 0;
     let complexIndex = 0;

--- a/src/client/components/document-seeder.js
+++ b/src/client/components/document-seeder.js
@@ -140,6 +140,23 @@ class DocumentSeeder extends React.Component {
     basicIntervals = basicIntervals.sort(cmp);
     complexIntervals = complexIntervals.sort(cmp);
 
+    let eleminateDuplication = sortedArr => {
+      return sortedArr.filter( ( currVal, currIndex ) => {
+        let compPrev = () => {
+          let prevVal = sortedArr[ currIndex - 1 ];
+
+          return currVal.start === prevVal.start && currVal.end === prevVal.end;
+        };
+
+        return currIndex === 0 || !compPrev();
+      } );
+    };
+
+    // same intervals would be repeated based on text mining results
+    // handle such cases by removing any duplication of intervals
+    basicIntervals = eleminateDuplication( basicIntervals );
+    complexIntervals = eleminateDuplication( complexIntervals );
+
     let basicIndex = 0;
     let complexIndex = 0;
     let retVal = [];


### PR DESCRIPTION
To re-solve #333

Based on the text mining results two different event frame would be pointing out to the exactly same event trigger.

For example as specific to #333 we have both of the followings:

Frame1:
Text: Phosphorylated SMAD2
Text start position: 240
Trigger: Phosphorylated

Frame2:
Text: Phosphorylated SMAD2 is able to bind to the common mediator SMAD4
Text start position: 240
Trigger: Phosphorylated

It means that Frame1 is a substring of Frame2 (we can make sure it from the fact that the start positions are the same) and both of them points to the same trigger. That is the reason why the trigger is duplicated.

For #333 the problem is based on trigger sentences but I made a more general fix. I do not know if the samething would happen for entity mentions (currently highlighted by yellow) or event texts (currently underlined) but this fix must be covering that cases as well.