### PR TITLE
Updates on interactions created through text mining results

### DIFF
--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -301,13 +301,6 @@ module.exports = {
                       return INTERACTION_TYPE.METHYLATION;
                   }
                 }
-                else if ( argsAreEnts ) {
-                  // more cases would be added in the future
-                  switch ( frame.type ) {
-                    case REACH_EVENT_TYPE.ACTIVATION:
-                      return INTERACTION_TYPE.MODIFICATION;
-                  }
-                }
               }
               // protein - chemical
               else if ( protCount == 1 ) {
@@ -320,7 +313,7 @@ module.exports = {
                 }
               }
 
-              return INTERACTION_TYPE.GENERAL;
+              return INTERACTION_TYPE.INTERACTION;
             };
 
             let getEntityFrame = frame => {

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -299,8 +299,13 @@ module.exports = {
                       return INTERACTION_TYPE.PHOSPHORYLATION;
                     case REACH_EVENT_TYPE.METHYLATION:
                       return INTERACTION_TYPE.METHYLATION;
-                    default:
-                      return null;
+                  }
+                }
+                else if ( argsAreEnts ) {
+                  // more cases would be added in the future
+                  switch ( frame.type ) {
+                    case REACH_EVENT_TYPE.ACTIVATION:
+                      return INTERACTION_TYPE.MODIFICATION;
                   }
                 }
               }
@@ -311,13 +316,11 @@ module.exports = {
                   switch ( frame.type ) {
                     case REACH_EVENT_TYPE.ACTIVATION:
                       return INTERACTION_TYPE.PROTEIN_CHEMICAL;
-                    default:
-                      return null;
                   }
                 }
               }
 
-              return null;
+              return INTERACTION_TYPE.GENERAL;
             };
 
             let getEntityFrame = frame => {
@@ -351,7 +354,7 @@ module.exports = {
               }
             }
 
-            if( intn.entries.length >= 2 ){
+            if( intn.entries.length >= 2 && intn.completed ){
               addElement( intn, frame );
             }
           }


### PR DESCRIPTION
Mainly addresses #336

The reason behind #336 was the following:

- Since ``General`` interaction type is the default for factoid I am classifying any interaction that is not classified as one of the other interaction types as general. However, while doing that I was letting ``getAssociation()`` to return ``null`` if interaction is not classified as any of the other types. I suppose while merging #287 Max added the last step to complete an interaction if it has an association and a direction. However, the problem is that even if  ``getAssociation()`` returns ``null`` I was expecting it to be a ``General`` type of interaction since factoid model use it as default. Returning ``null`` there was confusing and become problematic after the las change of Max. Therefore, I updated it so that ``getAssociation()`` returns ``General`` by default instead of ``null``.

Also since text mining should not bring an incomplete interaction I updated condition of adding interaction from text mining by checking if the interaction is completed as well. One important thing about this is that if an entity only exists as the participant of the interaction that is skipped because it is not complete that entity will be skipped as well. I can remove that extra check if it does not sound good.