### PR TITLE
Form layout improvements

### DIFF
--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -295,8 +295,6 @@ class FormEditor extends DataComponent {
       }, [
         h('button.plain-button', {
           onClick: () => {
-            let doc = this.data.document;
-
             let addInteractionRow = () => this.addInteractionRow( {
               name: formType.type,
               pptTypes: formType.pptTypes,

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -142,6 +142,14 @@ class FormEditor extends DataComponent {
       }
     });
 
+    let cy = null;
+
+    let destroyCy = () => {
+      if ( cy !== null ) {
+        cy.destroy();
+      }
+    };
+
     return (
       Promise.all([ createIntn(), createEnts() ])
       .then( ([ intn, ppts ]) => {
@@ -154,7 +162,7 @@ class FormEditor extends DataComponent {
         let runLayout = cy => {
           let layout = cy.layout( _.assign( {}, getCyLayoutOpts(), {
             animate: false,
-            randomize: true
+            randomize: false
           } ) );
 
           // if there is an existing layout disrupt it
@@ -179,7 +187,7 @@ class FormEditor extends DataComponent {
           el.reposition( pos );
         };
 
-        let cy = new Cytoscape({
+        cy = new Cytoscape({
           headless: true,
           elements: makeCyEles( doc.elements() ),
           layout: { name: 'preset' },
@@ -218,20 +226,22 @@ class FormEditor extends DataComponent {
             els.forEach( el => this.beingAdded.add( el ) );
 
             let postAdd = () => {
-              let toAddSet = new Set( elesToAdd );
-              _.remove( this.elesToAdd, ele => toAddSet.has( ele ) );
+              _.remove( this.elesToAdd, el => _.includes( elesToAdd, el ) );
               els.forEach( el => this.beingAdded.delete( el ) );
             };
 
-            return Promise.all( elesToAdd.map( handleElCreation ) ).then( () => {
+            let addAll = () => {
               return Promise.all( pptsToAdd.map( add ) ).then( () => {
                 return Promise.all( intnsToAdd.map( add ) );
               } ).then( postAdd );
-            } );
+            };
+
+            return Promise.all( elesToAdd.map( handleElCreation ) ).then( addAll );
           } );
         } );
       } )
       .then( () => this.dirty() )
+      .finally( destroyCy )
     );
   }
 


### PR DESCRIPTION
- Locks the already existing elements before the layout. In this way re-solves #328, replaces #329.
- Merges adding interaction from form and performing the layout after it is done into a single operation (Most probably #330 can also be closed if it was only visible while trying to perform layout after adding interaction).
- Disrupts one form layout if another one is called before it is completed.
- Tried to test by calling ``addInteractionRow()`` twice instead of once when add interaction button is clicked. Two interactions are added successfully. However, this was not enough to be able to test the layout disruption case because even in that case the first layout have already finished before the second layout call. However, I suppose the second layout is called after first one finished but the the elements of first interaction are not created/added yet. Therefore, I was able to test that case.
