### PR TITLE
Removed unused properties of form-interaction-adder button

### DIFF
--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -52,7 +52,6 @@ class FormEditor extends DataComponent {
     this.data = {
       document: doc,
       bus: bus,
-      showIntnAdder: false,
     };
 
     let dirty = (() => {
@@ -243,9 +242,7 @@ class FormEditor extends DataComponent {
               }
             }, [
               h('button', {
-                className: 'form-interaction-adder',
-                onToggle: () => this.toggleIntnAdderVisibility(),
-                getState: () => this.data.showIntnAdder
+                className: 'form-interaction-adder'
               }, [
                 h('i.material-icons.add-new-interaction-icon', 'add'),
                 'Add interaction'


### PR DESCRIPTION
- Form interaction adder button had ``onToggle`` and ``getState`` properties that must be forgotten to be removed while converting it to a button from a toggle component.
- These properties was causing a console warning. Also ``this.toggleIntnAdderVisibility()`` that is to be called on toggle does not exists.
- I removed these properties along with ``this.data.showIntnAdder`` which became useless.