### PR TITLE
Relocated buttons for switching between editors and bug fix for the one in form editor

### DIFF
--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -136,6 +136,23 @@ class AppButtons extends React.Component {
         h('button.editor-button.plain-button', { onClick: () => exportDocumentToOwl(document.id()) }, [
           h('i.material-icons', 'save_alt')
         ])
+      ]),
+
+      h(Tooltip, _.assign( {}, baseTooltipProps, { description: 'Form-based editor' }), [
+        h('button.editor-button.plain-button', {
+          onClick: () => {
+            let id = document.id();
+            let secret = document.secret();
+
+            if( document.editable() ){
+              history.push(`/form/${id}/${secret}`);
+            } else {
+              history.push(`/form/${id}`);
+            }
+          }
+        }, [
+          h('i.material-icons', 'swap_horiz')
+        ])
       ])
     ]);
 
@@ -154,20 +171,6 @@ class AppButtons extends React.Component {
                 onClick: () => history.push('/documents')
               }, [
                 h('span', ' My factoids')
-              ]),
-              h('button.editor-more-button.plain-button', {
-                onClick: () => {
-                  let id = document.id();
-                  let secret = document.secret();
-
-                  if( document.editable() ){
-                    history.push(`/form/${id}/${secret}`);
-                  } else {
-                    history.push(`/form/${id}`);
-                  }
-                }
-              }, [
-                h('span', 'Form-based editor')
               ]),
               h('button.editor-more-button.plain-button', {
                 onClick: () => history.push('/')

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -265,6 +265,22 @@ class FormEditor extends DataComponent {
                 h('i.material-icons', 'save_alt')
               ])
             ]),
+            h(Tooltip, { description: 'Network editor' }, [
+              h('button.editor-button.plain-button', {
+                onClick: () => {
+                  let id = doc.id();
+                  let secret = doc.secret();
+
+                  if( doc.editable() ){
+                    history.push(`/document/${id}/${secret}`);
+                  } else {
+                    history.push(`/document/${id}`);
+                  }
+                }
+              }, [
+                h('i.material-icons', 'swap_horiz')
+              ])
+            ]),
             h(Popover, {
               tippy: {
                 position: 'right',
@@ -291,20 +307,6 @@ class FormEditor extends DataComponent {
                     onClick: () => history.push('/documents')
                   }, [
                     h('span', ' My factoids')
-                  ]),
-                  h('button.editor-more-button.plain-button', {
-                    onClick: () => {
-                      let id = document.id();
-                      let secret = document.secret();
-
-                      if( document.editable() ){
-                        history.push(`/document/${id}/${secret}`);
-                      } else {
-                        history.push(`/document/${id}`);
-                      }
-                    }
-                  }, [
-                    h('span', 'Network editor')
                   ]),
                   h('button.editor-more-button.plain-button', {
                     onClick: () => history.push('/')


### PR DESCRIPTION
I shared my findings about toolbars of both editors below as well though all of them are not related to the issue (#352) and PR. We can move them to a new issue if needed.

- Moved links for switching between editors from "more buttons (...)" of toolbars to toolbars itself in both editors for #352. 
- In both editors put the new icon under the "export to biopax" icon. However, while doing that realized that places of existing buttons are not consistent between the editors.
- Also I realized that in network editor "more buttons" are not enabled in read only mode while they are enabled on read only mode of form editor. I think making them consistent would be good. Since they are not enabled for network editor and switch option was one of them it was not enabled on read only mode of network editor. Now it is enabled.
- One other thing I realized is that share link button has no tooltip in form editor but has tooltip in form editor. 
- Switch button of form editor was not working so fixed it (Bug was caused by trying to access the factoid document from the wrong variable name. The factoid document was being referred by the variable ``doc`` but the variable ``document`` was attempted to be used instead and I think it was referring to the html ``document``).