### PR TITLE
Added text file export utility

### DIFF
--- a/src/client/util/file.js
+++ b/src/client/util/file.js
@@ -1,17 +1,14 @@
 const FileSaver = require('file-saver');
 const _ = require('lodash');
 
-function exportContentToFile(content, fileName){
-  var file = new File([content], fileName, {type: "text/plain;charset=utf-8"});
-  FileSaver.saveAs(file);
-}
-
-function exportContentToOwl(content, fileName){
-  if( !_.endsWith(fileName, '.owl') ){
-    fileName += '.owl';
+function exportContentToFile(content, fileName, ext){
+  // if filename does not end with the extension append extension to the file name
+  if( ext && !_.endsWith(fileName, ext) ){
+    fileName += ext;
   }
 
-  exportContentToFile(content, fileName);
+  var file = new File([content], fileName, {type: "text/plain;charset=utf-8"});
+  FileSaver.saveAs(file);
 }
 
 function exportDocumentToOwl(docId, fileName){
@@ -25,7 +22,21 @@ function exportDocumentToOwl(docId, fileName){
   fileName = fileName || docId;
 
   Promise.try( makeRequest ).then( result => result.text() )
-          .then( content => exportContentToOwl(content, fileName) );
+          .then( content => exportContentToFile(content, fileName, '.owl') );
 }
 
-module.exports = { exportContentToFile, exportContentToOwl, exportDocumentToOwl };
+function exportDocumentToTxt(docId, fileName){
+  // in case document itself is given instead of document id
+  if( !_.isString(docId) ){
+      docId = docId.id();
+  }
+
+  let makeRequest = () => fetch(`/api/document/text/${docId}`);
+
+  fileName = fileName || docId;
+
+  Promise.try( makeRequest ).then( result => result.text() )
+          .then( content => exportContentToFile(content, fileName, '.txt') );
+}
+
+module.exports = { exportContentToFile, exportDocumentToOwl, exportDocumentToTxt };

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -346,6 +346,14 @@ class Document {
     return templates;
   }
 
+  toText(){
+    let interactions = this.interactions();
+    let strings = interactions.map( intn => intn.toString() );
+    let dotOrEmptyStr = interactions.length > 0 ? '.' : '';
+
+    return strings.join( ', ' ) + dotOrEmptyStr;
+  }
+
   fromJson( json ){
     let els = json.elements || [];
     let makeEl = json => Promise.try( () => this.factory().make({ data: json }) );

--- a/src/model/element/interaction.js
+++ b/src/model/element/interaction.js
@@ -245,6 +245,10 @@ class Interaction extends Element {
   toBiopaxTemplate(){
     return this.association().toBiopaxTemplate();
   }
+
+  toString(){
+    return this.association().toString();
+  }
 }
 
 // forward common calls to the element set

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -133,4 +133,13 @@ http.get('/biopax/:id', function( req, res ){
     .then( owl => res.send( owl ));
 });
 
+http.get('/text/:id', function( req, res ){
+  let id = req.params.id;
+  Promise.try( loadTables )
+    .then( json => _.assign( {}, json, { id } ) )
+    .then( loadDoc )
+    .then( doc => doc.toText() )
+    .then( txt => res.send( txt ));
+});
+
 module.exports = http;


### PR DESCRIPTION
- Added an api to get text representation of the document with given id accesible through ``http.get('/text/:id')``.
- Added a client side utility function that enables consuming this api ``exportDocumentToTxt()``.
- Text representation of a document is basically obtained by joining string representations of each interaction by common followed by space ('', '') and then adding a dot (".") to the end of text if needed (if the text is not empty).
- String representation of interactions are obtained by calling ``interaction.toString()`` method that internally calls already existing ``toString()`` methods of associations of the interactions. 
- An example result is the following:

```
TP53 interacts with MDM2, RAS promotes the phosphorylation of AKT1.
```