### PR TITLE
Switch chemical provider to Pubchem as Chebi has been down

### DIFF
--- a/src/server/routes/api/element-association/aggregate.js
+++ b/src/server/routes/api/element-association/aggregate.js
@@ -1,8 +1,8 @@
 const _ = require('lodash');
 const Promise = require('bluebird');
-const chebi = require('./chebi');
+const pubchem = require('./pubchem');
 const uniprot = require('./uniprot');
-const providers = [ uniprot, chebi ];
+const providers = [ uniprot, pubchem ];
 const { memoize, stringDistanceMetric } = require('../../../../util');
 const LRUCache = require('lru-cache');
 const Organism = require('../../../../model/organism');


### PR DESCRIPTION
Chebi is still down.  This switches to Pubchem, so at least the results come back.