### PR TITLE
Added menu bar to form based editor.

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -20,7 +20,7 @@ const defs = require('./defs');
 const EditorButtons = require('./buttons');
 const MainMenu = require('../main-menu');
 const UndoRemove = require('./undo-remove');
-const { TaskView } = require('./tasks');
+const { TaskView } = require('../tasks');
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -14,6 +14,8 @@ const { makeCyEles, getCyLayoutOpts, tryPromise } = require('../../../util');
 
 const Tooltip = require('../popover/tooltip');
 const Popover = require('../popover/popover');
+const MainMenu = require('../main-menu');
+const { TaskView } = require('../tasks');
 
 
 const ProteinModificationForm = require('./protein-modification-form');
@@ -88,6 +90,8 @@ class FormEditor extends DataComponent {
           docEl.removeListener('remotecomplete', dirty);
           dirty();
         });
+
+        doc.on('submit', dirty);
 
         dirty();
 
@@ -231,6 +235,8 @@ class FormEditor extends DataComponent {
 
   render(){
     let doc = this.data.document;
+    let { bus } = this.data;
+    let { history } = this.props;
 
     const formTypes = [
       { type: 'Protein modification', clazz: ProteinModificationForm, pptTypes:[Interaction.PARTICIPANT_TYPE.UNSIGNED, Interaction.PARTICIPANT_TYPE.POSITIVE],  description:"E.g., A phosphorylates B.", association: [Interaction.ASSOCIATION.PHOSPHORYLATION, Interaction.ASSOCIATION.UBIQUINATION, Interaction.ASSOCIATION.METHYLATION] },
@@ -285,28 +291,38 @@ class FormEditor extends DataComponent {
     );
 
     return (
-      h('div.form-editor', [
-        h('div.form-content', [
-          h('h3.form-editor-title', doc.name() === '' ? 'Untitled document' : doc.name()),
-          h('div.form-templates', (
-            doc.interactions()
-            .filter(intn => intn.completed())
-            .map(interaction => ({ interaction, formType: getFormType(interaction) }))
-            .filter(({ formType }) => formType != null)
-            .map( ({ interaction, formType }) => h(IntnEntry, { interaction, formType }) )
-          )),
-          h('div.form-interaction-adder-area', [
-            h(Popover, {
-              tippy: {
-                position: 'bottom',
-                html: h('div.form-interaction-adder-options', formTypes.map( formType => h(FormTypeButton, { formType }) ))
-              }
-            }, [
-              h('button', {
-                className: 'form-interaction-adder'
+      h('div', [
+        h('div.form-main-menu', [
+          h(MainMenu, { bus, document: doc, history })
+        ]),
+        h('div.form-submit', [
+          h(Popover, { tippy: { html: h(TaskView, { document: doc, bus } ) } }, [
+            doc.submitted() ? h('button.form-submit-button', 'Submitted') : h('button.form-submit-button.salient-button', 'Submit')
+          ])
+        ]),
+        h('div.form-editor', [
+          h('div.form-content', [
+            h('h3.form-editor-title', doc.name() === '' ? 'Untitled document' : doc.name()),
+            h('div.form-templates', (
+              doc.interactions()
+              .filter(intn => intn.completed())
+              .map(interaction => ({ interaction, formType: getFormType(interaction) }))
+              .filter(({ formType }) => formType != null)
+              .map( ({ interaction, formType }) => h(IntnEntry, { interaction, formType }) )
+            )),
+            h('div.form-interaction-adder-area', [
+              h(Popover, {
+                tippy: {
+                  position: 'bottom',
+                  html: h('div.form-interaction-adder-options', formTypes.map( formType => h(FormTypeButton, { formType }) ))
+                }
               }, [
-                h('i.material-icons.add-new-interaction-icon', 'add'),
-                'Add interaction'
+                h('button', {
+                  className: 'form-interaction-adder'
+                }, [
+                  h('i.material-icons.add-new-interaction-icon', 'add'),
+                  'Add interaction'
+                ])
               ])
             ])
           ])

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -1,14 +1,14 @@
-const DirtyComponent = require('../dirty-component');
-const DataComponent = require('../data-component');
+const DirtyComponent = require('./dirty-component');
+const DataComponent = require('./data-component');
 const h = require('react-hyperscript');
 
-const { PC_URL } = require('../../../config');
+const { PC_URL } = require('../../config');
 
-const { makeClassList } = require('../../../util');
+const { makeClassList } = require('../../util');
 
-const Notification = require('../notification');
-const NotificationList = require('../notification/list');
-const NotificationPanel = require('../notification/panel');
+const Notification = require('./notification');
+const NotificationList = require('./notification/list');
+const NotificationPanel = require('./notification/panel');
 
 
 const eleEvts = [ 'rename', 'complete', 'uncomplete' ];

--- a/src/styles/form-editor/form-editor.css
+++ b/src/styles/form-editor/form-editor.css
@@ -10,6 +10,30 @@
   justify-content: space-between;
 }
 
+.form-main-menu,
+.form-submit {
+  box-sizing: border-box;
+  position: absolute;
+  z-index: 1;
+  display: inline-flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.5);
+  border-bottom-right-radius: 0.5em;
+}
+
+.form-submit-button {
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.form-main-menu {
+  left: 0;
+}
+
+.form-submit {
+  right: 0;
+  padding: 0.75em 0.5em;
+}
+
 .form-app-bar {
   display: flex;
   flex-direction: column;
@@ -62,17 +86,6 @@
 
 .delete-interaction {
 
-}
-
-.form-submit {
-  color: #EEEEEE;
-  background-color: #00A84C;
-  height: 2.5em;
-  margin-top: 1.5em;
-  margin-bottom: 4em;
-  padding: 0 20px;
-  display: flex;
-  flex-direction: row;
 }
 
 .form-options {


### PR DESCRIPTION
The following is how form based editor looks after adding menu bar.

<img width="1440" alt="screen shot 2018-11-05 at 11 08 02 am" src="https://user-images.githubusercontent.com/6534865/48020642-4555fe00-e0eb-11e8-8770-1b226f026962.png">

It looks nearly same of menu bar of network editor excluding the title part. I think giving the same content to title as well would be nice in terms of consistency. However, network editor title does not contain solely a text. It includes other parts too (https://github.com/PathwayCommons/factoid/blob/unstable/src/client/components/editor/index.js#L344).  If both network and form editors are requested to have the same title contents, how do you feel about creating a new small component like ``TitleContent`` that will have this content?

Other than that I moved ``tasks.js`` from ``src/client/components/editor`` to ``src/client/components`` because it is needed from the form editor as well.

