### PR TITLE
Refs #382 and fixed a couple of prev. refactoring bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ warn.log
 error.log
 debug.log
 /.idea/
-
+*.iml

--- a/package-lock.json
+++ b/package-lock.json
@@ -13119,7 +13119,6 @@
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13134,8 +13133,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -13146,8 +13144,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13264,8 +13261,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13277,7 +13273,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13292,7 +13287,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13404,8 +13398,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13538,7 +13531,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "factoid",
-  "version": "0.2.0",
+  "version": "0.4.0-unstable",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4173,7 +4173,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4194,12 +4195,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4214,17 +4217,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4341,7 +4347,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4353,6 +4360,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4367,6 +4375,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4374,12 +4383,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4398,6 +4409,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4478,7 +4490,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4490,6 +4503,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4575,7 +4589,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4611,6 +4626,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4630,6 +4646,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4673,12 +4690,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13093,12 +13112,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13113,17 +13134,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13240,7 +13264,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13252,6 +13277,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13266,6 +13292,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13377,7 +13404,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13510,6 +13538,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/src/client/components/editor/cy/edgehandles.js
+++ b/src/client/components/editor/cy/edgehandles.js
@@ -66,8 +66,6 @@ module.exports = function({ bus, cy, document, controller }){
     let idIsNotIntn = el => el.id() !== intnNode.id();
     let pptNodes = source.add( target ).filter( idIsNotIntn );
     let ppts = pptNodes.map( n => document.get( n.id() ) );
-    let isChemical = el => el.type() === 'chemical';
-    let isProtein = el => el.type() === 'protein';
 
     let handleIntn = () => {
       if( createdIntnNode ){

--- a/src/client/components/editor/cy/edgehandles.js
+++ b/src/client/components/editor/cy/edgehandles.js
@@ -72,7 +72,7 @@ module.exports = function({ bus, cy, document, controller }){
     let handleIntn = () => {
       if( createdIntnNode ){
         return controller.addInteraction({
-          association: (ppts.some(isChemical) && ppts.some(isProtein)) ? 'chemicalprotein' : 'interaction',
+          association: 'interaction',
           position: _.clone( intnNode.position() ),
           entries: ppts.map( ppt => ({ id: ppt.id() }) )
         });

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -45,7 +45,7 @@ class InteractionInfo extends DataComponent {
     let { STAGES, ORDERED_STAGES } = progression;
     let initialStage;
 
-    if( allPpts.some(isProtein) && allPpts.some(isChemical) ){
+    if( allPpts.some(isProtein) && allPpts.some(isChemical) ){//TODO why skip?
       initialStage = ORDERED_STAGES[1]; // skip first stage for protein-chemical interaction
     } else {
       initialStage = ORDERED_STAGES[0];
@@ -262,11 +262,12 @@ class InteractionInfo extends DataComponent {
           return;
         }
 
-        // skip modification base type for now and just allow users to set
-        // modification subtypes
-        if( assoc.value === el.ASSOCIATION.MODIFICATION.value ){
-          return;
-        }
+        //DON'T skip base Modification type - used for prot-prot activation/inactivation without phys. mod. feature.
+        // (control of state change)
+        // // skip modification base type for now and just allow users to set modification subtypes
+        // if( assoc.value === el.ASSOCIATION.MODIFICATION.value ){
+        //   return;
+        // }
 
         let radioId = 'interaction-info-assoc-radioset-item-' + uuid();
         let checked = el.associated() && el.association().value === assoc.value;

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -43,13 +43,7 @@ class InteractionInfo extends DataComponent {
     });
 
     let { STAGES, ORDERED_STAGES } = progression;
-    let initialStage;
-
-    if( allPpts.some(isProtein) && allPpts.some(isChemical) ){//TODO why skip?
-      initialStage = ORDERED_STAGES[1]; // skip first stage for protein-chemical interaction
-    } else {
-      initialStage = ORDERED_STAGES[0];
-    }
+    let initialStage = ORDERED_STAGES[0];
 
     let stage = initCache( stageCache, el, el.completed() ? STAGES.COMPLETED : initialStage );
 
@@ -261,13 +255,6 @@ class InteractionInfo extends DataComponent {
         if( !anyPptIsUnassoc && !assoc.isAllowedForInteraction(el) ){
           return;
         }
-
-        //DON'T skip base Modification type - used for prot-prot activation/inactivation without phys. mod. feature.
-        // (control of state change)
-        // // skip modification base type for now and just allow users to set modification subtypes
-        // if( assoc.value === el.ASSOCIATION.MODIFICATION.value ){
-        //   return;
-        // }
 
         let radioId = 'interaction-info-assoc-radioset-item-' + uuid();
         let checked = el.associated() && el.association().value === assoc.value;

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -234,9 +234,10 @@ class FormEditor extends DataComponent {
 
     const formTypes = [
       { type: 'Protein modification', clazz: ProteinModificationForm, pptTypes:[Interaction.PARTICIPANT_TYPE.UNSIGNED, Interaction.PARTICIPANT_TYPE.POSITIVE],  description:"E.g., A phosphorylates B.", association: [Interaction.ASSOCIATION.PHOSPHORYLATION, Interaction.ASSOCIATION.UBIQUINATION, Interaction.ASSOCIATION.METHYLATION] },
-      { type: 'Binding', clazz: MolecularInteractionForm, pptTypes: [Interaction.PARTICIPANT_TYPE.UNSIGNED, Interaction.PARTICIPANT_TYPE.UNSIGNED], description: "E.g., A interacts with B.", association: [Interaction.ASSOCIATION.INTERACTION] },
+      { type: 'Binding', clazz: MolecularInteractionForm, pptTypes: [Interaction.PARTICIPANT_TYPE.UNSIGNED, Interaction.PARTICIPANT_TYPE.UNSIGNED], description: "E.g., A interacts with B.", association: [Interaction.ASSOCIATION.BINDING] },
       { type: 'Activation or inhibition', clazz:ActivationInhibitionForm, pptTypes: [Interaction.PARTICIPANT_TYPE.UNSIGNED, Interaction.PARTICIPANT_TYPE.POSITIVE], description: "E.g., A activates B.", association: [Interaction.ASSOCIATION.MODIFICATION] },
       { type: 'Gene expression regulation', clazz: ExpressionRegulationForm, pptTypes: [Interaction.PARTICIPANT_TYPE.UNSIGNED, Interaction.PARTICIPANT_TYPE.POSITIVE], description: "E.g., A promotes the expression of B.", association: [Interaction.ASSOCIATION.EXPRESSION] }
+      //TODO add "other" (see the design doc, biopax 4A-E) type and form that supports all participants types { type: 'Other',..,association: [Interaction.ASSOCIATION.INTERACTION] }
     ];
 
     let getFormType = intn => {

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -431,7 +431,7 @@ class Document {
       }
     } );
 
-    console.log(JSON.stringify(templates));//TODO remove debug log
+    // console.log(JSON.stringify(templates));//TODO remove debug log
     return templates;
   }
 

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -431,6 +431,7 @@ class Document {
       }
     } );
 
+    console.log(JSON.stringify(templates));//TODO remove debug log
     return templates;
   }
 

--- a/src/model/element/entity-type.js
+++ b/src/model/element/entity-type.js
@@ -1,10 +1,10 @@
 const _ = require('lodash');
 
-const ENTITY_TYPE = {
+const ENTITY_TYPE = Object.freeze({
   ENTITY: 'entity',
   PROTEIN: 'protein',
   CHEMICAL: 'chemical'
-};
+});
 
 const ENTITY_TYPES = _.flatMap( ENTITY_TYPE );
 

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -101,15 +101,16 @@ class Entity extends Element {
 
     return {
       id: assoc.id,
-      namespace: assoc.namespace
+      db: assoc.namespace
     };
   }
 
   toBiopaxTemplate(){
+    let type = this.type();
     let name = this.name() || '';
     let xref = this.getBiopaxXref();
     
-    return { name, xref };
+    return { type, name, xref };
   }
 }
 

--- a/src/model/element/interaction-type/binding.js
+++ b/src/model/element/interaction-type/binding.js
@@ -1,9 +1,10 @@
 const InteractionType = require('./interaction-type');
 const { PARTICIPANT_TYPE } = require('../participant-type');
 const { ENTITY_TYPE } = require('../entity-type');
+const { BIOPAX_TEMPLATE_TYPE } = require('./biopax-type');
 
 const VALUE = 'binding';
-const DISPLAY_VALUE = 'Binding';
+const DISPLAY_VALUE = 'Binding'; //several (two?) proteins binding
 
 class Binding extends InteractionType {
   constructor( intn ){
@@ -24,7 +25,13 @@ class Binding extends InteractionType {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
+    let participants = this.interaction.participants();
+    let participantTemplates = participants.map( participant => participant.toBiopaxTemplate() );
+
+    return {
+      type: BIOPAX_TEMPLATE_TYPE.MOLECULAR_INTERACTION,
+      participants: participantTemplates
+    };
   }
 
   toString(){

--- a/src/model/element/interaction-type/biopax-type.js
+++ b/src/model/element/interaction-type/biopax-type.js
@@ -1,13 +1,12 @@
-// TODO BIOPAX
-
 const BIOPAX_TEMPLATE_TYPE = Object.freeze({
-  PROTEIN_CONTROLS_STATE: 'Protein Controls State',
-  CHEMICAL_AFFECTS_STATE: 'Chemical Affects State',
-  EXPRESSION_REGULATION: 'Expression Regulation',
+  //case: 1 (intn. type: Binding)
   MOLECULAR_INTERACTION: 'Molecular Interaction',
-  PROTEIN_MODIFICATION: 'Protein Modification',
-  PROTEIN_CONTROLS_CONSUMPTION: 'Protein Controls Consumption',
-  PROTEIN_CONTROLS_PRODUCTION: 'Protein Controls Production'
+  // case: 2 (TranscriptionTranslation)
+  EXPRESSION_REGULATION: 'Expression Regulation',
+  //case: 3 (Modification affects active/inactive state, possibly via e.g. ubiquitination)
+  PROTEIN_CONTROLS_STATE: 'Protein Controls State',
+  //case: 4A-E; biopax converter results are based on the ent. types, order, sign.
+  OTHER_INTERACTION: 'Other Interaction',
 });
 
 const BIOPAX_CONTROL_TYPE = Object.freeze({

--- a/src/model/element/interaction-type/demethylation.js
+++ b/src/model/element/interaction-type/demethylation.js
@@ -10,7 +10,6 @@ class Demethylation extends Modification {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     return super.toBiopaxTemplate(EFFECT);
   }
 

--- a/src/model/element/interaction-type/dephosphorylation.js
+++ b/src/model/element/interaction-type/dephosphorylation.js
@@ -10,7 +10,6 @@ class Dephosphorylation extends Modification {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     return super.toBiopaxTemplate(EFFECT);
   }
 

--- a/src/model/element/interaction-type/deubiquitination.js
+++ b/src/model/element/interaction-type/deubiquitination.js
@@ -10,7 +10,6 @@ class Deubiquitination extends Modification {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     return super.toBiopaxTemplate(EFFECT);
   }
 

--- a/src/model/element/interaction-type/enum.js
+++ b/src/model/element/interaction-type/enum.js
@@ -14,6 +14,7 @@ const Deubiquitination = require('./deubiquitination');
 const INTERACTION_TYPE = Object.freeze({
   BINDING: Binding,
   TRANSCRIPTION_TRANSLATION: TranscriptionTranslation,
+  //next are 1 base and 6 sub-classes of protein-protein modification and state change -
   MODIFICATION: Modification,
   PHOSPHORYLATION: Phosphorylation,
   DEPHOSPHORYLATION: Dephosphorylation,
@@ -21,7 +22,10 @@ const INTERACTION_TYPE = Object.freeze({
   DEMETHYLATION: Demethylation,
   UBIQUITINATION: Ubiquitination,
   DEUBIQUITINATION: Deubiquitination,
-  INTERACTION: Interaction
+  //TODO keep defining specific interaction types as needed
+  //for other interactions (participant type, sign, etc. combinations),
+  //such as modulation (chemical affects protein activity), conversion (chemical->chemical), etc.
+  INTERACTION: Interaction //other
 });
 
 const INTERACTION_TYPE_VALS = ( () => {
@@ -30,7 +34,6 @@ const INTERACTION_TYPE_VALS = ( () => {
 
   keys.forEach( key => {
     let val = INTERACTION_TYPE[key].value;
-
     vals[ key ] = val;
   } );
 

--- a/src/model/element/interaction-type/interaction-type.js
+++ b/src/model/element/interaction-type/interaction-type.js
@@ -89,7 +89,8 @@ class InteractionType {
     let ppts = intn.participantsNotOfType( PARTICIPANT_TYPE.UNSIGNED );
 
     if( ppts.length > 1 ){ // can't have more than one target
-      throw error(`Can not get target, as more than two participants of interaction ${intn.id()} are signed: ` + intn.participants().map( ppt => ppt.id() ).join(', '));
+      throw error(`Can not get target, as more than two participants of interaction ${intn.id()} are signed: `
+        + intn.participants().map( ppt => ppt.id() ).join(', '));
     }
 
     return ppts[0];
@@ -110,7 +111,8 @@ class InteractionType {
     let ppts = intn.participantsOfType( PARTICIPANT_TYPE.UNSIGNED );
 
     if( ppts.length > 1 ){ // can't have more than one source
-      throw error(`Can not get source, as more than two participants of interaction ${intn.id()} are unsigned: ` + intn.participants().map( ppt => ppt.id() ).join(', '));
+      throw error(`Can not get source, as more than two participants of interaction ${intn.id()} are unsigned: `
+        + intn.participants().map( ppt => ppt.id() ).join(', '));
     }
 
     return ppts[0];

--- a/src/model/element/interaction-type/interaction.js
+++ b/src/model/element/interaction-type/interaction.js
@@ -1,23 +1,41 @@
 const InteractionType = require('./interaction-type');
-const { BIOPAX_TEMPLATE_TYPE } = require('./biopax-type');
+const { BIOPAX_TEMPLATE_TYPE, BIOPAX_CONTROL_TYPE } = require('./biopax-type');
 
 const VALUE = 'interaction';
 const DISPLAY_VALUE = 'Other';
 
 class Interaction extends InteractionType {
+
   constructor( intn ){
     super( intn );
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
+    // "Other" type; see 4A-E in "Factoid binary interaction types" doc.
     let participants = this.interaction.participants();
     let participantTemplates = participants.map( participant => participant.toBiopaxTemplate() );
 
-    return {
-      type: BIOPAX_TEMPLATE_TYPE.MOLECULAR_INTERACTION,
-      moleculeList: participantTemplates
+    let controlType = this.isInhibition()
+      ? BIOPAX_CONTROL_TYPE.INHIBITION
+      : BIOPAX_CONTROL_TYPE.ACTIVATION;
+
+    let template = {
+      type: BIOPAX_TEMPLATE_TYPE.OTHER_INTERACTION,
+      participants: participantTemplates
     };
+
+    if(controlType)
+      template.controlType = controlType;
+
+    let source = this.getSource();
+    if(source)
+      template.controller = source.toBiopaxTemplate();
+
+    let target = this.getTarget();
+    if(target)
+      template.target = target.toBiopaxTemplate();
+
+    return template;
   }
 
   static get value(){ return VALUE; }
@@ -25,6 +43,10 @@ class Interaction extends InteractionType {
 
   static get displayValue(){ return DISPLAY_VALUE; }
   get displayValue(){ return DISPLAY_VALUE; }
+
+  toString(){
+    return super.toString('interacts with');
+  }
 }
 
 module.exports = Interaction;

--- a/src/model/element/interaction-type/methylation.js
+++ b/src/model/element/interaction-type/methylation.js
@@ -10,7 +10,6 @@ class Methylation extends Modification {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     return super.toBiopaxTemplate(EFFECT);
   }
 

--- a/src/model/element/interaction-type/modification.js
+++ b/src/model/element/interaction-type/modification.js
@@ -4,7 +4,7 @@ const { ENTITY_TYPE } = require('../entity-type');
 const { BIOPAX_TEMPLATE_TYPE, BIOPAX_CONTROL_TYPE } = require('./biopax-type');
 
 const VALUE = 'modification';
-const DISPLAY_VALUE = 'Protein modification/activity change';
+const DISPLAY_VALUE = 'Modification/activity change';
 
 class Modification extends InteractionType {
   constructor( intn ){

--- a/src/model/element/interaction-type/modification.js
+++ b/src/model/element/interaction-type/modification.js
@@ -4,7 +4,7 @@ const { ENTITY_TYPE } = require('../entity-type');
 const { BIOPAX_TEMPLATE_TYPE, BIOPAX_CONTROL_TYPE } = require('./biopax-type');
 
 const VALUE = 'modification';
-const DISPLAY_VALUE = 'Post-translational modification';
+const DISPLAY_VALUE = 'Protein modification/activity change';
 
 class Modification extends InteractionType {
   constructor( intn ){
@@ -28,23 +28,24 @@ class Modification extends InteractionType {
     return ppts.length === 2 && ppts.every( isProtein );
   }
 
-  // TODO BIOPAX
-  toBiopaxTemplate(effect){
+  toBiopaxTemplate(effect){ //effect is undefined in base Modification case (i.e., no phys. mod. feature)
     let source = this.getSource();
     let target = this.getTarget();
 
     let srcTemplate = source.toBiopaxTemplate();
     let tgtTemplate = target.toBiopaxTemplate();
-    let templateType = ( effect === undefined )
-            ? BIOPAX_TEMPLATE_TYPE.PROTEIN_CONTROLS_STATE : BIOPAX_TEMPLATE_TYPE.PROTEIN_MODIFICATION;
 
-    let controlType = this.isInhibition() ? BIOPAX_CONTROL_TYPE.INHIBITION : BIOPAX_CONTROL_TYPE.ACTIVATION;
+    let controlType = this.isInhibition()
+      ? BIOPAX_CONTROL_TYPE.INHIBITION
+      : BIOPAX_CONTROL_TYPE.ACTIVATION;
 
     let template = {
-      type: templateType,
-      controllerProtein: srcTemplate,
-      targetProtein: tgtTemplate,
+      type: BIOPAX_TEMPLATE_TYPE.PROTEIN_CONTROLS_STATE,
+      controller: srcTemplate, //controller protein
+      target: tgtTemplate,
       controlType: controlType
+      //here controlType is not bp:controlType but is about whether
+      //target's state switches from 'inactive' to 'active' or the other way around.
     };
 
     if (effect) {

--- a/src/model/element/interaction-type/phosphorylation.js
+++ b/src/model/element/interaction-type/phosphorylation.js
@@ -10,7 +10,6 @@ class Phosphorylation extends Modification {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     return super.toBiopaxTemplate(EFFECT);
   }
 

--- a/src/model/element/interaction-type/transcription-translation.js
+++ b/src/model/element/interaction-type/transcription-translation.js
@@ -29,7 +29,6 @@ class TranscriptionTranslation extends InteractionType {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     let source = this.getSource();
     let target = this.getTarget();
 
@@ -40,14 +39,15 @@ class TranscriptionTranslation extends InteractionType {
 
     return {
       type: BIOPAX_TEMPLATE_TYPE.EXPRESSION_REGULATION,
-      transcriptionFactor: srcTemplate,
-      targetProtein: tgtTemplate,
+      controller: srcTemplate,
+      target: tgtTemplate,
       controlType: controlType
     };
   }
 
   toString(){
-    return super.toString( (this.isInhibition() ? 'inhibits' : 'activates') + ' the transcription/translation of' );
+    return super.toString( (this.isInhibition() ? 'inhibits' : 'activates')
+      + ' the transcription/translation of' );
   }
 
   static get value(){ return VALUE; }

--- a/src/model/element/interaction-type/ubiquitination.js
+++ b/src/model/element/interaction-type/ubiquitination.js
@@ -10,7 +10,6 @@ class Ubiquitination extends Modification {
   }
 
   toBiopaxTemplate(){
-    // TODO BIOPAX
     return super.toBiopaxTemplate(EFFECT);
   }
 

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -295,7 +295,7 @@ module.exports = {
 
                   switch ( type ) {
                     case REACH_EVENT_TYPE.TRANSCRIPTION:
-                      return INTERACTION_TYPE.EXPRESSION;
+                      return INTERACTION_TYPE.TRANSCRIPTION_TRANSLATION;
                     case REACH_EVENT_TYPE.PHOSPHORYLATION:
                       return INTERACTION_TYPE.PHOSPHORYLATION;
                     case REACH_EVENT_TYPE.METHYLATION:
@@ -309,7 +309,7 @@ module.exports = {
                   // more cases would be added in the future
                   switch ( frame.type ) {
                     case REACH_EVENT_TYPE.ACTIVATION:
-                      return INTERACTION_TYPE.PROTEIN_CHEMICAL;
+                      return INTERACTION_TYPE.INTERACTION;
                   }
                 }
               }


### PR DESCRIPTION
Refs #382 

There are 4 biopax template types now. 
In the Factoid model (interaction types), I re-purposed Interaction class to  what we call "Other" now, and Binding is what the Interaction used to be (MolecularInteraction), etc.

(Currently, you cannot export to BioPAX until factoid-converters is updated too, but you can see the intermediate JSON output in the log; see TODOs..)

See:
- [biopax-type.js](https://github.com/IgorRodchenkov/factoid/blob/model-bin-intns/src/model/element/interaction-type/biopax-type.js)
- [enum.js](https://github.com/IgorRodchenkov/factoid/blob/model-bin-intns/src/model/element/interaction-type/enum.js)
- an [example JSON output](https://github.com/PathwayCommons/factoid-converters/blob/master/src/test/resources/test2.json) (doc.toBiopaxtemplates()): 

I think the new intermediate JSON output (input for factoid-converters ws) is better and easier to convert to a biopax model than before.

I also fixed a bug (there was wrong/missing "chemicalprotein" edge type and interaction type), and now one can successfully draw an edge between a protein and chemical nodes ("other" by default).

If we all like the new json and model, I could also write tests in the test/interaction.js, for each specific interaction and participants case...