### PR TITLE
add editor selector button to the factoid menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4173,8 +4173,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4195,14 +4194,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4217,20 +4214,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4347,8 +4341,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4360,7 +4353,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4375,7 +4367,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4383,14 +4374,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4409,7 +4398,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4490,8 +4478,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4503,7 +4490,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4589,8 +4575,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4626,7 +4611,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4646,7 +4630,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4690,14 +4673,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -13112,8 +13093,7 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
@@ -13138,8 +13118,7 @@
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -352,7 +352,7 @@ class Editor extends DataComponent {
         ])
       ]),
       h('div.editor-main-menu', [
-        h(MainMenu, { bus, document, history })
+        h(MainMenu, { bus, document, history, networkEditor: true })
       ]),
       h('div.editor-submit', [
         h(Popover, { tippy: { html: h(TaskView, { document, bus } ) } }, [

--- a/src/client/components/main-menu.js
+++ b/src/client/components/main-menu.js
@@ -38,7 +38,7 @@ class MenuContent extends Component {
   }
 
   render(){
-    const { bus, document, history, emitter } = this.props;
+    const { bus, document, history, emitter, networkEditor } = this.props;
     const { selectedLinkouts, selectedMyFactoids } = this.state;
 
     const set = (props, children) => h('div.main-menu-set', props, children);
@@ -54,6 +54,17 @@ class MenuContent extends Component {
     }, [
       h('span', label)
     ]);
+
+    let editorSwitcher = ( document, networkEditor) => {
+      if( document == null ){ return null; }
+
+      let id = document.id();
+      let secret = document.secret();
+      let label = networkEditor ? 'Form Editor' : 'Network Editor';
+      let url = `/${networkEditor ? 'form' : 'document'}/${id}/${secret}`;
+
+      return item({ label, action: () => history.push(url) });
+    };
 
     let content;
 
@@ -77,7 +88,8 @@ class MenuContent extends Component {
         ]) : null,
         set({ key: 'nav' }, [
           item({ label: 'New factoid', action: () => history.push('/new') }),
-          item({ label: 'My factoids', action: () => this.selectMyFactoids(), actionCloses: false })
+          item({ label: 'My factoids', action: () => this.selectMyFactoids(), actionCloses: false }),
+          editorSwitcher( document, networkEditor )
         ])
       ]);
     }
@@ -95,7 +107,7 @@ class MainMenu extends Component {
 
   render(){
     let { emitter } = this;
-    let { bus, document, history, title } = this.props;
+    let { bus, document, history, title, networkEditor } = this.props;
 
     return h('div.main-menu', [
       h(Popover, {
@@ -104,7 +116,7 @@ class MainMenu extends Component {
           onHide: () => emitter.emit('hide'),
           onShow: () => emitter.emit('show'),
           placement: 'bottom',
-          html: h(MenuContent, { bus, document, history, emitter })
+          html: h(MenuContent, { bus, document, history, emitter, networkEditor })
         }
       }, [
         h(Tooltip, { description: 'Menu', tippy: { placement: 'bottom' } }, [

--- a/src/client/router.js
+++ b/src/client/router.js
@@ -81,8 +81,9 @@ let routes = [
     path: '/form/:id',
     render: props => {
       let { id } = props.match.params;
+      let { history } = props;
 
-      return h( FormEditor, { id } );
+      return h( FormEditor, { id, history } );
     }
   },
   {
@@ -98,8 +99,9 @@ let routes = [
     path: '/document/:id',
     render: props => {
       let { id } = props.match.params;
+      let { history } = props;
 
-      return h( Editor, { id } );
+      return h( Editor, { id, history } );
     }
   },
   {


### PR DESCRIPTION
- implement editor chooser in the factoid main menu
- ~~doesn't work like the other react router links as referenced in issue #385~~
- Fix #385 so that the editor select button works in read only mode -- passed history as props to the read only versions of the editors. 


