### PR TITLE
Further to #382 and PathwayCommons/factoid-converters#4, plus polishing.

### DIFF
--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -73,7 +73,7 @@ class InteractionInfo extends DataComponent {
       case STAGES.PARTICIPANT_TYPES:
         return el.associated();
       case STAGES.COMPLETED:
-        return el.associated() && el.association().areParticipantsTyped();
+        return el.associated() && el.association().isComplete();
       default:
         return false;
     }

--- a/src/client/components/form-editor/interaction-form.js
+++ b/src/client/components/form-editor/interaction-form.js
@@ -32,19 +32,11 @@ class InteractionForm extends DirtyComponent {
   }
 
   getInputParticipant(){
-    try {
-      return this.data.interaction.association().getSource();
-    } catch(err){
-      return null;
-    }
+    return this.data.interaction.association().getSource(); //null if not set
   }
 
   getOutputParticipant(){
-    try {
-      return this.data.interaction.association().getTarget();
-    } catch(err){
-      return null;
-    }
+    return this.data.interaction.association().getTarget(); //null if not set
   }
 
   completeIfReady(){

--- a/src/model/element/interaction-type/binding.js
+++ b/src/model/element/interaction-type/binding.js
@@ -11,6 +11,10 @@ class Binding extends InteractionType {
     super( intn );
   }
 
+  isComplete() {
+    return true; //can be unsigned or even have untyped participants
+  }
+
   allowedParticipantTypes(){
     const T = PARTICIPANT_TYPE;
 

--- a/src/model/element/interaction-type/interaction-type.js
+++ b/src/model/element/interaction-type/interaction-type.js
@@ -36,8 +36,8 @@ class InteractionType {
     return this.isPositive() || this.isNegative();
   }
 
-  areParticipantsTyped(){
-    return true;
+  isComplete(){
+    return false;
   }
 
   setParticipantAs( ppt, type ){
@@ -85,15 +85,10 @@ class InteractionType {
 
   getTarget(){
     let intn = this.interaction;
-
     let ppts = intn.participantsNotOfType( PARTICIPANT_TYPE.UNSIGNED );
-
-    if( ppts.length > 1 ){ // can't have more than one target
-      throw error(`Can not get target, as more than two participants of interaction ${intn.id()} are signed: `
-        + intn.participants().map( ppt => ppt.id() ).join(', '));
-    }
-
-    return ppts[0];
+    // assoc. cannot have more than one target,
+    // but this must be checked somewhere else (no need to throw an exception here)
+    return( ppts.length > 1 ) ? null : ppts[0];
   }
 
   setTarget( ppt ){
@@ -109,13 +104,9 @@ class InteractionType {
   getSource(){
     let intn = this.interaction;
     let ppts = intn.participantsOfType( PARTICIPANT_TYPE.UNSIGNED );
-
-    if( ppts.length > 1 ){ // can't have more than one source
-      throw error(`Can not get source, as more than two participants of interaction ${intn.id()} are unsigned: `
-        + intn.participants().map( ppt => ppt.id() ).join(', '));
-    }
-
-    return ppts[0];
+    // assoc. cannot have more than one source,
+    // but this must be checked somewhere else (no need to throw an exception here)
+    return ( ppts.length > 1 ) ? null : ppts[0];
   }
 
   toBiopaxTemplate() {
@@ -123,15 +114,15 @@ class InteractionType {
   }
 
   toString(verbPhrase, post = ''){
-    let intn = this.interaction;
     let src, tgt;
 
-    try {
+    if(this.isSigned()) {
       src = this.getSource();
       tgt = this.getTarget();
-    } catch( err ){
-      let ppts = intn.participants();
-
+      if(!src || !tgt) //any null or undefined
+        throw new Error(`Source or target is undefined for signed interaction type ${this.value}`);
+    } else { //currently, unsigned also means undirected (signed - always directed, directed - signed)
+      let ppts = this.interaction.participants();
       src = ppts[0];
       tgt = ppts[1];
     }

--- a/src/model/element/interaction-type/interaction.js
+++ b/src/model/element/interaction-type/interaction.js
@@ -10,30 +10,29 @@ class Interaction extends InteractionType {
     super( intn );
   }
 
+  isComplete() {
+    //TODO: according to the doc (4A-E), we'd define conditions of completeness in each case
+    return true; //base case (can be unsigned or have untyped participants if the UI allows)
+  }
+
   toBiopaxTemplate(){
     // "Other" type; see 4A-E in "Factoid binary interaction types" doc.
-    let participants = this.interaction.participants();
-    let participantTemplates = participants.map( participant => participant.toBiopaxTemplate() );
-
-    let controlType = this.isInhibition()
-      ? BIOPAX_CONTROL_TYPE.INHIBITION
-      : BIOPAX_CONTROL_TYPE.ACTIVATION;
-
     let template = {
-      type: BIOPAX_TEMPLATE_TYPE.OTHER_INTERACTION,
-      participants: participantTemplates
+      type: BIOPAX_TEMPLATE_TYPE.OTHER_INTERACTION
     };
 
-    if(controlType)
-      template.controlType = controlType;
+    //optional controlType
+    if(this.isInhibition())
+      template.controlType = BIOPAX_CONTROL_TYPE.INHIBITION;
+    else if(this.isActivation())
+      template.controlType = BIOPAX_CONTROL_TYPE.ACTIVATION;
 
+    //optional source, target are either both null or both defined (unless there is a bug)
     let source = this.getSource();
-    if(source)
-      template.controller = source.toBiopaxTemplate();
-
     let target = this.getTarget();
-    if(target)
-      template.target = target.toBiopaxTemplate();
+    //ensure participants order is always [source,target] if defined
+    let participants = (source && target) ? [source, target] : this.interaction.participants();
+    template.participants = participants.map( participant => participant.toBiopaxTemplate() );
 
     return template;
   }

--- a/src/model/element/interaction-type/modification.js
+++ b/src/model/element/interaction-type/modification.js
@@ -17,7 +17,7 @@ class Modification extends InteractionType {
     return [T.POSITIVE, T.NEGATIVE];
   }
 
-  areParticipantsTyped(){
+  isComplete(){
     return this.isSigned();
   }
 
@@ -28,25 +28,23 @@ class Modification extends InteractionType {
     return ppts.length === 2 && ppts.every( isProtein );
   }
 
-  toBiopaxTemplate(effect){ //effect is undefined in base Modification case (i.e., no phys. mod. feature)
-    let source = this.getSource();
-    let target = this.getTarget();
-
-    let srcTemplate = source.toBiopaxTemplate();
-    let tgtTemplate = target.toBiopaxTemplate();
-
-    let controlType = this.isInhibition()
-      ? BIOPAX_CONTROL_TYPE.INHIBITION
-      : BIOPAX_CONTROL_TYPE.ACTIVATION;
+  toBiopaxTemplate(effect){//effect is undefined in base Modification case (i.e., no phys. mod. feature)
+    // src and tgt must be both set, not null, by this point
+    let srcTemplate = this.getSource().toBiopaxTemplate();
+    let tgtTemplate = this.getTarget().toBiopaxTemplate();
 
     let template = {
       type: BIOPAX_TEMPLATE_TYPE.PROTEIN_CONTROLS_STATE,
       controller: srcTemplate, //controller protein
-      target: tgtTemplate,
-      controlType: controlType
-      //here controlType is not bp:controlType but is about whether
-      //target's state switches from 'inactive' to 'active' or the other way around.
+      target: tgtTemplate
     };
+
+    //here controlType is not bp:controlType but is about the
+    //target's state change between 'inactive' and 'active'.
+    if(this.isInhibition())
+      template.controlType = BIOPAX_CONTROL_TYPE.INHIBITION;
+    else if(this.isActivation())
+      template.controlType = BIOPAX_CONTROL_TYPE.ACTIVATION;
 
     if (effect) {
       template.modification = effect;

--- a/src/model/element/interaction-type/transcription-translation.js
+++ b/src/model/element/interaction-type/transcription-translation.js
@@ -17,7 +17,7 @@ class TranscriptionTranslation extends InteractionType {
     return [T.POSITIVE, T.NEGATIVE];
   }
 
-  areParticipantsTyped(){
+  isComplete(){
     return this.isSigned();
   }
 
@@ -29,20 +29,22 @@ class TranscriptionTranslation extends InteractionType {
   }
 
   toBiopaxTemplate(){
-    let source = this.getSource();
-    let target = this.getTarget();
+    //src, tgt shouldn't be null at this point (barring bug)
+    let srcTemplate = this.getSource().toBiopaxTemplate();
+    let tgtTemplate = this.getTarget().toBiopaxTemplate();
 
-    let srcTemplate = source.toBiopaxTemplate();
-    let tgtTemplate = target.toBiopaxTemplate();
-
-    let controlType = this.isInhibition() ? BIOPAX_CONTROL_TYPE.INHIBITION : BIOPAX_CONTROL_TYPE.ACTIVATION;
-
-    return {
+    let template = {
       type: BIOPAX_TEMPLATE_TYPE.EXPRESSION_REGULATION,
       controller: srcTemplate,
-      target: tgtTemplate,
-      controlType: controlType
+      target: tgtTemplate
     };
+
+    if(this.isInhibition())
+      template.controlType = BIOPAX_CONTROL_TYPE.INHIBITION;
+    else if(this.isActivation())
+      template.controlType = BIOPAX_CONTROL_TYPE.ACTIVATION;
+
+    return template;
   }
 
   toString(){

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -574,6 +574,7 @@ describe('Interaction', function(){
           } ).then( () => {
             expect( intnC1.association().value ).to.equal( intnType.value );
             expect( intnC1.association().isPositive() ).to.equal( pptType.value === Interaction.PARTICIPANT_TYPE.POSITIVE.value );
+            expect( intnC1.association().getTarget() ).to.equal(entC1);
             expect( intnC1.association().getTarget().id() ).to.equal( entC1.id() );
           } );
         });
@@ -595,6 +596,7 @@ describe('Interaction', function(){
       } ).then( () => {
         expect( intnC1.association().value ).to.equal( Interaction.ASSOCIATION.TRANSCRIPTION_TRANSLATION.value );
         expect( intnC1.association().isPositive() ).to.be.true;
+        expect( intnC1.association().getTarget() ).to.equal(entC1);
         expect( intnC1.association().getTarget().id() ).to.equal( entC1.id() );
       } );
     });


### PR DESCRIPTION
Removed some redundancy in the toBiopaxTemplates output.
Renamed misleading areParticipantsTyped() to isComplete(), checked its use in base class and subclasses.
Made getSource(), getTarget() return null instead of exception in case of questionable state (which, if ever happens at all, shold not be dealt with in those get/set accessors).
