### PR TITLE
Updates to the UI re. the 'Factoid binary interactions' specification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,9 +2622,13 @@
       "integrity": "sha1-0k3O4OCiRNFRxPjYBWUfL2dOgXo="
     },
     "cytoscape-edgehandles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/cytoscape-edgehandles/-/cytoscape-edgehandles-3.2.1.tgz",
-      "integrity": "sha512-EOhVbgpBZVXZBF88awCX0dilAPXug9rKyvVR/4G+OLV3hoNPVJ9giWqIPGYkeX0OQACVQkFWKiN2yAdxyTy1bg=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-edgehandles/-/cytoscape-edgehandles-3.5.0.tgz",
+      "integrity": "sha512-PKuuCLKvgVPPiR0PLY51FbtHFS2w9mRGRjd5kwWJqARQrKqVm8yJqElbyjFHCs9DhuDMDlOgdZcCWm+mBvaCBA==",
+      "requires": {
+        "lodash.memoize": "^4.1.2",
+        "lodash.throttle": "^4.1.1"
+      }
     },
     "cytoscape-popper": {
       "version": "1.0.1",
@@ -5624,7 +5628,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
@@ -6082,8 +6086,7 @@
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
     },
     "lodash.template": {
       "version": "4.4.0",
@@ -6103,6 +6106,11 @@
       "requires": {
         "lodash._reinterpolate": "~3.0.0"
       }
+    },
+    "lodash.throttle": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
+      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -10714,7 +10722,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -11031,7 +11039,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
         "define-property": "^1.0.0",
@@ -11050,7 +11058,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
         "kind-of": "^3.2.0"
@@ -11264,7 +11272,7 @@
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cytoscape-automove": "^1.9.0",
     "cytoscape-cose-bilkent": "^1.6.10",
     "cytoscape-cxtmenu": "^2.10.3",
-    "cytoscape-edgehandles": "^3.2.1",
+    "cytoscape-edgehandles": "^3.5.0",
     "cytoscape-popper": "^1.0.1",
     "date-fns": "^1.28.5",
     "debug": "^2.2.0",

--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const { tippyTopZIndex } = require('../../defs');
 const Tooltip = require('../popover/tooltip');
 const Toggle = require('../toggle');
+const { PARTICIPANT_TYPE } = require('../../../model/element/participant-type');
 
 class EditorButtons extends React.Component {
   render(){
@@ -25,6 +26,20 @@ class EditorButtons extends React.Component {
     };
 
     if( document.editable() ){
+      const PptTypeBtn = (type, description, shortcut) => (
+        h(Tooltip, _.assign({}, baseTooltipProps, { description, shortcut }), [
+          h(Toggle, {
+            className: 'editor-button plain-button',
+            onToggle: () => controller.toggleDrawMode(null, type),
+            getState: () => controller.drawMode() && controller.drawModeType().value === type.value
+          }, [
+            h('i', {
+              className: type.icon + ' icon-rot-345'
+            })
+          ])
+        ])
+      );
+
       grs.push([
         h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add an entity', shortcut: 'e' }), [
           h('button.editor-button.plain-button', { onClick: () => controller.addElement().then( el => bus.emit('opentip', el) )  }, [
@@ -32,11 +47,9 @@ class EditorButtons extends React.Component {
           ])
         ]),
 
-        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Draw an interaction', shortcut: 'd' }), [
-          h(Toggle, { className: 'editor-button plain-button', onToggle: () => controller.toggleDrawMode(), getState: () => controller.drawMode()  }, [
-            h('i.material-icons.icon-rot-45', 'remove')
-          ])
-        ])
+        PptTypeBtn(PARTICIPANT_TYPE.UNSIGNED, 'Draw an undirected interaction', 'd'),
+        PptTypeBtn(PARTICIPANT_TYPE.POSITIVE, 'Draw an activation interaction', 'd'),
+        PptTypeBtn(PARTICIPANT_TYPE.NEGATIVE, 'Draw an inhibition interaction', 'd')
       ]);
     }
 

--- a/src/client/components/editor/cy/cxtmenu.js
+++ b/src/client/components/editor/cy/cxtmenu.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 
-const icon = (name, cls) => `<span class="cxtmenu-command-icon"><i class="material-icons ${cls}">${name}</i></span>`;
+const matIcon = (name, cls) => `<span class="cxtmenu-command-icon"><i class="material-icons ${cls}">${name}</i></span>`;
+const customIcon = (name, cls) => `<span class="cxtmenu-command-icon"><i class="icon icon-white ${name} ${cls}"></i></span>`;
 
 const DEFAULTS = Object.freeze({
   fillColor: 'rgba(0, 0, 0, 0.85)',
@@ -8,52 +9,61 @@ const DEFAULTS = Object.freeze({
   openMenuEvents: 'cxttapstart'
 });
 
+const { PARTICIPANT_TYPE } = require('../../../../model/element/participant-type');
+
 module.exports = function({ cy, document, bus }){
   if( !document.editable() ){ return; }
 
-  let drawCmd = {
-    content: icon('remove', 'icon-rot-45'),
+  let drawUnsignedCmd = {
+    content: customIcon('icon-arrow-unsigned', 'icon-rot-345'),
     select: function( el ){
-      bus.emit( 'drawfrom', el );
+      bus.emit( 'drawfrom', el, PARTICIPANT_TYPE.UNSIGNED );
+    }
+  };
+
+  let drawPositiveCmd = {
+    content: customIcon('icon-arrow-positive', 'icon-rot-345'),
+    select: function( el ){
+      bus.emit( 'drawfrom', el, PARTICIPANT_TYPE.POSITIVE );
+    }
+  };
+
+  let drawNegativeCmd = {
+    content: customIcon('icon-arrow-negative', 'icon-rot-345'),
+    select: function( el ){
+      bus.emit( 'drawfrom', el, PARTICIPANT_TYPE.NEGATIVE );
     }
   };
 
   let rmElCmd = {
-    content: icon('clear'),
+    content: matIcon('clear'),
     select: function( el ){
       bus.emit('removebycy', el);
     }
   };
 
   let rmSelCmd = {
-    content: icon('clear'),
+    content: matIcon('clear'),
     select: function(){
       bus.emit('removeselected');
     }
   };
 
   let addEntCmd = {
-    content: icon('fiber_manual_record'),
+    content: matIcon('fiber_manual_record'),
     select: function(){
       bus.emit('addelementmouse');
     }
   };
 
-  let drawModeCmd = {
-    content: icon('remove', 'icon-rot-45'),
-    select: function(){
-      bus.emit('drawtoggle');
-    }
-  };
-
   cy.cxtmenu( _.assign( {}, DEFAULTS, {
     selector: 'node[?isInteraction]',
-    commands: [ drawCmd, rmElCmd ]
+    commands: [ drawUnsignedCmd, drawPositiveCmd, drawNegativeCmd, rmElCmd ]
   } ) );
 
   cy.cxtmenu( _.assign( {}, DEFAULTS, {
     selector: 'node[?isEntity]',
-    commands: [ drawCmd, rmElCmd ]
+    commands: [ drawUnsignedCmd, drawPositiveCmd, drawNegativeCmd, rmElCmd ]
   } ) );
 
   cy.cxtmenu( _.assign( {}, DEFAULTS, {
@@ -61,7 +71,7 @@ module.exports = function({ cy, document, bus }){
     commands: [ rmElCmd ]
   } ) );
 
-  let bgCmds = [ drawModeCmd, addEntCmd, rmSelCmd ];
+  let bgCmds = [ addEntCmd, rmSelCmd ];
 
   cy.cxtmenu( _.assign( {}, DEFAULTS, {
     selector: 'core',

--- a/src/client/components/editor/cy/stylesheet.js
+++ b/src/client/components/editor/cy/stylesheet.js
@@ -67,6 +67,12 @@ function makeStylesheet(){
       }
     },
     {
+      selector: 'node[?isInteraction] -> node',
+      style: {
+        'source-endpoint': 'inside-to-node'
+      }
+    },
+    {
       selector: 'edge[type="positive"]',
       style: {
         'target-arrow-shape': 'triangle'
@@ -122,9 +128,7 @@ function makeStylesheet(){
         'background-color': activeColor,
         'line-color': activeColor,
         'target-arrow-color': activeColor,
-        'source-arrow-color': activeColor,
-        'source-endpoint': 'inside-to-node',
-        'target-endpoint': 'inside-to-node'
+        'source-arrow-color': activeColor
       }
     },
     {
@@ -146,6 +150,12 @@ function makeStylesheet(){
         'border-color': activeColor,
         'border-width': 4,
         'border-style': 'double'
+      }
+    },
+    {
+      selector: '.eh-ghost-edge.eh-preview-active',
+      style: {
+        'opacity': 0
       }
     }
   ].filter( block => block != null );

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 
 const { getId, defer, makeClassList, tryPromise } = require('../../../util');
 const Document = require('../../../model/document');
+const { PARTICIPANT_TYPE } = require('../../../model/element/participant-type');
 
 const Notification = require('../notification');
 const CornerNotification = require('../notification/corner');
@@ -202,18 +203,36 @@ class Editor extends DataComponent {
     return this.data.document.editable();
   }
 
-  toggleDrawMode( toggle ){
+  toggleDrawMode( toggle, type = PARTICIPANT_TYPE.UNSIGNED ){
     if( !this.editable() ){ return; }
 
-    let on = toggle === undefined ? !this.drawMode() : toggle;
+    let on;
 
-    this.data.bus.emit( on ? 'drawon' : 'drawoff' );
+    if( toggle == null ){
+      if( this.data.drawModeType == null || type.value !== this.data.drawModeType.value ){
+        on = true; // keep on if just changing type
+      } else {
+        on = !this.drawMode(); // otherwise flip
+      }
+    } else {
+      on = !!toggle; // ensure bool
+    }
 
-    return new Promise( resolve => this.setData({ drawMode: on }, resolve) );
+    if( on ){
+      this.data.bus.emit('drawon', type );
+    } else {
+      this.data.bus.emit('drawoff');
+    }
+
+    return new Promise( resolve => this.setData({ drawMode: on, drawModeType: type }, resolve) );
   }
 
   drawMode(){
     return this.data.drawMode;
+  }
+
+  drawModeType(){
+    return this.data.drawModeType;
   }
 
   addElement( data = {} ){

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -12,6 +12,8 @@ const EventEmitter = require('eventemitter3');
 const Notification = require('../notification/notification');
 const InlineNotification = require('../notification/inline');
 const Tooltip = require('../popover/tooltip');
+const { INTERACTION_TYPES, INTERACTION_TYPE } = require('../../../model/element/interaction-type');
+const { PARTICIPANT_TYPE } = require('../../../model/element/participant-type');
 
 let stageCache = new WeakMap();
 let assocNotificationCache = new SingleValueCache();
@@ -33,14 +35,14 @@ class InteractionInfo extends DataComponent {
     let ppt = doc.get( pptNode.id() );
 
     let progression = new Progression({
-      STAGES: ['ASSOCIATE', 'PARTICIPANT_TYPES', 'COMPLETED'],
+      STAGES: ['PARTICIPANT_TYPES', 'ASSOCIATE', 'COMPLETED'],
       getStage: () => this.getStage(),
       canGoToStage: stage => this.canGoToStage(stage),
       goToStage: stage => this.goToStage(stage)
     });
 
     let { STAGES, ORDERED_STAGES } = progression;
-    let initialStage = ORDERED_STAGES[0];
+    let initialStage = ORDERED_STAGES[1]; // skip the arrow / ppt types stage b/c the user drew the edge with the arrow already
 
     let stage = initCache( stageCache, el, el.completed() ? STAGES.COMPLETED : initialStage );
 
@@ -68,10 +70,10 @@ class InteractionInfo extends DataComponent {
     let { STAGES } = progression;
 
     switch( stage ){
+      case STAGES.PARTICIPANT_TYPES:
+        return true;
       case STAGES.ASSOCIATE:
         return true;
-      case STAGES.PARTICIPANT_TYPES:
-        return el.associated();
       case STAGES.COMPLETED:
         return el.associated() && el.association().isComplete();
       default:
@@ -246,20 +248,37 @@ class InteractionInfo extends DataComponent {
       let radiosetChildren = [];
       let anyPptIsUnassoc = el.participants().some( ppt => !ppt.associated() );
 
-      el.ASSOCIATIONS.forEach( assoc => {
+      INTERACTION_TYPES.forEach( IntnType => {
         // skip types that don't apply to the participant set
         // but don't block options if the ent's are unassociated/untyped
-        if( !anyPptIsUnassoc && !assoc.isAllowedForInteraction(el) ){
+        let pptAssocsAllowed = anyPptIsUnassoc || IntnType.isAllowedForInteraction(el);
+        let pptType = (
+          el.participants()
+          .map(ppt => el.participantType(ppt))
+          .filter(type => type.value !== PARTICIPANT_TYPE.UNSIGNED.value)[0] // assume one typed ppt, others unsigned
+          || PARTICIPANT_TYPE.UNSIGNED // if no other type found, then it's unsigned overall
+        );
+        let pptTypeAllowed = IntnType.allowedParticipantTypes().some(type => type.value === pptType.value);
+
+        if( !pptAssocsAllowed || !pptTypeAllowed ){
           return;
         }
 
         let radioId = 'interaction-info-assoc-radioset-item-' + uuid();
-        let checked = el.associated() && el.association().value === assoc.value;
+        let checked = el.associated() && el.association().value === IntnType.value;
+        let indented = [
+          INTERACTION_TYPE.PHOSPHORYLATION,
+          INTERACTION_TYPE.DEPHOSPHORYLATION,
+          INTERACTION_TYPE.METHYLATION,
+          INTERACTION_TYPE.DEMETHYLATION,
+          INTERACTION_TYPE.UBIQUITINATION,
+          INTERACTION_TYPE.DEUBIQUITINATION
+        ].some( IndentedType => IndentedType.value === IntnType.value );
 
         radiosetChildren.push( h('input.interaction-info-type-radio', {
           type: 'radio',
           onChange: () => {
-            this.associate( assoc );
+            this.associate( IntnType );
             progression.forward();
           },
           onClick: () => { // skip to next stage when clicking existing assoc
@@ -267,13 +286,14 @@ class InteractionInfo extends DataComponent {
           },
           id: radioId,
           name: radioName,
-          value: assoc.value,
+          value: IntnType.value,
           checked
         }) );
 
         radiosetChildren.push( h('label.interaction-info-assoc-radio-label', {
+          className: indented ? 'interaction-info-type-radio-indented' : '',
           htmlFor: radioId
-        }, assoc.displayValue) );
+        }, IntnType.displayValue) );
       } );
 
       children.push( makeNotification(s.assocNotification) );

--- a/src/client/components/element-info/participant-info.js
+++ b/src/client/components/element-info/participant-info.js
@@ -3,6 +3,7 @@ const ReactDom = require('react-dom');
 const h = require('react-hyperscript');
 const uuid = require('uuid');
 const { animateDomForEdit } = require('../animate');
+const { PARTICIPANT_TYPES } = require('../../../model/element/participant-type');
 
 class ParticipantInfo extends React.Component {
   constructor( props ){
@@ -26,6 +27,7 @@ class ParticipantInfo extends React.Component {
     intn.participants().forEach( retypeToNull );
 
     intn.participantType( ppt, type );
+    intn.unassociate(); // if we change the arrow, we can't guarantee the assoc is compatible anymore
 
     this.setState({ pptType: type });
   }
@@ -42,11 +44,7 @@ class ParticipantInfo extends React.Component {
       let radioName = 'participant-info-type-radioset-' + ppt.id();
       let radiosetChildren = [];
 
-      intn.PARTICIPANT_TYPES.forEach( type => {
-        if( !intn.association().allowedParticipantTypes().some( t => t.value === type.value ) ){
-          return; // ignore unsupported ppt types for the interaction type
-        }
-
+      PARTICIPANT_TYPES.forEach( type => {
         let radioId = 'participant-info-type-radioset-item-' + uuid();
         let checked = this.state.pptType.value === type.value;
 
@@ -67,9 +65,10 @@ class ParticipantInfo extends React.Component {
         }) );
 
         radiosetChildren.push( h('label.participant-info-type-label', {
-          htmlFor: radioId,
-          dangerouslySetInnerHTML: { __html: type.icon }
-        }) );
+          htmlFor: radioId
+        }, [
+          h('i', { className: type.icon })
+        ]) );
       } );
 
       children.push( h('div.radioset.participant-info-type-radioset', radiosetChildren) );

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -12,8 +12,9 @@ const Tooltip = require('../popover/tooltip');
 const Popover = require('../popover/popover');
 const MainMenu = require('../main-menu');
 const { TaskView } = require('../tasks');
-const Interaction = require('../../../model/element/interaction');
 const InteractionForm = require('./interaction-form');
+const { PARTICIPANT_TYPE } = require('../../../model/element/participant-type');
+const { INTERACTION_TYPE } = require('../../../model/element/interaction-type');
 
 class FormEditor extends DataComponent {
   constructor(props){
@@ -106,7 +107,7 @@ class FormEditor extends DataComponent {
 
     let entries = [ uuid(), uuid() ].map( (id) => ({
       id,
-      group: Interaction.PARTICIPANT_TYPE.UNSIGNED
+      group: PARTICIPANT_TYPE.UNSIGNED
     }) );
 
     let createEnt = (entry) => doc.factory().make({
@@ -251,8 +252,8 @@ class FormEditor extends DataComponent {
           className: 'form-interaction-adder',
           onClick: () => {
             let addInteractionRow = () => this.addInteractionRow( {
-              name: Interaction.ASSOCIATION.INTERACTION.toString(),
-              association: Interaction.ASSOCIATION.INTERACTION
+              name: INTERACTION_TYPE.INTERACTION.toString(),
+              association: INTERACTION_TYPE.INTERACTION
             } );
             addInteractionRow();
           }
@@ -277,8 +278,7 @@ class FormEditor extends DataComponent {
             h('h3.form-editor-title',
               doc.name() === '' ? 'Untitled document' : doc.name()),
             h('div.form-templates', (
-              doc.interactions().filter(intn => intn.completed())
-                .map( (interaction) =>  h(IntnEntry, { interaction }))
+              doc.interactions().map( (interaction) =>  h(IntnEntry, { interaction }))
             )),
             h('div.form-interaction-adder-area', [
               h(FormTypeButton, {

--- a/src/model/element/element.js
+++ b/src/model/element/element.js
@@ -15,8 +15,6 @@ const DEFAULTS = Object.freeze({
 
 const sanitizePosition = pos => _.pick( pos, _.keys( DEFAULTS.position ) );
 
-const { ELEMENT_TYPES, ELEMENT_TYPE } = require('./element-type');
-
 /**
 A generic biological element of no specific type
 
@@ -25,12 +23,6 @@ This allows for reading and writing on the DB and keeping the object synched
 with remote updates.
 */
 class Element {
-  static get TYPES(){ return ELEMENT_TYPES; }
-  get TYPES(){ return ELEMENT_TYPES; }
-
-  static get TYPE(){ return ELEMENT_TYPE; }
-  get TYPE(){ return ELEMENT_TYPE; }
-
   constructor( opts = {} ){
     EventEmitterMixin.call( this ); // defines this.emitter
 

--- a/src/model/element/interaction-type/binding.js
+++ b/src/model/element/interaction-type/binding.js
@@ -6,6 +6,12 @@ const { BIOPAX_TEMPLATE_TYPE } = require('./biopax-type');
 const VALUE = 'binding';
 const DISPLAY_VALUE = 'Binding';
 
+const allowedParticipantTypes = () => {
+  const T = PARTICIPANT_TYPE;
+
+  return [ T.UNSIGNED ];
+};
+
 class Binding extends InteractionType {
   constructor( intn ){
     super( intn );
@@ -15,10 +21,12 @@ class Binding extends InteractionType {
     return !this.isSigned() && Binding.isAllowedForInteraction(this.interaction);
   }
 
-  allowedParticipantTypes(){
-    const T = PARTICIPANT_TYPE;
+  static allowedParticipantTypes(){
+    return allowedParticipantTypes();
+  }
 
-    return [T.UNSIGNED];
+  allowedParticipantTypes(){
+    return allowedParticipantTypes();
   }
 
   static isAllowedForInteraction( intn ){
@@ -39,7 +47,7 @@ class Binding extends InteractionType {
   }
 
   toString(){
-    return super.toString('binds');
+    return super.toString('binds with');
   }
 
   static get value(){ return VALUE; }

--- a/src/model/element/interaction-type/index.js
+++ b/src/model/element/interaction-type/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./enum');

--- a/src/model/element/interaction-type/interaction.js
+++ b/src/model/element/interaction-type/interaction.js
@@ -2,7 +2,7 @@ const InteractionType = require('./interaction-type');
 const { BIOPAX_TEMPLATE_TYPE, BIOPAX_CONTROL_TYPE } = require('./biopax-type');
 
 const VALUE = 'interaction';
-const DISPLAY_VALUE = 'Interaction';
+const DISPLAY_VALUE = 'Other';
 
 class Interaction extends InteractionType {
 

--- a/src/model/element/interaction-type/modification.js
+++ b/src/model/element/interaction-type/modification.js
@@ -6,16 +6,23 @@ const { BIOPAX_TEMPLATE_TYPE, BIOPAX_CONTROL_TYPE } = require('./biopax-type');
 const VALUE = 'modification';
 const DISPLAY_VALUE = 'Post-translational modification';
 
+const allowedParticipantTypes = () => {
+  const T = PARTICIPANT_TYPE;
+
+  return [T.POSITIVE, T.NEGATIVE];
+};
 
 class Modification extends InteractionType {
   constructor( intn ){
     super( intn );
   }
 
-  allowedParticipantTypes(){
-    const T = PARTICIPANT_TYPE;
+  static allowedParticipantTypes(){
+    return allowedParticipantTypes();
+  }
 
-    return [T.POSITIVE, T.NEGATIVE];
+  allowedParticipantTypes(){
+    return allowedParticipantTypes();
   }
 
   isComplete(){

--- a/src/model/element/interaction-type/transcription-translation.js
+++ b/src/model/element/interaction-type/transcription-translation.js
@@ -6,13 +6,23 @@ const { BIOPAX_TEMPLATE_TYPE, BIOPAX_CONTROL_TYPE } = require('./biopax-type');
 const VALUE = 'transcription-translation';
 const DISPLAY_VALUE = 'Transcription/translation';
 
+const allowedParticipantTypes = () => {
+  const T = PARTICIPANT_TYPE;
+
+  return [T.POSITIVE, T.NEGATIVE];
+};
+
 class TranscriptionTranslation extends InteractionType {
   constructor( intn ){
     super( intn );
   }
 
+  static allowedParticipantTypes(){
+    return allowedParticipantTypes();
+  }
+
   allowedParticipantTypes(){
-    return [PARTICIPANT_TYPE.POSITIVE, PARTICIPANT_TYPE.NEGATIVE];
+    return allowedParticipantTypes();
   }
 
   isComplete(){
@@ -46,7 +56,7 @@ class TranscriptionTranslation extends InteractionType {
   }
 
   toString(){
-    return super.toString(null, 'the transcription/translation of');
+    return super.toString(this.getSign().verbPhrase + ' the transcription/translation of');
   }
 
   static get value(){ return VALUE; }

--- a/src/model/element/interaction.js
+++ b/src/model/element/interaction.js
@@ -3,8 +3,8 @@ const _ = require('lodash');
 const ElementSet = require('../element-set');
 const { assertFieldsDefined, tryPromise } = require('../../util');
 
-const { INTERACTION_TYPE, INTERACTION_TYPES, getIntnTypeByVal } = require('./interaction-type/enum');
-const { PARTICIPANT_TYPE, PARTICIPANT_TYPES, getPptTypeByVal } = require('./participant-type');
+const { INTERACTION_TYPE, getIntnTypeByVal } = require('./interaction-type/enum');
+const { PARTICIPANT_TYPE, getPptTypeByVal } = require('./participant-type');
 
 const TYPE = 'interaction';
 
@@ -70,27 +70,6 @@ class Interaction extends Element {
     });
   }
 
-  // the following 12 methods simply provide convenient access to the
-  // interaction/participant enum methods/values through this object/class
-  static get PARTICIPANT_TYPE(){ return PARTICIPANT_TYPE; }
-  get PARTICIPANT_TYPE(){ return PARTICIPANT_TYPE; }
-
-  static get PARTICIPANT_TYPES(){ return PARTICIPANT_TYPES; }
-  get PARTICIPANT_TYPES(){ return PARTICIPANT_TYPES; }
-
-  static get ASSOCIATION(){ return INTERACTION_TYPE; }
-  get ASSOCIATION(){ return INTERACTION_TYPE; }
-
-  static get ASSOCIATIONS(){ return INTERACTION_TYPES; }
-  get ASSOCIATIONS(){ return INTERACTION_TYPES; }
-
-  static get getIntnTypeByVal(){ return getIntnTypeByVal; }
-  get getIntnTypeByVal(){ return getIntnTypeByVal; }
-
-  static get getPptTypeByVal(){ return getPptTypeByVal; }
-  get getPptTypeByVal(){ return getPptTypeByVal; }
-
-
   static type(){ return TYPE; }
 
   isInteraction(){ return true; }
@@ -139,7 +118,6 @@ class Interaction extends Element {
     return getPptTypeByVal( this.elementSet.group( ele ) );
   }
 
-  //TODO simplify (and test) this weird method; what happens when type is UNSIGNED_TARGET?..
   setParticipantType( ele, type ){
     let oldType = this.getParticipantType( ele );
     let typeVal;
@@ -218,7 +196,7 @@ class Interaction extends Element {
     let oldType = makeAssociation( this.syncher.get('association'), this );
 
     let update = this.syncher.update({
-      association: null,
+      association: INTERACTION_TYPE.INTERACTION.value,
       type: TYPE
     }).then( () => {
       this.emit('unassociated', oldType);

--- a/src/model/element/participant-type.js
+++ b/src/model/element/participant-type.js
@@ -1,18 +1,11 @@
 const _ = require('lodash');
 
-const pptType = ( value, displayValue, icon, verb ) => Object.freeze({ value, displayValue, icon, verb });
+const pptType = ( value, displayValue, icon, verbPhrase ) => Object.freeze({ value, displayValue, icon, verbPhrase });
 
 const PARTICIPANT_TYPE = Object.freeze({
-  //target cannot be UNSIGNED but can be UNSIGNED_TARGET (special value)
-  UNSIGNED: pptType('unsigned', '–',
-    '<i class="material-icons">remove</i>', 'interacts with'),
-  // unsigned target only indicates the target of an interaction; not meant for ui display
-  UNSIGNED_TARGET: pptType('unsigned target', '–',
-    '<i class="material-icons">remove</i>', 'affects'),
-  POSITIVE: pptType('positive', '→',
-    '<i class="material-icons">arrow_forward</i>', 'positively affects'),
-  NEGATIVE: pptType('negative', '⊣',
-    '<i class="material-icons icon-rot-90">title</i>', 'negatively affects')
+  UNSIGNED: pptType('unsigned', 'unsigned', 'icon icon-arrow-unsigned', 'interacts with'),
+  POSITIVE: pptType('positive', 'positive', 'icon icon-arrow-positive', 'activates'),
+  NEGATIVE: pptType('negative', 'negative', 'icon icon-arrow-negative', 'inhibits')
 });
 
 //pptType objects array

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -270,7 +270,7 @@ module.exports = {
                 return PARTICIPANT_TYPE.NEGATIVE;
               }
 
-              return PARTICIPANT_TYPE.UNSIGNED_TARGET;
+              return PARTICIPANT_TYPE.UNSIGNED;
             };
 
             let attachTargetGroup = entry => {

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -323,16 +323,18 @@ button {
   width: 1em;
   height: 1em;
   background-size: contain;
+}
 
-  &.icon-spinner {
-    transform: translate3d(0, 0, 0);
-    background-image: url('./image/spinner.svg');
-    animation: spin 750ms infinite linear;
-  }
+.icon-rot-15 {
+  transform: rotate(30deg);
+}
 
-  &.icon-logo {
-    background-image: url('./image/logo.svg');
-  }
+.icon-rot-30 {
+  transform: rotate(30deg);
+}
+
+.icon-rot-45 {
+  transform: rotate(45deg);
 }
 
 .icon-rot-90 {
@@ -347,8 +349,16 @@ button {
   transform: rotate(270deg);
 }
 
-.icon-rot-45 {
-  transform: rotate(45deg);
+.icon-rot-315 {
+  transform: rotate(315deg);
+}
+
+.icon-rot-330 {
+  transform: rotate(330deg);
+}
+
+.icon-rot-345 {
+  transform: rotate(345deg);
 }
 
 h1,

--- a/src/styles/custom-icons.css
+++ b/src/styles/custom-icons.css
@@ -1,0 +1,35 @@
+.icon {
+  &.icon-spinner {
+    transform: translate3d(0, 0, 0);
+    background-image: url('./image/spinner.svg');
+    animation: spin 750ms infinite linear;
+  }
+
+  &.icon-logo {
+    background-image: url('./image/logo.svg');
+  }
+
+  &.icon-arrow-positive {
+    background-image: url('./image/arrow-positive-long-filled.svg');
+
+    &.icon-white {
+      background-image: url('./image/arrow-positive-long-filled-white.svg');
+    }
+  }
+
+  &.icon-arrow-negative {
+    background-image: url('./image/arrow-negative-small.svg');
+
+    &.icon-white {
+      background-image: url('./image/arrow-negative-small-white.svg');
+    }
+  }
+
+  &.icon-arrow-unsigned {
+    background-image: url('./image/arrow-unsigned.svg');
+
+    &.icon-white {
+      background-image: url('./image/arrow-unsigned-white.svg');
+    }
+  }
+}

--- a/src/styles/element-info/interaction-info.css
+++ b/src/styles/element-info/interaction-info.css
@@ -29,6 +29,10 @@ textarea.interaction-info-description {
   }
 }
 
+.interaction-info-type-radio-indented {
+  margin-left: 1.25em;
+}
+
 .interaction-info-assoc-radio-label {
   display: block;
 }

--- a/src/styles/form-editor/form-editor.css
+++ b/src/styles/form-editor/form-editor.css
@@ -84,13 +84,16 @@
   }
 }
 
-.delete-interaction {
-
-}
-
 .form-options {
   margin: 0 0.5em;
-  width: 10em;
+}
+
+.form-verb-phrase {
+  width: 9em;
+}
+
+.form-post-phrase {
+  width: 17em;
 }
 
 .add-new-interaction-icon {

--- a/src/styles/image/arrow-negative-small-white.svg
+++ b/src/styles/image/arrow-negative-small-white.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M20,5.625 L18.172,5.625 L18.172,11 L4,11 L4,13 L18.172,13 L18.172,18.406 L20,18.39 L20,12 z" fill="#FFFFFF"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-negative-small.svg
+++ b/src/styles/image/arrow-negative-small.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M20,5.625 L18.172,5.625 L18.172,11 L4,11 L4,13 L18.172,13 L18.172,18.406 L20,18.39 L20,12 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-negative.svg
+++ b/src/styles/image/arrow-negative.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M20,4.078 L18.172,4.078 L18.172,11 L4,11 L4,13 L18.172,13 L18.172,20.016 L20,20 L20,12 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-positive-filled.svg
+++ b/src/styles/image/arrow-positive-filled.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M14.562,4 L14.625,11 L4,11 L4,13 L14.625,13 L14.562,20 L20,12 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-positive-long-filled-white.svg
+++ b/src/styles/image/arrow-positive-long-filled-white.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M14.793,4 L14.809,11 L1.207,11 L1.207,13 L14.809,13 L14.793,20 L22.793,12 z" fill="#FFFFFF"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-positive-long-filled.svg
+++ b/src/styles/image/arrow-positive-long-filled.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M14.793,4 L14.809,11 L1.207,11 L1.207,13 L14.809,13 L14.793,20 L22.793,12 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-positive-long.svg
+++ b/src/styles/image/arrow-positive-long.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M13.766,4 L12.356,5.41 L17.936,11 L2.531,11 L2.531,13 L17.936,13 L12.356,18.59 L13.766,20 L21.766,12 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-positive-small.svg
+++ b/src/styles/image/arrow-positive-small.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M13.438,5.469 L12.028,6.879 L16.17,11 L4,11 L4,13 L16.17,13 L12.028,17.059 L13.438,18.469 L20,12 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-positive.svg
+++ b/src/styles/image/arrow-positive.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M0 0h24v24H0z" fill="none"/><path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"/></svg>

--- a/src/styles/image/arrow-unsigned-white.svg
+++ b/src/styles/image/arrow-unsigned-white.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M20.016,11 L4,11 L4,13 L20,13 z" fill="#FFFFFF"/>
+  </g>
+</svg>

--- a/src/styles/image/arrow-unsigned.svg
+++ b/src/styles/image/arrow-unsigned.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0" y="0" width="24" height="24" viewBox="0, 0, 24, 24">
+  <g id="Layer_1">
+    <path d="M20.016,11 L4,11 L4,13 L20,13 z" fill="#000000"/>
+  </g>
+</svg>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,6 +3,7 @@
 /* app styles */
 @import "./animations.css";
 @import "./base.css";
+@import "./custom-icons.css";
 @import "./popover";
 @import "./react-tabs.css";
 @import "./init-app.css";

--- a/test/interaction.js
+++ b/test/interaction.js
@@ -5,6 +5,8 @@ let Syncher = require('../src/model/syncher');
 let ElementFactory = require('../src/model/element/factory');
 let Entity = require('../src/model/element/entity');
 let Interaction = require('../src/model/element/interaction');
+let { PARTICIPANT_TYPE, PARTICIPANT_TYPES } = require('../src/model/element/participant-type');
+let { INTERACTION_TYPES, INTERACTION_TYPE } = require('../src/model/element/interaction-type');
 let MockSocket = require('./mock/socket');
 let MockCache = require('./mock/cache');
 let TableUtil = require('./util/table');
@@ -556,10 +558,10 @@ describe('Interaction', function(){
       } );
     });
 
-    let isNotUnsigned = type => type.value !== Interaction.PARTICIPANT_TYPE.UNSIGNED.value;
+    let isNotUnsigned = type => type.value !== PARTICIPANT_TYPE.UNSIGNED.value;
 
-    Interaction.ASSOCIATIONS.forEach( intnType => {
-      Interaction.PARTICIPANT_TYPES.filter( isNotUnsigned ).forEach( pptType => {
+    INTERACTION_TYPES.forEach( intnType => {
+      PARTICIPANT_TYPES.filter( isNotUnsigned ).forEach( pptType => {
         it(`sets interaction type as ${intnType.value}:${pptType.value}`, function(){
           return Promise.resolve().then( () => {
             return intnC1.add( entC1 );
@@ -573,7 +575,7 @@ describe('Interaction', function(){
             return intnC1.complete();
           } ).then( () => {
             expect( intnC1.association().value ).to.equal( intnType.value );
-            expect( intnC1.association().isPositive() ).to.equal( pptType.value === Interaction.PARTICIPANT_TYPE.POSITIVE.value );
+            expect( intnC1.association().isPositive() ).to.equal( pptType.value === PARTICIPANT_TYPE.POSITIVE.value );
             expect( intnC1.association().getTarget() ).to.equal(entC1);
             expect( intnC1.association().getTarget().id() ).to.equal( entC1.id() );
           } );
@@ -588,13 +590,13 @@ describe('Interaction', function(){
       } ).then( () => {
         return intnC1.add( ent2C1 );
       } ).then( () => {
-        return intnC1.associate( Interaction.ASSOCIATION.TRANSCRIPTION_TRANSLATION );
+        return intnC1.associate( INTERACTION_TYPE.TRANSCRIPTION_TRANSLATION );
       } ).then( () => {
-        return intnC1.association().setParticipantAs( entC1, Interaction.PARTICIPANT_TYPE.POSITIVE );
+        return intnC1.association().setParticipantAs( entC1, PARTICIPANT_TYPE.POSITIVE );
       } ).then( () => {
         return intnC1.complete();
       } ).then( () => {
-        expect( intnC1.association().value ).to.equal( Interaction.ASSOCIATION.TRANSCRIPTION_TRANSLATION.value );
+        expect( intnC1.association().value ).to.equal( INTERACTION_TYPE.TRANSCRIPTION_TRANSLATION.value );
         expect( intnC1.association().isPositive() ).to.be.true;
         expect( intnC1.association().getTarget() ).to.equal(entC1);
         expect( intnC1.association().getTarget().id() ).to.equal( entC1.id() );


### PR DESCRIPTION
- Add custom icons for activation, inhibition, and unsigned arrowheads.
- Update the network context menu with the new arrowhead tools.
- Add more rotation CSS classes for icons.  The arrowhead buttons in the network toolbar use a slight angle.
- Add support for specifying the sign of an interaction in the network UI with three buttons in the toolbar -- one for each sign.
- Revise the interaction wizard:  The sign is chosen before the association.  The sign stage is optional, because the sign is preselected by the three buttons.  When selecting a sign that is incompatible with the current association, the default association (`Interaction` -- other) is set.
- Update edgehandles to v3.5.0.  This is necessary to use the `ghostEdgeParams` feature so that the ghost edge arrowhead matches the selected, edge-drawing button.  Enable snapping.
- Indent the subtypes of modification in the network UI.
- Model cleanup
  - Have a static `allowedParticipantTypes()` function on interaction types.  This allows for better lookup/matching -- before having an instance.
  - Remove `UNSIGNED_TARGET` participant type.  Funda wanted this type to have a specified target on unsigned interactions, but it's never been strictly necessary.  The source and target ordering for an unsigned interaction does not matter.
  - Remove unneeded `static` methods in the model.  Just `require()` the `PARTICIPANT_TYPE` etc. directly.  This was a TODO previously, but it wasn't prioritised.
  - Clean up `toString()` fields under `InteractionType`.  Only `verbPhrase` and `postPhrase` are necessary.
  - Correct the `toString()` outputs according to the specification document.  Some cases did not match the document, and some were broken (partially `undefined`).
  - Remove `setParticipantType()` comment under `Interaction`.  This function is not weird.  It's just setting participant type (sign) on top of a more general-case grouping feature in the model.  In an interaction, each participant may be assigned a group in order to flexibly classify the participants.
- Form cleanup
  - Remove manual specification of interaction association list.  This makes the `render()` more readable.
  - Correct dropdown widths to support full view of labels.
  - Make sure dropdown labels are in all lowercase to be formatted properly as a sentence.
  - When the user selects a new sign for an interaction, the interaction association is reset if the (sign, type) combination is not valid.