### PR TITLE
Improved shortcuts for the tool set

### DIFF
--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -41,15 +41,15 @@ class EditorButtons extends React.Component {
       );
 
       grs.push([
-        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add an entity', shortcut: 'e' }), [
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add an entity', shortcut: '1' }), [
           h('button.editor-button.plain-button', { onClick: () => controller.addElement().then( el => bus.emit('opentip', el) )  }, [
             h('i.material-icons', 'fiber_manual_record')
           ])
         ]),
 
-        PptTypeBtn(PARTICIPANT_TYPE.UNSIGNED, 'Draw an undirected interaction', 'd'),
-        PptTypeBtn(PARTICIPANT_TYPE.POSITIVE, 'Draw an activation interaction', 'd'),
-        PptTypeBtn(PARTICIPANT_TYPE.NEGATIVE, 'Draw an inhibition interaction', 'd')
+        PptTypeBtn(PARTICIPANT_TYPE.UNSIGNED, 'Draw an undirected interaction', '2'),
+        PptTypeBtn(PARTICIPANT_TYPE.POSITIVE, 'Draw an activation interaction', '3'),
+        PptTypeBtn(PARTICIPANT_TYPE.NEGATIVE, 'Draw an inhibition interaction', '4')
       ]);
     }
 

--- a/src/client/components/editor/cy/doc.js
+++ b/src/client/components/editor/cy/doc.js
@@ -502,8 +502,7 @@ function listenToDoc({ bus, cy, document, controller }){
   bus.on('addelementmouse', () => controller.addElement({ position: lastMousePos }).then( el => bus.emit('opentip', el) ));
   bus.on('addinteractionmouse', () => bus.emit('addinteraction', { position: lastMousePos }));
 
-  onKey('e', () => bus.emit('addelementmouse'));
-  onKey('i', () => bus.emit('addinteractionmouse'));
+  onKey('1', () => bus.emit('addelementmouse'));
   onKey('a', selectAll);
   onKey('n', selectNone);
   onKey('backspace', removeSelected);

--- a/src/client/components/editor/cy/edgehandles.js
+++ b/src/client/components/editor/cy/edgehandles.js
@@ -210,5 +210,7 @@ module.exports = function({ bus, cy, document, controller }){
     eh.start(el);
   });
 
-  on('d', () => bus.emit('drawtoggle'));
+  on('2', () => bus.emit('drawtoggle', null, PARTICIPANT_TYPE.UNSIGNED));
+  on('3', () => bus.emit('drawtoggle', null, PARTICIPANT_TYPE.POSITIVE));
+  on('4', () => bus.emit('drawtoggle', null, PARTICIPANT_TYPE.NEGATIVE));
 };

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -120,7 +120,7 @@ class Editor extends DataComponent {
 
     let bus = new EventEmitter();
 
-    bus.on('drawtoggle', toggle => this.toggleDrawMode(toggle));
+    bus.on('drawtoggle', (toggle, type) => this.toggleDrawMode(toggle, type));
     bus.on('addelement', data => this.addElement( data ));
     bus.on('remove', docEl => this.remove( docEl ));
 


### PR DESCRIPTION
- Each of the edge buttons now has a shortcut key.
- Each of the shortcut keys are numbers, in the same order as the buttons are displayed.  This way, the tool set acts as a visual queue of the shortcut keys.  This is probably easier to remember than particular letters.  (And `A` for activation would conflict with `A` for select all.)
- Because the shortcut keys (`1`, `2`, `3`, `4`) are on the left of the keyboard, it's easy to use your left hand to activate a tool and your right hand to use the tool with the mouse.
- When using the keyboard shortcut `1` to create an entity, the entity is added at the current mouse position rather than by the tool set button.