### PR TITLE
Made switcher in main menu more salient and solved overlap problem of form editor title 

### DIFF
--- a/src/client/components/editor-type-switcher.js
+++ b/src/client/components/editor-type-switcher.js
@@ -1,0 +1,29 @@
+const { Component } = require('react');
+const Tooltip = require('./popover/tooltip');
+const { Link } = require('react-router-dom');
+const h = require('react-hyperscript');
+
+class EditorTypeSwitcher extends Component {
+  constructor( props ){
+    super( props );
+  }
+
+  render(){
+    let { networkEditor, document } = this.props;
+
+    let id = document.id();
+    let secret = document.secret();
+    let description = networkEditor ? 'Form Editor' : 'Network Editor';
+    let url = `/${networkEditor ? 'form' : 'document'}/${id}/${secret}`;
+
+    return h(Tooltip, { description, tippy: { placement: 'bottom' } }, [
+      h('div.editor-type-switcher', [
+        h(Link, { to: url }, [
+          h('i.material-icons', 'swap_horiz')
+        ])
+      ])
+    ]);
+  }
+}
+
+module.exports = EditorTypeSwitcher;

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -22,6 +22,7 @@ const EditorButtons = require('./buttons');
 const MainMenu = require('../main-menu');
 const UndoRemove = require('./undo-remove');
 const { TaskView } = require('../tasks');
+const EditorTypeSwitcher = require('../editor-type-switcher');
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;
@@ -360,18 +361,19 @@ class Editor extends DataComponent {
     let { history } = this.props;
 
     let editorContent = this.data.initted ? [
-      h('div.editor-title', [
-        h('div.editor-title-content', [
+      h('div.editor-header', [
+        h('div.editor-header-content', [
           h('div.editor-title-name', document.name() || 'Unnamed document'),
           h('div.editor-title-info', [
             h('span', document.authorName() ? `${document.authorName()} et al., ` : ``),
             h('span', `${document.year()}`),
-            h('span', document.journalName() ? `, ${document.journalName()}` : ``)
-          ])
+            h('span', document.journalName() ? `, ${document.journalName()}` : ``),
+          ]),
+          h(EditorTypeSwitcher, { networkEditor: true, document })
         ])
       ]),
       h('div.editor-main-menu', [
-        h(MainMenu, { bus, document, history, networkEditor: true })
+        h(MainMenu, { bus, document, history })
       ]),
       h('div.editor-submit', [
         h(Popover, { tippy: { html: h(TaskView, { document, bus } ) } }, [

--- a/src/client/components/form-editor/index.js
+++ b/src/client/components/form-editor/index.js
@@ -11,6 +11,7 @@ const { makeCyEles, getCyLayoutOpts, tryPromise } = require('../../../util');
 const Tooltip = require('../popover/tooltip');
 const Popover = require('../popover/popover');
 const MainMenu = require('../main-menu');
+const EditorTypeSwitcher = require('../editor-type-switcher');
 const { TaskView } = require('../tasks');
 const InteractionForm = require('./interaction-form');
 const { PARTICIPANT_TYPE } = require('../../../model/element/participant-type');
@@ -275,8 +276,11 @@ class FormEditor extends DataComponent {
         ]),
         h('div.form-editor', [
           h('div.form-content', [
-            h('h3.form-editor-title',
-              doc.name() === '' ? 'Untitled document' : doc.name()),
+            h('div.form-header', [
+              h('h3.form-editor-title',
+                doc.name() === '' ? 'Untitled document' : doc.name()),
+              h(EditorTypeSwitcher, { networkEditor: false, document: doc })
+            ]),
             h('div.form-templates', (
               doc.interactions().map( (interaction) =>  h(IntnEntry, { interaction }))
             )),

--- a/src/client/components/main-menu.js
+++ b/src/client/components/main-menu.js
@@ -38,7 +38,7 @@ class MenuContent extends Component {
   }
 
   render(){
-    const { bus, document, history, emitter, networkEditor } = this.props;
+    const { bus, document, history, emitter } = this.props;
     const { selectedLinkouts, selectedMyFactoids } = this.state;
 
     const set = (props, children) => h('div.main-menu-set', props, children);

--- a/src/client/components/main-menu.js
+++ b/src/client/components/main-menu.js
@@ -55,17 +55,6 @@ class MenuContent extends Component {
       h('span', label)
     ]);
 
-    let editorSwitcher = ( document, networkEditor) => {
-      if( document == null ){ return null; }
-
-      let id = document.id();
-      let secret = document.secret();
-      let label = networkEditor ? 'Form Editor' : 'Network Editor';
-      let url = `/${networkEditor ? 'form' : 'document'}/${id}/${secret}`;
-
-      return item({ label, action: () => history.push(url) });
-    };
-
     let content;
 
     if( selectedLinkouts ){
@@ -89,8 +78,7 @@ class MenuContent extends Component {
         ]) : null,
         set({ key: 'nav' }, [
           item({ label: 'New factoid', action: () => history.push('/new') }),
-          item({ label: 'My factoids', action: () => this.selectMyFactoids(), actionCloses: false }),
-          editorSwitcher( document, networkEditor )
+          item({ label: 'My factoids', action: () => this.selectMyFactoids(), actionCloses: false })
         ])
       ]);
     }
@@ -109,6 +97,23 @@ class MainMenu extends Component {
   render(){
     let { emitter } = this;
     let { bus, document, history, title, networkEditor } = this.props;
+
+    let editorSwitcher = () => {
+      if( document == null ){ return null; }
+
+      let id = document.id();
+      let secret = document.secret();
+      let description = networkEditor ? 'Form Editor' : 'Network Editor';
+      let url = `/${networkEditor ? 'form' : 'document'}/${id}/${secret}`;
+
+      return h(Tooltip, { description, tippy: { placement: 'bottom' } }, [
+        h('div.main-menu-switcher', [
+          h(Link, { to: url }, [
+            h('i.material-icons', 'swap_horiz')
+          ])
+        ])
+      ]);
+    };
 
     return h('div.main-menu', [
       h(Popover, {
@@ -134,6 +139,8 @@ class MainMenu extends Component {
           ])
         ])
       ]),
+
+      editorSwitcher(),
 
       title ? h('h1.main-menu-title', title) : null
     ]);

--- a/src/client/components/main-menu.js
+++ b/src/client/components/main-menu.js
@@ -98,23 +98,6 @@ class MainMenu extends Component {
     let { emitter } = this;
     let { bus, document, history, title, networkEditor } = this.props;
 
-    let editorSwitcher = () => {
-      if( document == null ){ return null; }
-
-      let id = document.id();
-      let secret = document.secret();
-      let description = networkEditor ? 'Form Editor' : 'Network Editor';
-      let url = `/${networkEditor ? 'form' : 'document'}/${id}/${secret}`;
-
-      return h(Tooltip, { description, tippy: { placement: 'bottom' } }, [
-        h('div.main-menu-switcher', [
-          h(Link, { to: url }, [
-            h('i.material-icons', 'swap_horiz')
-          ])
-        ])
-      ]);
-    };
-
     return h('div.main-menu', [
       h(Popover, {
         hide: hideNow => emitter.on('close', hideNow),
@@ -139,8 +122,6 @@ class MainMenu extends Component {
           ])
         ])
       ]),
-
-      editorSwitcher(),
 
       title ? h('h1.main-menu-title', title) : null
     ]);

--- a/src/styles/editor-type-switcher.css
+++ b/src/styles/editor-type-switcher.css
@@ -1,0 +1,11 @@
+.editor-type-switcher {
+  font-size: 2.25em;
+  margin-right: 0.125em;
+  transition-property: filter;
+  transition-timing-function: ease-out;
+  transition-duration: 250ms;
+
+  &:active {
+    filter: brightness(50%);
+  }
+}

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -73,7 +73,7 @@
   font-size: 1.25em;
 }
 
-.editor-title {
+.editor-header {
   z-index: 1;
   position: absolute;
   top: 0;
@@ -82,7 +82,7 @@
   pointer-events: none;
 }
 
-.editor-title-content {
+.editor-header-content {
   display: inline-block;
   background: rgba(255, 255, 255, 0.5);
   padding: 0.375em 0.5em;

--- a/src/styles/editor/undo-remove.css
+++ b/src/styles/editor/undo-remove.css
@@ -1,6 +1,6 @@
 .editor-undo-rm {
   position: absolute;
-  top: 2.5em;
+  top: 3.7em;
   left: 50%;
   transform: translate(-50%, 0);
   text-align: center;

--- a/src/styles/form-editor/form-editor.css
+++ b/src/styles/form-editor/form-editor.css
@@ -167,3 +167,9 @@
   display: flex;
   flex-direction: row;
 }
+
+.form-content {
+  width: 60%;
+  position: fixed;
+  left: 20%;
+}

--- a/src/styles/form-editor/form-editor.css
+++ b/src/styles/form-editor/form-editor.css
@@ -39,8 +39,13 @@
   flex-direction: column;
 }
 
-.form-editor-title {
+.form-header {
   margin-bottom: 2em;
+  display: flex;
+  align-items: center;
+}
+
+.form-editor-title {
   overflow: hidden;
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -30,3 +30,4 @@
 @import "./main-menu.css";
 @import "./reach-interval-highlighter.css";
 @import "./copy-field.css";
+@import "./editor-type-switcher.css";

--- a/src/styles/main-menu.css
+++ b/src/styles/main-menu.css
@@ -43,8 +43,7 @@
   }
 }
 
-.main-menu-logo,
-.main-menu-switcher {
+.main-menu-logo {
   font-size: 2.25em;
   margin-right: 0.125em;
   transition-property: filter;

--- a/src/styles/main-menu.css
+++ b/src/styles/main-menu.css
@@ -43,7 +43,8 @@
   }
 }
 
-.main-menu-logo, .main-menu-switcher {
+.main-menu-logo,
+.main-menu-switcher {
   font-size: 2.25em;
   margin-right: 0.125em;
   transition-property: filter;

--- a/src/styles/main-menu.css
+++ b/src/styles/main-menu.css
@@ -43,7 +43,7 @@
   }
 }
 
-.main-menu-logo {
+.main-menu-logo, .main-menu-switcher {
   font-size: 2.25em;
   margin-right: 0.125em;
   transition-property: filter;


### PR DESCRIPTION
The followings are how the main menu looks like in network and form editors when the mouse is over the switcher:

<img width="1438" alt="screen shot 2018-12-31 at 1 46 35 pm" src="https://user-images.githubusercontent.com/6534865/50568137-90167f80-0d02-11e9-8b63-2e5feb60aa74.png">

<img width="1433" alt="screen shot 2018-12-31 at 1 46 12 pm" src="https://user-images.githubusercontent.com/6534865/50568138-90167f80-0d02-11e9-89a1-766ce4d4ced3.png">
