### PR TITLE
REACH JSON importer 

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -252,4 +252,9 @@ http.get('/text/:id', function( req, res ){
     .then( txt => res.send( txt ));
 });
 
+// create new doc
+http.post('/elements', function( req, res ){
+  provider.get( req.body.text ).then( reachOut => res.json( reachOut ) );
+});
+
 module.exports = http;

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -252,9 +252,4 @@ http.get('/text/:id', function( req, res ){
     .then( txt => res.send( txt ));
 });
 
-// create new doc
-http.post('/elements', function( req, res ){
-  provider.get( req.body.text ).then( reachOut => res.json( reachOut ) );
-});
-
 module.exports = http;

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -321,7 +321,7 @@ module.exports = {
         const entryFromEl = el => el == null ? null : ({ id: el.id });
         const getEntryByEntity = ( entity, subtype ) => {
           const el = elementsReachMap.get( getReachId( entity.record ) );
-          const entry = entryFromEl( el );console.log(`subtype: ${subtype}`);
+          const entry = entryFromEl( el );
           if( subtype && isTargetArgType( entity.type ) ) entry.group = getTargetSign( subtype ).value;
           return entry;
         };
@@ -350,24 +350,12 @@ module.exports = {
           association: getMechanism( frame ).value
         };
 
-        let entities, subtype;
+        if( frame.type === REACH_EVENT_TYPE.REGULATION || frame.type === REACH_EVENT_TYPE.ACTIVATION || frame.type === REACH_EVENT_TYPE.COMPLEX_ASSEMBLY ){
 
-        if( frame.type === REACH_EVENT_TYPE.REGULATION || frame.type === REACH_EVENT_TYPE.ACTIVATION ){
-
-          const controllerEntities = getArgEntities( argByType( frame, 'controller' ) );
-          const controlledEntities = getArgEntities( argByType( frame, 'controlled' ) );
-          entities = _.concat( controllerEntities, controlledEntities );
-          subtype = frame.subtype;
-
-        } else if( frame.type === REACH_EVENT_TYPE.COMPLEX_ASSEMBLY ) {
-          entities =  _.flatten( frame.arguments.map( getArgEntities ) );
-          subtype = null;
-        }
-
-        intn.entries = entities.map( entity => getEntryByEntity( entity, subtype ) ).filter( e => e != null );
-        intn.completed = true;
-
-        if( intn.completed ){
+          intn.entries =  _.flatten( frame.arguments.map( getArgEntities ) )
+            .map( entity => getEntryByEntity( entity, frame.subtype ) )
+            .filter( e => e != null );
+          intn.completed = true;
           addElement( intn, frame );
         }
       }); // END evtFrames.forEach

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -275,6 +275,7 @@ module.exports = {
         const frameIsControlType = frame => frame.type === REACH_EVENT_TYPE.REGULATION || frame.type === REACH_EVENT_TYPE.ACTIVATION;
         const argIsComplex = arg => arg['argument-type'] === 'complex';
         const argIsEntity = arg => arg['argument-type'] === 'entity';
+        const argIsEvent = arg => arg['argument-type'] === 'event';
         const argByType = ( frame, type ) => frame.arguments.find( arg => arg.type === type  );
         const getArgId = arg => arg.arg;
         const getArgIds = arg => _.values( arg.args );
@@ -300,10 +301,10 @@ module.exports = {
             return getArgIds( arg ).map( themeId => entityTemplate( { arg: themeId }, argType ) );
 
           }
-          else { // must be event
-            if( argType == 'controller' ) return null; //dunno what to do here
-            return getEventArgEntities( arg );
+          else if ( argIsEvent( arg ) ) {
+            return argType === 'controlled' ? getEventArgEntities( arg ): null;
           }
+          return null;
         };
 
         const targetArgTypes = new Set([ 'theme', 'controlled' ]);

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -320,9 +320,10 @@ module.exports = {
 
         const entryFromEl = el => el == null ? null : ({ id: el.id });
         const getEntryByEntity = ( entity, subtype ) => {
+
           const el = elementsReachMap.get( getReachId( entity.record ) );
           const entry = entryFromEl( el );
-          if( subtype && isTargetArgType( entity.type ) ) entry.group = getTargetSign( subtype ).value;
+          if( entry && subtype && isTargetArgType( entity.type ) ) entry.group = getTargetSign( subtype ).value;
           return entry;
         };
 

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -79,7 +79,7 @@ const REACH_TO_FACTOID_MECHANISM = new Map([
   [ REACH_EVENT_TYPE.HYDROLYSIS, INTERACTION_TYPE.MODIFICATION ],
   [ REACH_EVENT_TYPE.DEHYDROLYSIS, INTERACTION_TYPE.MODIFICATION ],
   [ REACH_EVENT_TYPE.TRANSLOCATION, INTERACTION_TYPE.INTERACTION ],
-  [ REACH_EVENT_TYPE.AMOUNT, INTERACTION_TYPE.AMOUNT ],
+  [ REACH_EVENT_TYPE.AMOUNT, INTERACTION_TYPE.INTERACTION ],
   [ REACH_EVENT_TYPE.PROTEIN_MODIFICATION, INTERACTION_TYPE.MODIFICATION ],
   [ REACH_EVENT_TYPE.TRANSCRIPTION, INTERACTION_TYPE.TRANSCRIPTION_TRANSLATION ],
   [ REACH_EVENT_TYPE.COMPLEX_ASSEMBLY, INTERACTION_TYPE.BINDING ],
@@ -331,7 +331,6 @@ module.exports = {
         const getMechanism = frame => {
           let reachMech;
           if( frame.type === REACH_EVENT_TYPE.REGULATION ){
-            // Beware of nested ?
             const controlledFrame = getFrame( getArgId( argByType( frame, 'controlled' ) ) );
             reachMech = controlledFrame.type === REACH_EVENT_TYPE.REGULATION ? REACH_EVENT_TYPE.REGULATION : getSimpleMechanism( controlledFrame );
 
@@ -356,7 +355,8 @@ module.exports = {
             .map( entity => getEntryByEntity( entity, frame.subtype ) )
             .filter( e => e != null );
 
-          intn.association = getMechanism( frame ).value;
+          const mechanism =  getMechanism( frame );
+          intn.association = mechanism.value;
           intn.completed = true;
           addElement( intn, frame );
         }

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -220,6 +220,7 @@ module.exports = {
         let supportedTypes = {
           'protein': 'protein',
           'gene': 'protein',
+          'gene-or-gene-product': 'protein',
           'simple-chemical': 'chemical'
         };
 
@@ -294,7 +295,7 @@ module.exports = {
         // How to handle nested? Traverse once to fetch either the Simple event theme or the Nested event controller
         const getArgEntities = arg => {
           if ( argIsEntity( arg ) ) {
-            return entityTemplate ( arg );
+            return entityTemplate ( arg, arg.type );
 
           } else if ( argIsComplex( arg ) ) {
             return getArgIds( arg ).map( themeId => entityTemplate( { arg: themeId }, arg.type ) );
@@ -352,7 +353,9 @@ module.exports = {
         if( frameIsControlType( frame ) || frame.type === REACH_EVENT_TYPE.COMPLEX_ASSEMBLY ){
 
           intn.entries =  _.flatten( frame.arguments.map( getArgEntities ) )
+            // .map( entity => { console.log(`entity: ${entity.record.text} (${entity.type})`); return entity; } )
             .map( entity => getEntryByEntity( entity, frame.subtype ) )
+            // .map( entry => { console.log(`entry: ${JSON.stringify(entry, null, 2)}`); return entry; } )
             .filter( e => e != null );
 
           const mechanism =  getMechanism( frame );
@@ -366,7 +369,8 @@ module.exports = {
 
       if( ONLY_BINARY_INTERACTIONS ) {
         const binaryInts = elements.filter( elIsIntn )
-          .filter( int => ( _.uniqBy( int.entries, 'id' ) ).length === 2 );
+          .filter( int => int.entries.length === 2 ) // must be two entries
+          .filter( int => ( _.uniqBy( int.entries, 'id' ) ).length === 2 ); // those two must be unique
         const entities = elements.filter( e => !elIsIntn( e ) );
         elements = _.concat( entities, binaryInts );
       }

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -126,12 +126,6 @@ module.exports = {
       let getFrame = id => framesMap.get( id );
       let getReachId = frame => frame['frame-id'];
       let addFrame = frame => framesMap.set( getReachId(frame), frame );
-      const frameIsControlType = frame => frame.type === REACH_EVENT_TYPE.REGULATION || frame.type === REACH_EVENT_TYPE.ACTIVATION;
-      const argIsEvent = arg => arg['argument-type'] === 'event';
-      const argIsComplex = arg => arg['argument-type'] === 'complex';
-      const argIsEntity = arg => arg['argument-type'] === 'entity';
-      const getArgId = arg => arg.arg;
-      const getArgIds = arg => _.values( arg.args );
       let groundIsSame = (g1, g2) => g1.namespace === g2.namespace && g1.id === g2.id;
       let elIsIntn = el => el.entries != null;
       let contains = ( arr, str ) => arr.indexOf( str.toLowerCase() ) >= 0;
@@ -279,7 +273,13 @@ module.exports = {
       // add interactions
       evtFrames.forEach( frame => {
 
+        const frameIsControlType = frame => frame.type === REACH_EVENT_TYPE.REGULATION || frame.type === REACH_EVENT_TYPE.ACTIVATION;
+        const argIsEvent = arg => arg['argument-type'] === 'event';
+        const argIsComplex = arg => arg['argument-type'] === 'complex';
+        const argIsEntity = arg => arg['argument-type'] === 'entity';
         const argByType = ( frame, type ) => frame.arguments.find( arg => arg.type === type  );
+        const getArgId = arg => arg.arg;
+        const getArgIds = arg => _.values( arg.args );
         const entityTemplate = ( arg, type ) => ({ type, record: getFrame( getArgId( arg ) ) });
 
         // Record the frame arguments.arg.type ('theme', 'site')
@@ -353,9 +353,7 @@ module.exports = {
         if( frameIsControlType( frame ) || frame.type === REACH_EVENT_TYPE.COMPLEX_ASSEMBLY ){
 
           intn.entries =  _.flatten( frame.arguments.map( getArgEntities ) )
-            // .map( entity => { console.log(`entity: ${entity.record.text} (${entity.type})`); return entity; } )
             .map( entity => getEntryByEntity( entity, frame.subtype ) )
-            // .map( entry => { console.log(`entry: ${JSON.stringify(entry, null, 2)}`); return entry; } )
             .filter( e => e != null );
 
           const mechanism =  getMechanism( frame );
@@ -364,8 +362,6 @@ module.exports = {
           addElement( intn, frame );
         }
       }); // END evtFrames.forEach
-
-      // filter 'duplicate' interactions based upon equal { entries, association }
 
       if( ONLY_BINARY_INTERACTIONS ) {
         const binaryInts = elements.filter( elIsIntn )

--- a/src/server/routes/api/document/reach.js
+++ b/src/server/routes/api/document/reach.js
@@ -341,12 +341,7 @@ module.exports = {
           } else {
             reachMech = getSimpleMechanism( frame );
           }
-          let out =  REACH_TO_FACTOID_MECHANISM.get( reachMech );
-          if( !out ) {
-            console.log(`getMechanism !out - frame: ${JSON.stringify(frame, null, 2)}`);
-            console.log(`getMechanism !out - reachMech: ${JSON.stringify(reachMech, null, 2)}`);
-          }
-          return out;
+          return REACH_TO_FACTOID_MECHANISM.get( reachMech );
         };
 
         const intn = {
@@ -362,7 +357,6 @@ module.exports = {
             .filter( e => e != null );
 
           intn.association = getMechanism( frame ).value;
-          intn.frameType = frame.type;
           intn.completed = true;
           addElement( intn, frame );
         }
@@ -370,11 +364,12 @@ module.exports = {
 
       // filter 'duplicate' interactions based upon equal { entries, association }
 
-      // if( ONLY_BINARY_INTERACTIONS ) {
-      //   const binaryInts = elements.filter( elIsIntn ).filter( int => int.entries.length === 2 );
-      //   const entities = elements.filter( e => !elIsIntn( e ) );
-      //   elements = _.concat( entities, binaryInts );
-      // }
+      if( ONLY_BINARY_INTERACTIONS ) {
+        const binaryInts = elements.filter( elIsIntn )
+          .filter( int => ( _.uniqBy( int.entries, 'id' ) ).length === 2 );
+        const entities = elements.filter( e => !elIsIntn( e ) );
+        elements = _.concat( entities, binaryInts );
+      }
 
       if( REMOVE_DISCONNECTED_ENTS ){
         let interactions = elements.filter( elIsIntn );


### PR DESCRIPTION
Notable updates:

- Captures 'regulation', 'activation' (i.e. control type) and 'complex-assembly' events
- Explicitly maps to Factoid interaction types for 'binding', 'transcription-translation' and protein modifications; everything else (e.g. 'amount') gets binned into 'other'   
  - Added 'autophosphorylation' 
- Allows nested control type events where controlled is itself a control
- Accommodates event argument frames that include reference to modification feature 'site' (e.g. 'p53 phosphorylated on serine-15') 
- Captures complexes as either controllers and complex-assembly as controlled
- Filters out: complexes as controller/controlled; self-loops; events as controllers

Refs #388. Please refer to Google docs for 'REACH Output' for design considerations.