### PR TITLE
One interaction, one edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2598,9 +2598,9 @@
       "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "cytoscape": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.2.8.tgz",
-      "integrity": "sha1-TOM/5I4v6UhNtdnDUxyxzPeTgMU=",
+      "version": "3.2.22",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.2.22.tgz",
+      "integrity": "sha512-0eHGQWuE6UTTZ0T3L/p1gYBfAkq/+PAFJWq79PL2qDexPSLnbYi6JivSid31TLIRwxe29MW6TPqZZ6ynMXPK8A==",
       "requires": {
         "heap": "^0.2.6",
         "lodash.debounce": "^4.0.8"
@@ -4833,7 +4833,7 @@
     },
     "got": {
       "version": "6.7.1",
-      "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
       "dev": true,
       "requires": {
@@ -10076,7 +10076,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "body-parser": "^1.15.1",
     "clipboard": "^1.7.1",
     "cookie-parser": "^1.4.3",
-    "cytoscape": "^3.2.7",
+    "cytoscape": "^3.2.22",
     "cytoscape-automove": "^1.9.0",
     "cytoscape-cose-bilkent": "^1.6.10",
     "cytoscape-cxtmenu": "^2.10.3",

--- a/src/client/components/editor/cy/cxtmenu.js
+++ b/src/client/components/editor/cy/cxtmenu.js
@@ -57,11 +57,6 @@ module.exports = function({ cy, document, bus }){
   };
 
   cy.cxtmenu( _.assign( {}, DEFAULTS, {
-    selector: 'node[?isInteraction]',
-    commands: [ drawUnsignedCmd, drawPositiveCmd, drawNegativeCmd, rmElCmd ]
-  } ) );
-
-  cy.cxtmenu( _.assign( {}, DEFAULTS, {
     selector: 'node[?isEntity]',
     commands: [ drawUnsignedCmd, drawPositiveCmd, drawNegativeCmd, rmElCmd ]
   } ) );

--- a/src/client/components/editor/cy/stylesheet.js
+++ b/src/client/components/editor/cy/stylesheet.js
@@ -55,33 +55,35 @@ function makeStylesheet(){
         'curve-style': 'bezier',
         'line-color': defaultColor,
         'target-arrow-color': defaultColor,
-        'source-arrow-color': defaultColor,
-        'source-endpoint': 'inside-to-node',
-        'target-endpoint': 'outside-to-node'
+        'source-arrow-color': defaultColor
       }
     },
     {
-      selector: 'node -> node[?isInteraction]',
+      selector: 'edge[sign="positive"]',
       style: {
-        'target-endpoint': 'inside-to-node'
-      }
-    },
-    {
-      selector: 'node[?isInteraction] -> node',
-      style: {
-        'source-endpoint': 'inside-to-node'
-      }
-    },
-    {
-      selector: 'edge[type="positive"]',
-      style: {
+        'source-arrow-shape': 'none',
         'target-arrow-shape': 'triangle'
       }
     },
     {
-      selector: 'edge[type="negative"]',
+      selector: 'edge[sign="negative"]',
       style: {
+        'source-arrow-shape': 'none',
         'target-arrow-shape': 'tee'
+      }
+    },
+    {
+      selector: 'edge[sign="positive"][?reversed]',
+      style: {
+        'source-arrow-shape': 'triangle',
+        'target-arrow-shape': 'none'
+      }
+    },
+    {
+      selector: 'edge[sign="negative"][?reversed]',
+      style: {
+        'source-arrow-shape': 'tee',
+        'target-arrow-shape': 'none'
       }
     },
     {
@@ -89,6 +91,7 @@ function makeStylesheet(){
       style: {
         'line-color': activeColor,
         'target-arrow-color': activeColor,
+        'source-arrow-color': activeColor,
         'z-index': 999,
         'z-compound-depth': 'top'
       }

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -1,7 +1,7 @@
 const DataComponent = require('../data-component');
 const h = require('react-hyperscript');
 const ReactDom = require('react-dom');
-const { isInteractionNode, initCache, SingleValueCache, error } = require('../../../util');
+const { initCache, SingleValueCache, error } = require('../../../util');
 const _ = require('lodash');
 const defs = require('../../defs');
 const { animateDomForEdit } = require('../animate');
@@ -29,10 +29,6 @@ class InteractionInfo extends DataComponent {
 
     let p = this.props;
     let el = p.element;
-    let doc = p.document;
-    let evtTgt = p.eventTarget;
-    let pptNode = evtTgt.connectedNodes().filter( el => !isInteractionNode(el) );
-    let ppt = doc.get( pptNode.id() );
 
     let progression = new Progression({
       STAGES: ['PARTICIPANT_TYPES', 'ASSOCIATE', 'COMPLETED'],
@@ -53,7 +49,6 @@ class InteractionInfo extends DataComponent {
       el,
       stage,
       description: p.element.description(),
-      ppt: ppt,
       progression,
       bus: p.bus || new EventEmitter(),
       assocNotification,

--- a/src/util/cy.js
+++ b/src/util/cy.js
@@ -37,33 +37,33 @@ function makeCyElesForEle( docEl ){
       name: docEl.name(),
       type: docEl.type(),
       isEntity: docEl.isEntity(),
-      isInteraction: docEl.isInteraction(),
-      associated: docEl.isEntity() ? docEl.associated() : undefined,
-      completed: docEl.isEntity() ? docEl.completed() : undefined
-    },
-    position: _.clone( docEl.position() )
+      isInteraction: docEl.isInteraction()
+    }
   };
 
-  els.push( el );
-
-  if( docEl.isInteraction() ){ // add edges connecting participants to interaction node
-    let edges = makePptEdges( docEl );
-
-    els.push( ...edges );
+  if( docEl.isEntity() ){
+    el.position = _.clone( docEl.position() );
+    el.data.associated = docEl.associated();
+    el.data.completed = docEl.completed();
   }
 
-  return els;
-}
+  if( docEl.isInteraction() ){
+    let ppts = docEl.participants();
+    let assoc = docEl.association();
+    let src = assoc.getSource();
+    let tgt = assoc.getTarget();
 
-function makePptEdges( docIntn, docPpt ){
-  let els = [];
-  let ppts = docPpt ? [ docPpt ] : docIntn.participants();
+    if( !src || !tgt ){
+      src = ppts[0];
+      tgt = ppts[1];
+    }
 
-  ppts.forEach( ppt => {
-    els.push({
-      data: { source: docIntn.id(), target: ppt.id(), type: docIntn.participantType( ppt ).value }
-    });
-  } );
+    el.data.source = src.id();
+    el.data.target = tgt.id();
+    el.data.sign = assoc.getSign().value;
+  }
+
+  els.push( el );
 
   return els;
 }
@@ -80,4 +80,4 @@ function isInteractionNode( el ){
   return el.data('isInteraction') === true;
 }
 
-module.exports = { makeCyEles, makePptEdges, regCyExts, regCyLayouts, getCyLayoutOpts, isInteractionNode };
+module.exports = { makeCyEles, regCyExts, regCyLayouts, getCyLayoutOpts, isInteractionNode };


### PR DESCRIPTION
- Interaction lines used to be in two parts, with two underlying edges and a hidden middle node.  An interaction is just one edge now.
- Allows display of multiple interactions between a pair of entities via bundled beziers.
- Update to cytoscape@3.2.22