### PR TITLE
Disable the participant arrow ui in the interaction wizard #456

### DIFF
--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -66,7 +66,7 @@ class InteractionInfo extends DataComponent {
 
     switch( stage ){
       case STAGES.PARTICIPANT_TYPES:
-        return true;
+        return false; // disable this phase for now, maybe delete all related code eventually
       case STAGES.ASSOCIATE:
         return true;
       case STAGES.COMPLETED:


### PR DESCRIPTION
Ref : Remove back button on interaction wizard #456

Minimal code change for now:  This just disables it for now in case we decide to change things again in future.  Eventually, we could delete all the related code.