### PR TITLE
Create tables in sequential order.

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -111,7 +111,8 @@ tryPromise( () => {
     ;
   };
 
-  return Promise.all( ['element', 'document'].map( setup ) );
+  const tables = ['element', 'document'];
+  return tables.reduce( ( p, name ) => p.then( () => setup( name ) ), Promise.resolve() );
 } ).then( () => {
   server.listen(port);
 } );


### PR DESCRIPTION
I think this may resolve the weird error regarding adding a database when it already exists in a fresh install.

Refs #452 and #481.