### PR TITLE
Make it easier to delete

### DIFF
--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -51,6 +51,14 @@ class EditorButtons extends React.Component {
         PptTypeBtn(PARTICIPANT_TYPE.POSITIVE, 'Draw an activation interaction', '3'),
         PptTypeBtn(PARTICIPANT_TYPE.NEGATIVE, 'Draw an inhibition interaction', '4')
       ]);
+
+      grs.push([
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Delete selected', shortcut: 'Delete' }), [
+          h('button.editor-button.plain-button', { onClick: () => controller.removeSelected()  }, [
+            h('i.material-icons', 'delete')
+          ])
+        ])
+      ]);
     }
 
     return h(`div.${className}`, grs.map( btns => h('div.editor-button-group', btns) ));

--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -55,7 +55,7 @@ class EditorButtons extends React.Component {
       grs.push([
         h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Delete selected', shortcut: 'Delete' }), [
           h('button.editor-button.plain-button', { onClick: () => controller.removeSelected()  }, [
-            h('i.material-icons', 'delete')
+            h('i.material-icons', 'clear')
           ])
         ])
       ]);

--- a/src/client/components/editor/cy/tippy.js
+++ b/src/client/components/editor/cy/tippy.js
@@ -190,6 +190,7 @@ export default function({ bus, cy, document }){
   };
 
   let hideTippy = (ele, list = '_tippies') => {
+    let isSelected = ele.selected();
     let tippies = ele.scratch(list);
     let didClose = false;
 
@@ -207,6 +208,13 @@ export default function({ bus, cy, document }){
       if( docEl && !docEl.completed() ){
         makeIncompleteNotification( ele, docEl );
       }
+    }
+
+    // keep the node or edge selected when you just close the tippy popover
+    if( didClose && isSelected ){
+      setTimeout(() => { // on next tick
+        ele.select();
+      }, 0);
     }
   };
 


### PR DESCRIPTION
- Adds a delete button  #520 
- Revises selection s.t. closing an element's popover does not deselect the element  #519

Demo of deleting after clicking the background using the delete key, followed by deleting by the delete button:

![beam3](https://user-images.githubusercontent.com/989043/61317215-8e109b80-a7d0-11e9-8a00-2e4fb8f0ce7f.gif)
