### PR TITLE
Revise .travis.yml to use addon rethink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
-dist: trusty
 language: node_js
 node_js:
   - "8"
-  - "stable"
+  - "10"
+addons:
+  rethinkdb: '2.3.4'
 script: npm run test:travis
-sudo: required
-before_install:
-  - sudo apt-get -qq update
-  - source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
-  - wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
-  - sudo apt-get update
-  - sudo apt-get install rethinkdb
-  - rethinkdb &

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
   - "10"
 addons:
   rethinkdb: '2.3.6'
+before_script:
+  - sleep 15
 script: npm run test:travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - "8"
   - "10"
 addons:
-  rethinkdb: '2.3.4'
+  rethinkdb: '2.3.6'
 script: npm run test:travis

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "fix": "run-s fix:*",
     "watch": "run-p watch:*",
     "test": "mocha -r esm",
-    "test:travis": "run-s ci",
+    "test:travis": "run-s lint",
     "ci": "run-s test lint"
   },
   "dependencies": {


### PR DESCRIPTION
Previously, we used a manual install of rethink on travis.  That no longer works.

Ref : Travis builds are broken #530