### PR TITLE
Automatic grounding of entities (initial version)

### DIFF
--- a/src/client/components/editor/buttons.js
+++ b/src/client/components/editor/buttons.js
@@ -41,7 +41,7 @@ class EditorButtons extends React.Component {
       );
 
       grs.push([
-        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add an entity', shortcut: '1' }), [
+        h(Tooltip, _.assign({}, baseTooltipProps, { description: 'Add a gene or chemical', shortcut: '1' }), [
           h('button.editor-button.plain-button', { onClick: () => controller.addElement().then( el => bus.emit('opentip', el) )  }, [
             h('i.material-icons', 'fiber_manual_record')
           ])

--- a/src/client/components/editor/cy/compound-dnd.js
+++ b/src/client/components/editor/cy/compound-dnd.js
@@ -1,6 +1,6 @@
-import { tryPromise } from '../../../../util';
+import { tryPromise, delay } from '../../../../util';
 
-export default function({ cy, document, controller }){
+export default function({ cy, document, controller, bus }){
     if( !document.editable() ){ return; }
     cy.compoundDragAndDrop();
     let lastOldParent = null;
@@ -73,12 +73,19 @@ export default function({ cy, document, controller }){
           return updateParent( docDropSibling );
         };
 
+        const openTippy = () => delay(50).then(() => {
+          if( newParent ){
+            bus.emit('opentip', docNewParent);
+          }
+        });
+
         return (
             tryPromise( startBatch )
                 .then( handleNewComplex )
                 .then( updateSelfParent )
                 .then( updateSiblingParent )
                 .then( endBatch )
+                .then( openTippy )
         );
     } );
 }

--- a/src/client/components/editor/cy/doc.js
+++ b/src/client/components/editor/cy/doc.js
@@ -588,19 +588,6 @@ function listenToDoc({ bus, cy, document, controller }){
 
   cy.on('taphold', onTapHold);
 
-  cy.on('tap', 'node, edge', _.debounce( e => {
-    let tgt = e.target;
-
-    if( tgt.isNode() && isInteractionNode(tgt) ){
-      tgt.connectedEdges().select();
-    } else if( tgt.isEdge() ){
-      let intnNode = tgt.connectedNodes( isInteractionNode );
-
-      intnNode.connectedEdges().select();
-      intnNode.select();
-    }
-  }, 10 ));
-
   cy.on('add', 'edge', e => {
     let edge = e.target;
 

--- a/src/client/components/editor/cy/stylesheet.js
+++ b/src/client/components/editor/cy/stylesheet.js
@@ -32,7 +32,10 @@ function makeStylesheet(){
       selector: 'node:parent',
       style: {
         'background-opacity': 0.5,
-        'background-color': '#FFFFFF'
+        'background-color': '#FFFFFF',
+        'text-outline-opacity': 0,
+        'color': defaultColor,
+        'text-valign': 'top'
       }
     },
     {

--- a/src/client/components/editor/cy/tippy.js
+++ b/src/client/components/editor/cy/tippy.js
@@ -259,7 +259,7 @@ export default function({ bus, cy, document }){
   let makeTippy = ({ el, ref, content, overrides, sublist }) => {
     let tippy = tippyjs( ref, _.assign( {}, tippyDefaults, {
       duration: 0,
-      placement: isSmallScreen() ? 'bottom' : 'right',
+      placement: 'bottom',
       hideOnClick: false,
       sticky: true,
       livePlacement: true,

--- a/src/client/components/editor/cy/tippy.js
+++ b/src/client/components/editor/cy/tippy.js
@@ -296,7 +296,7 @@ export default function({ bus, cy, document }){
 
         let edgesBb = el.add(el.connectedNodes()).renderedBoundingBox();
 
-        let intnTippyAway = true; // always shift
+        let intnTippyAway = false; // disable shifting, since we're currently not using arrow editing
 
         let getIntnTippyBb = () => {
           let bb = el.isNode () ? el.renderedBoundingBox({ includeLabels: false, includeOverlays: false }) : {
@@ -343,7 +343,7 @@ export default function({ bus, cy, document }){
 
           // cause tippy to animate a distance away
           setTimeout(() => {
-            intnTippyAway = true;
+            intnTippyAway = false; // we're not currently using arrow editing
           }, 1);
         } else {
           ppts.forEach( ppt => {

--- a/src/client/components/editor/cy/tippy.js
+++ b/src/client/components/editor/cy/tippy.js
@@ -11,7 +11,9 @@ export default function({ bus, cy, document }){
   let isSmallScreen = () => window.innerWidth <= 650;
 
   let hideAllTippies = (list = '_tippies') => {
-    cy.elements().forEach( el => hideTippy(el, list) );
+    const event = null;
+
+    cy.elements().forEach( el => hideTippy(el, event, list) );
   };
 
   bus.on('closetip', function( el ){
@@ -48,7 +50,7 @@ export default function({ bus, cy, document }){
       let id = el.id();
       let ele = cy.getElementById( id );
 
-      hideTippy( ele, '_pptTippies' );
+      hideTippy( ele, null, '_pptTippies' );
     } else {
       hideAllTippies('_pptTippies');
     }
@@ -121,7 +123,9 @@ export default function({ bus, cy, document }){
     }
   };
 
-  let hideTippy = (ele, list = '_tippies') => {
+  const defaultTippyList = '_tippies';
+
+  let hideTippy = (ele, event, list = defaultTippyList) => {
     let isSelected = ele.selected();
     let tippies = ele.scratch(list);
     let didClose = false;
@@ -135,7 +139,7 @@ export default function({ bus, cy, document }){
     }
 
     // keep the node or edge selected when you just close the tippy popover
-    if( didClose && isSelected ){
+    if( didClose && isSelected && event != null && event.type === 'tap' && event.target === cy ){
       setTimeout(() => { // on next tick
         ele.select();
       }, 0);
@@ -222,7 +226,7 @@ export default function({ bus, cy, document }){
     return div;
   };
 
-  let toggleElementInfoFor = ( el, opts ) => {
+  let toggleElementInfoFor = ( el, opts = {} ) => {
     let { toggleOn, togglePpts } = _.assign( {
       toggleOn: undefined,
       togglePpts: false
@@ -230,6 +234,8 @@ export default function({ bus, cy, document }){
 
     let pan = cy.pan();
     let zoom = cy.zoom();
+
+    let event = opts.event;
 
     let modelToRenderedPt = p => {
       return {
@@ -252,9 +258,9 @@ export default function({ bus, cy, document }){
 
     if( !toggleOn ){
       if( togglePpts ){
-        hideTippy( el, '_pptTippies' );
+        hideTippy( el, event, '_pptTippies' );
       } else {
-        hideTippy( el );
+        hideTippy( el, event );
       }
     } else {
       if( !togglePpts ){
@@ -401,6 +407,6 @@ export default function({ bus, cy, document }){
       return;
     }
 
-    toggleElementInfoFor( e.target );
+    toggleElementInfoFor( e.target, { event: e } );
   });
 }

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -9,8 +9,6 @@ import { getId, defer, makeClassList, tryPromise } from '../../../util';
 import Document from '../../../model/document';
 import { PARTICIPANT_TYPE } from '../../../model/element/participant-type';
 
-import Notification from '../notification';
-import CornerNotification from '../notification/corner';
 import Popover from '../popover/popover';
 
 import logger from '../../logger';
@@ -179,27 +177,6 @@ class Editor extends DataComponent {
         });
 
         logger.info('Initialised Cytoscape on mounted editor');
-      } )
-      .then( () => {
-        let anyIsInc = doc.entities().some( ent => !ent.completed() );
-
-        let ntfn = new Notification({
-          openable: true,
-          openText: 'Show me',
-          active: anyIsInc,
-          message: 'Provide more information for incomplete entities, labelled "?".'
-        });
-
-        ntfn.on('open', () => this.openFirstIncompleteEntity());
-
-        if( this.editable() ){
-          let listenForComplete = el => el.on('complete', () => ntfn.dismiss());
-
-          doc.elements().forEach(listenForComplete);
-          doc.on('add', listenForComplete);
-
-          this.setData({ incompleteNotification: ntfn });
-        }
       } )
       .then( () => {
         logger.info('The editor has initialised');
@@ -445,7 +422,7 @@ class Editor extends DataComponent {
   }
 
   render(){
-    let { document, bus, incompleteNotification, showHelp } = this.data;
+    let { document, bus, showHelp } = this.data;
     let controller = this;
     let { history } = this.props;
 
@@ -484,7 +461,6 @@ class Editor extends DataComponent {
         ])
       ]),
       h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),
-      incompleteNotification ? h(CornerNotification, { notification: incompleteNotification }) : h('span'),
       h(UndoRemove, { controller, document, bus }),
       h('div.editor-graph#editor-graph'),
       h('div.editor-help' + (showHelp ? '.editor-help-shown' : ''), showHelp ? [

--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -55,6 +55,15 @@ let chemical = (m, searchTerms) => {
   ];
 };
 
+let complex = (m) => {
+  return [
+    h('div.entity-info-section', [
+      h('span.entity-info-title', 'Components'),
+      h('span', m.entityNames.join('; '))
+    ])
+  ];
+};
+
 let link = m => {
   let url, nsName;
 
@@ -100,6 +109,6 @@ let modification = (mod, onEdit) => h('div.entity-info-section.entity-info-mod-s
   ])
 ]);
 
-export const assocDisp = { protein, modification, chemical, link };
+export const assocDisp = { protein, modification, chemical, complex, link };
 
 export default assocDisp;

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -355,7 +355,7 @@ class EntityInfo extends DataComponent {
       assoc = null;
     }
 
-    let targetFromAssoc = (m, complete) => {
+    let targetFromAssoc = (m, complete = false) => {
       let highlight = !complete;
       let searchStr = highlight ? s.name : null;
       let searchTerms = searchStr ? searchStr.split(/\s+/) : [];
@@ -460,6 +460,10 @@ class EntityInfo extends DataComponent {
           h(Loader)
         );
       } else if( s.matches.length > 0 && s.manualAssocMode ){
+        children.push( h('div.entity-info-matches-instructions', [
+          h('p', `Select a better match for "${s.name}"`)
+        ]) );
+
         children.push( h('div.entity-info-matches', {
           className: s.replacingMatches ? 'entity-info-matches-replacing' : '',
           onScroll: evt => {
@@ -469,13 +473,18 @@ class EntityInfo extends DataComponent {
           }
         }, [
           ...s.matches.map( m => {
+            const isCurrentMatch = m.namespace == assoc.namespace && m.id == assoc.id;
+
             return h('div.entity-info-match', [
               h('div.entity-info-match-target', {
+                className: makeClassList({
+                  'entity-info-match-target-selected': isCurrentMatch
+                }),
                 onClick: () => {
                   this.disableManualMatchMode();
                   this.associate( m );
                 }
-              }, targetFromAssoc( m )),
+              }, targetFromAssoc( m, isCurrentMatch ).concat( isCurrentMatch ? h('span.entity-info-match-current-indicator', 'Current match') : null )),
               assocDisp.link( m )
             ]);
           }),
@@ -490,7 +499,7 @@ class EntityInfo extends DataComponent {
             h('button.entity-info-assoc-button', {
               onClick: () => this.enableManualMatchMode()
             }, [
-              `Select a better match for "${s.name}"`
+              `This isn't the "${s.name}" that I meant`
             ])
           ])
         );

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -124,6 +124,7 @@ class EntityInfo extends DataComponent {
     let el = s.element;
 
     el.associate( match );
+    el.complete();
 
     // this indicates to render the match immediately though the data on the server may not be updated yet
     this.setData({
@@ -136,6 +137,7 @@ class EntityInfo extends DataComponent {
     let el = s.element;
 
     el.unassociate();
+    el.uncomplete();
 
     this.setData({
       matches: [],

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -7,13 +7,10 @@ import * as defs from '../../defs';
 import Heap from 'heap';
 import Highlighter from '../highlighter';
 import Notification from '../notification';
-import InlineNotification from '../notification/inline';
-import Tooltip from '../popover/tooltip';
 import assocDisp from './entity-assoc-display';
 import CancelablePromise from 'p-cancelable';
 
 import { stringDistanceMetric } from '../../../util';
-import { animateDomForEdit } from '../animate';
 
 const MAX_FIXED_SYNONYMS = 5;
 const MAX_SYNONYMS_SHOWN = 10;

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -100,8 +100,6 @@ class EntityInfo extends DataComponent {
     el.rename( name );
 
     const associate = matches => {
-      console.log('associate on rename', matches);
-
       if( matches && matches.length > 0 ){
         this.associate(matches[0]);
       } else {
@@ -403,19 +401,11 @@ class EntityInfo extends DataComponent {
         children.push( h('div.entity-info-assoc', allAssoc( assoc )) );
       }
     } else {
-      let NameNotification = () => {
-        let notification = s.nameNotification;
-
-        return h(InlineNotification, { notification, key: notification.id(), className: 'entity-info-notification' });
-      };
-
-      // children.push( h(NameNotification) );
-
       children.push(
         h('div.entity-info-name-input-area', [
           h('input.input-round.input-joined.entity-info-name-input', {
             type: 'text',
-            placeholder: 'Entity name',
+            placeholder: 'Name of gene or chemical (e.g. p53)',
             value: s.name,
             spellCheck: false,
             onChange: evt => this.rename( evt.target.value ),
@@ -488,7 +478,7 @@ class EntityInfo extends DataComponent {
         );
       } else if( !s.loadingMatches && s.name && !s.updateDirty ){
         children.push( h('div.entity-info-match-empty', [
-        `We aren't able to disambiguate  "${s.name}".  Please try renaming "${s.name}" to a clearer, perhaps more standard name.`
+        `We couldn't find  "${s.name}".  Please try renaming "${s.name}" to a clearer, perhaps more standard name.`
         ] ) );
       }
     }

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -449,16 +449,16 @@ class EntityInfo extends DataComponent {
         ])
       );
 
-      if( s.name && (s.loadingMatches || s.updateDirty) && !s.manualAssocMode ){
-        children.push(
-          h(Loader)
-        );
-      } else if( s.name && isComplex(s.element.type()) ){
+      if( s.name && isComplex(s.element.type()) ){
         let type = s.element.type();
         let name = s.name;
         let entityNames = s.element.participants().map(ppt => ppt.name());
 
         children.push( h('div.entity-info-assoc', targetFromAssoc({ type, name, entityNames }, true )) );
+      } else if( s.name && (s.loadingMatches || s.updateDirty) && !s.manualAssocMode ){
+        children.push(
+          h(Loader)
+        );
       } else if( s.matches.length > 0 && s.manualAssocMode ){
         children.push( h('div.entity-info-matches', {
           className: s.replacingMatches ? 'entity-info-matches-replacing' : '',

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -68,7 +68,6 @@ class InteractionInfo extends DataComponent {
   goToStage( stage ){
     let { el, progression, bus, stage: currentStage } = this.data;
     let { STAGES } = progression;
-    let getPptName = ppt => ppt.completed() ? ppt.name() : '(?)';
 
     if( this.canGoToStage(stage) ){
       this.setData({ stage, stageError: null });

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -7,10 +7,7 @@ import * as defs from '../../defs';
 import { animateDomForEdit } from '../animate';
 import uuid from 'uuid';
 import Progression from './progression';
-import ProgressionStepper from './progression-stepper';
 import EventEmitter from 'eventemitter3';
-import Notification from '../notification/notification';
-import InlineNotification from '../notification/inline';
 import Tooltip from '../popover/tooltip';
 import { INTERACTION_TYPES, INTERACTION_TYPE } from '../../../model/element/interaction-type';
 
@@ -222,14 +219,6 @@ class InteractionInfo extends DataComponent {
     let { STAGES, ORDERED_STAGES } = progression;
     let stage = progression.getStage();
 
-    let makeNotification = notification => {
-      return( h(InlineNotification, {
-        notification,
-        key: notification.id(),
-        className: 'interaction-info-notification'
-      }) );
-    };
-
     if( stage === STAGES.COMPLETED || !doc.editable() ){
       let showEditIcon = doc.editable();
       let assoc = el.association();
@@ -286,13 +275,9 @@ class InteractionInfo extends DataComponent {
         }, IntnType.displayValue) );
       } );
 
-      children.push( makeNotification(s.assocNotification) );
-
       children.push( h('label.interaction-info-assoc-radioset-label', 'Interaction type') );
 
       children.push( h('div.interaction-info-assoc-radioset', radiosetChildren) );
-    } else if( stage === STAGES.PARTICIPANT_TYPES ){
-      children.push( makeNotification(s.pptTypeNotification) );
     }
 
     return h('div.interaction-info', children);

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -1,7 +1,7 @@
 import DataComponent from '../data-component';
 import h from 'react-hyperscript';
 import ReactDom from 'react-dom';
-import { initCache, SingleValueCache, error } from '../../../util';
+import { initCache, error } from '../../../util';
 import _ from 'lodash';
 import * as defs from '../../defs';
 import { animateDomForEdit } from '../animate';
@@ -12,8 +12,6 @@ import Tooltip from '../popover/tooltip';
 import { INTERACTION_TYPES, INTERACTION_TYPE } from '../../../model/element/interaction-type';
 
 let stageCache = new WeakMap();
-let assocNotificationCache = new SingleValueCache();
-let pptTypeNotificationCache = new SingleValueCache();
 
 class InteractionInfo extends DataComponent {
   constructor( props ){
@@ -38,17 +36,12 @@ class InteractionInfo extends DataComponent {
 
     let stage = initCache( stageCache, el, el.completed() ? STAGES.COMPLETED : initialStage );
 
-    let assocNotification = initCache( assocNotificationCache, el, new Notification({ active: true }) );
-    let pptTypeNotification = initCache( pptTypeNotificationCache, el, new Notification({ active: true }) );
-
     this.data = {
       el,
       stage,
       description: p.element.description(),
       progression,
-      bus: p.bus || new EventEmitter(),
-      assocNotification,
-      pptTypeNotification
+      bus: p.bus || new EventEmitter()
     };
   }
 
@@ -73,7 +66,7 @@ class InteractionInfo extends DataComponent {
   }
 
   goToStage( stage ){
-    let { el, progression, bus, assocNotification, pptTypeNotification, stage: currentStage } = this.data;
+    let { el, progression, bus, stage: currentStage } = this.data;
     let { STAGES } = progression;
     let getPptName = ppt => ppt.completed() ? ppt.name() : '(?)';
 
@@ -85,12 +78,10 @@ class InteractionInfo extends DataComponent {
       switch( stage ){
         case STAGES.ASSOCIATE:
           bus.emit('closepptstip', el);
-          assocNotification.message('Select the type of interaction between ' + el.participants().map(getPptName).join(' and ') + '.');
           break;
 
         case STAGES.PARTICIPANT_TYPES:
           bus.emit('openpptstip', el);
-          pptTypeNotification.message(`Activation or inhibition?`);
           break;
 
         case STAGES.COMPLETED:

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -295,10 +295,6 @@ class InteractionInfo extends DataComponent {
       children.push( makeNotification(s.pptTypeNotification) );
     }
 
-    if( doc.editable() ){
-      children.push( h(ProgressionStepper, { progression }) );
-    }
-
     return h('div.interaction-info', children);
   }
 }

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -8,7 +8,6 @@ import { animateDomForEdit } from '../animate';
 import uuid from 'uuid';
 import Progression from './progression';
 import EventEmitter from 'eventemitter3';
-import Tooltip from '../popover/tooltip';
 import { INTERACTION_TYPES, INTERACTION_TYPE } from '../../../model/element/interaction-type';
 
 let stageCache = new WeakMap();
@@ -210,20 +209,20 @@ class InteractionInfo extends DataComponent {
     let stage = progression.getStage();
 
     if( stage === STAGES.COMPLETED || !doc.editable() ){
-      let showEditIcon = doc.editable();
+      let showEditButton = doc.editable();
       let assoc = el.association();
       let summaryChildren = [];
 
-      summaryChildren.push( h('span.interaction-info-summary-text', assoc ? assoc.toString() : [
+      summaryChildren.push( h('div.interaction-info-summary-text', assoc ? assoc.toString() : [
         h('i.material-icons', 'info'),
         h('span', ' This interaction has no data associated with it.')
       ]) );
 
-      if( showEditIcon ){
-        summaryChildren.push( h(Tooltip, { description: 'Edit from the beginning' }, [
-          h('button.interaction-info-edit.plain-button', {
+      if( showEditButton ){
+        summaryChildren.push( h('div.interaction-info-edit', [
+          h('button', {
             onClick: () => progression.goToStage( ORDERED_STAGES[1] )
-          }, [ h('i.material-icons', 'edit') ])
+          }, `Select a different type than "${assoc.displayValue}"`)
         ]) );
       }
 

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -197,7 +197,9 @@ class TaskView extends DataComponent {
   render(){
     let { document, bus } = this.props;
     let submitted = this.props.document.submitted();
-    let incompleteEles = this.props.document.elements().filter(ele => !ele.completed());
+    let incompleteEles = this.props.document.elements().filter(ele => {
+      return !ele.completed() && !ele.isInteraction();
+    });
 
     let ntfns = document.entities().concat(document.interactions()).filter(ele => !ele.completed()).map(ele => {
       let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : '') }`;

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -61,7 +61,7 @@ class TaskList extends DirtyComponent {
   render(){
     let doc = this.props.document;
     let ntfns = doc.entities().concat(doc.interactions()).filter(ele => !ele.completed()).map(ele => {
-      let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : ' (?)') }`;
+      let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : '') }`;
       let innerMsg = entMsg(ele);
 
       if( ele.isInteraction() ){
@@ -200,7 +200,7 @@ class TaskView extends DataComponent {
     let incompleteEles = this.props.document.elements().filter(ele => !ele.completed());
 
     let ntfns = document.entities().concat(document.interactions()).filter(ele => !ele.completed()).map(ele => {
-      let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : ' (?)') }`;
+      let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : '') }`;
       let innerMsg = entMsg(ele);
 
       if( ele.isInteraction() ){

--- a/src/client/defs.js
+++ b/src/client/defs.js
@@ -1,4 +1,4 @@
-export const updateDelay = 1000;
+export const updateDelay = 250;
 export const editAnimationDuration = 600;
 export const editAnimationEasing = 'linear';
 export const editAnimationColor = 'rgba(255, 255, 0, 0.5)';

--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -103,6 +103,23 @@
   }
 }
 
+.entity-info-match-target-selected {
+  background: #f0f0f0;
+}
+
+.entity-info-matches-instructions {
+  text-align: center;
+}
+
+.entity-info-match-current-indicator {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 0.5em;
+  color: #888;
+  font-size: var(--smallFontSize);
+}
+
 .entity-info-name {
   display: block;
   font-weight: 600;

--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -6,6 +6,15 @@
   width: 100%;
 }
 
+.entity-info-assoc {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}
+
+.entity-info-assoc-manual {
+  text-align: center;
+}
+
 .entity-info-name-clear-disabled {
   opacity: 0;
   pointer-events: none;
@@ -28,10 +37,11 @@
 
 .entity-info-matches {
   box-sizing: border-box;
-  max-height: calc(100vh - 8em);
+  max-height: 20em;
   overflow: auto;
   transition: opacity 500ms ease-out;
   opacity: 1;
+  margin-top: 1em;
 }
 
 @media (max-width: 400px) {
@@ -41,7 +51,11 @@
 }
 
 .entity-info-match-empty {
-  margin: 1em 0;
+  margin: 1em;
+  padding: 0.25em 0.5em;
+  background-color: var(--invalidColor);
+  color: #fff;
+  border-radius: 0.5em;
 }
 
 .entity-info-match-instructions {

--- a/src/styles/element-info/interaction-info.css
+++ b/src/styles/element-info/interaction-info.css
@@ -50,7 +50,7 @@ textarea.interaction-info-description {
   font-weight: bold;
 }
 
-button.interaction-info-edit {
-  margin-left: 0.25em;
-  vertical-align: baseline;
+.interaction-info-edit {
+  text-align: center;
+  margin-top: 1em;
 }


### PR DESCRIPTION
This revises the UI as per #504 for items (1), (2), and (3).  

The user starts by only typing the name, without anything else to distract him:

![Screen Shot 2019-08-16 at 12 48 44 PM](https://user-images.githubusercontent.com/989043/63183939-3ca03a00-c024-11e9-8d20-4046d7396731.png)

The user types the name of the entity and the best-guess grounding is used by default:

![Screen Shot 2019-08-16 at 12 48 51 PM](https://user-images.githubusercontent.com/989043/63183978-56418180-c024-11e9-9545-872069300e2d.png)

In all but a small minority of cases, the expected grounding is correct.  If the user does not like the grounding, he can click the button to select a better match:

![Screen Shot 2019-08-16 at 12 51 06 PM](https://user-images.githubusercontent.com/989043/63184065-8852e380-c024-11e9-9353-c403069fb9e4.png)

If the user types something for which we can't find any possible groundings, we display an error message:

![Screen Shot 2019-08-16 at 1 01 36 PM](https://user-images.githubusercontent.com/989043/63184790-2eebb400-c026-11e9-9ec8-9b664465697c.png)



The UI for complexes is consistent with the automatic grounding UI:

![Screen Shot 2019-08-16 at 12 54 46 PM](https://user-images.githubusercontent.com/989043/63184368-2cd52580-c025-11e9-8c09-68fcd23e99c0.png)

The UI for interactions is also consistent:

![Screen Shot 2019-08-16 at 12 56 58 PM](https://user-images.githubusercontent.com/989043/63184465-59893d00-c025-11e9-85f9-e054431fc995.png)

Related changes:

- Remove support for grouped selection via interaction nodes -- we don't support interaction nodes for n-ary interactions anymore.  Without this change, there are conflicts with automatic grounding.
- Update labels for "entity" to instead use the words "gene or chemical".
- Fix a related selection issue.  When clicking from one node to another node, the old node remains selected.
- Remove the extra spacing for interaction popovers.
- Complexes now have a label, to be consistent with other complete entity nodes.
- Notifications are removed, since they are not relevant with an automatic grounding UI.
- The submission task list excludes complexes and interactions.  They are always submittable.

Ref: 
- Ground a named node by default #504 : (1), (2), and (3) complete
- Remove the grounding popover for complexes #516 : No longer applicable