### PR TITLE
Add support for entity types `ggp`, `dna`, `rna`

### DIFF
--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -32,6 +32,10 @@ let protein = (m, searchTerms) => {
   ];
 };
 
+let ggp = protein;
+let dna = protein;
+let rna = protein;
+
 let chemical = (m, searchTerms) => {
   return [
     h('div.entity-info-section', [
@@ -109,6 +113,6 @@ let modification = (mod, onEdit) => h('div.entity-info-section.entity-info-mod-s
   ])
 ]);
 
-export const assocDisp = { protein, modification, chemical, complex, link };
+export const assocDisp = { ggp, dna, rna, protein, modification, chemical, complex, link };
 
 export default assocDisp;

--- a/src/model/element/element-type.js
+++ b/src/model/element/element-type.js
@@ -20,4 +20,12 @@ const isComplex = type => {
   return type == ENTITY_TYPE.COMPLEX;
 };
 
-export { ELEMENT_TYPE, ELEMENT_TYPES, isEntity, isInteraction, isComplex };
+const isGGP = type => {
+  return ( type === ENTITY_TYPE.GGP
+    || type === ENTITY_TYPE.DNA
+    || type === ENTITY_TYPE.RNA
+    || type === ENTITY_TYPE.PROTEIN
+  );
+};
+
+export { ELEMENT_TYPE, ELEMENT_TYPES, isEntity, isInteraction, isComplex, isGGP };

--- a/src/model/element/entity-type.js
+++ b/src/model/element/entity-type.js
@@ -2,6 +2,9 @@ import _ from 'lodash';
 
 const ENTITY_TYPE = Object.freeze({
   ENTITY: 'entity',
+  GGP: 'ggp', // gene or gene product
+  DNA: 'dna',
+  RNA: 'rna',
   PROTEIN: 'protein',
   CHEMICAL: 'chemical',
   COMPLEX: 'complex'

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -112,6 +112,10 @@ button.button-toggle {
       border-radius: 0;
     }
 
+    &:not(:active) + label:not(:last-child) {
+      border-right-color: transparent;
+    }
+
     &:first-child + label {
       border-top-left-radius: var(--widgetBorderRadius);
       border-bottom-left-radius: var(--widgetBorderRadius);

--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -82,7 +82,7 @@
   padding: 0.25em 0;
 
   & + * {
-    margin-top: 0.25em;
+    margin-top: 0.5em;
   }
 }
 
@@ -123,7 +123,14 @@
 .entity-info-name {
   display: block;
   font-weight: 600;
-  margin: 0.25em 0;
+  margin: 0.25em 0 0.5em;
+}
+
+.entity-info-subtype {
+  font-size: var(--smallFontSize);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 button.entity-info-edit {


### PR DESCRIPTION
- Add model support.
- Add display support based on existing protein implementation.
- Add a subtype selector for NCBI groundings.

Ref : Entity subtypes : `ggp`, `dna`, `rna` #551