### PR TITLE
Popper overflow fixes

### DIFF
--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -163,7 +163,8 @@ button.entity-info-edit {
 .entity-info-alt-name,
 .entity-info-formula {
   display: inline;
-
+  overflow-wrap: break-word;
+  
   &::after {
     content: '; ';
   }

--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -190,3 +190,8 @@ button.entity-info-edit {
 .entity-info-linkout {
   margin-right: 0.5em;
 }
+
+.entity-info-assoc-button {
+  display: inline-block;
+  height: auto;
+}

--- a/src/styles/element-info/interaction-info.css
+++ b/src/styles/element-info/interaction-info.css
@@ -53,4 +53,9 @@ textarea.interaction-info-description {
 .interaction-info-edit {
   text-align: center;
   margin-top: 1em;
+
+  & button {
+    display: inline-block;
+    height: auto;
+  }
 }


### PR DESCRIPTION
This PR fixes overflow issues in the grounding popovers: 

- (1) "Change grounding" buttons
- (2) Synonyms

--

(1) "Change grounding" buttons:

Before:

![Screen Shot 2019-09-18 at 4 40 14 PM](https://user-images.githubusercontent.com/989043/65184190-04c94f80-da33-11e9-833c-af300c9626ca.png)

After:

![Screen Shot 2019-09-18 at 4 40 22 PM](https://user-images.githubusercontent.com/989043/65184202-08f56d00-da33-11e9-946e-c2980a616858.png)

--

(2) Synonyms:

Before:

![Screen Shot 2019-09-18 at 4 41 47 PM](https://user-images.githubusercontent.com/989043/65184310-3e01bf80-da33-11e9-8e94-8e93955dcfc5.png)

After:

![Screen Shot 2019-09-18 at 4 41 58 PM](https://user-images.githubusercontent.com/989043/65184324-45c16400-da33-11e9-9c89-e6d5c693cd0a.png)


