### PR TITLE
Iss555 mailjet integration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,8 @@
         "sourceType": "module",
         "ecmaFeatures": {
             "jsx": true
-        }
+        },
+        "ecmaVersion": 8
     },
     "plugins": [
 

--- a/src/config.js
+++ b/src/config.js
@@ -49,9 +49,9 @@ export const NCBI_LINK_BASE_URL = env('NCBI_LINK_BASE_URL', 'https://www.ncbi.nl
 
 // Email
 export const EMAIL_ENABLED = env('EMAIL_ENABLED', false);
-export const EMAIL_FROM = env('EMAIL_FROM', 'Factoid');
-export const EMAIL_FROM_ADDR = env('EMAIL_FROM_ADDR', 'support@mentana.org');
-export const SMTP_PORT = env('SMTP_PORT', 465);
+export const EMAIL_FROM = env('EMAIL_FROM', 'Biofactoid');
+export const EMAIL_FROM_ADDR = env('EMAIL_FROM_ADDR', 'support@biofactoid.org');
+export const SMTP_PORT = env('SMTP_PORT', 587);
 export const SMTP_HOST = env('SMTP_HOST', 'localhost');
 export const SMTP_USER = env('SMTP_USER', 'user');
 export const SMTP_PASSWORD = env('SMTP_PASSWORD', 'password');

--- a/src/config.js
+++ b/src/config.js
@@ -56,6 +56,7 @@ export const SMTP_HOST = env('SMTP_HOST', 'localhost');
 export const SMTP_USER = env('SMTP_USER', 'user');
 export const SMTP_PASSWORD = env('SMTP_PASSWORD', 'password');
 
+export const EMAIL_VENDOR_MAILJET = env('EMAIL_VENDOR_MAILJET', 'Mailjet');
 export const INVITE_TMPLID = env('INVITE_SIGNUP_TMPLID', '1005099');
 export const SUBMIT_SUCCESS_TMPLID = env('SUBMIT_SUCCESS_TMPLID', '1007008');
 export const EMAIL_CONTEXT_JOURNAL = env('EMAIL_CONTEXT_JOURNAL', 'journal');

--- a/src/config.js
+++ b/src/config.js
@@ -56,9 +56,10 @@ export const SMTP_HOST = env('SMTP_HOST', 'localhost');
 export const SMTP_USER = env('SMTP_USER', 'user');
 export const SMTP_PASSWORD = env('SMTP_PASSWORD', 'password');
 
-export const INVITE_JOURNAL_TMPLID = env('INVITE_JOURNAL_TMPLID', '1007008');
-export const INVITE_SIGNUP_TMPLID = env('INVITE_SIGNUP_TMPLID', '1005099');
+export const INVITE_TMPLID = env('INVITE_SIGNUP_TMPLID', '1005099');
 export const SUBMIT_SUCCESS_TMPLID = env('SUBMIT_SUCCESS_TMPLID', '1007008');
+export const EMAIL_CONTEXT_JOURNAL = env('EMAIL_CONTEXT_JOURNAL', 'journal');
+export const EMAIL_CONTEXT_SIGNUP = env('EMAIL_CONTEXT_SIGNUP', 'signup');
 
 // client vars:
 // these vars are always included in the bundle because they ref `process.env.${name}` directly

--- a/src/config.js
+++ b/src/config.js
@@ -56,6 +56,10 @@ export const SMTP_HOST = env('SMTP_HOST', 'localhost');
 export const SMTP_USER = env('SMTP_USER', 'user');
 export const SMTP_PASSWORD = env('SMTP_PASSWORD', 'password');
 
+export const INVITE_JOURNAL_TMPLID = env('INVITE_JOURNAL_TMPLID', '1007008');
+export const INVITE_SIGNUP_TMPLID = env('INVITE_SIGNUP_TMPLID', '1005099');
+export const SUBMIT_SUCCESS_TMPLID = env('SUBMIT_SUCCESS_TMPLID', '1007008');
+
 // client vars:
 // these vars are always included in the bundle because they ref `process.env.${name}` directly
 // NB DO NOT include passwords etc. here

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -24,7 +24,7 @@ const parseTestAccount = account => ({
 });
 const createTransporter = ( transportOpts, messageOpts ) => nodemailer.createTransport( transportOpts, messageOpts );
 
-const addHeaders = ( message, opts ) => {
+const withVendorOpts = ( message, opts ) => {
   if( _.has( opts, 'mailJet' ) ){
     const mailJet = _.get( opts, 'mailJet' );
     return _.assign( {}, message, { headers: {
@@ -76,7 +76,7 @@ const email = {
 const sendMail = opts => {
 
   let message = _.pick( opts, [ 'from', 'to', 'cc', 'bcc', 'subject', 'text', 'html', 'attachments' ] );
-  message = addHeaders( message, opts );
+  message = withVendorOpts( message, opts );
   return email.sendMail( message )
     .then( logInfo )
     .catch( logErr );

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -1,13 +1,82 @@
+import _ from 'lodash';
 import nodemailer from 'nodemailer';
-import { SMTP_PORT, SMTP_HOST, SMTP_USER, SMTP_PASSWORD } from '../config';
 
-const transport = nodemailer.createTransport({
-  port: SMTP_PORT,
-  host: SMTP_HOST,
-  auth: {
-    user: SMTP_USER,
-    pass: SMTP_PASSWORD
+import { SMTP_PORT, SMTP_HOST, SMTP_USER, SMTP_PASSWORD, 
+  EMAIL_FROM, EMAIL_FROM_ADDR, 
+  EMAIL_ENABLED } from '../config';
+
+import logger from './logger';
+
+const logInfo = info => {
+  logger.info( `Email sent: ${info.messageId}` );
+  if( !EMAIL_ENABLED ) logger.info( `Preview URL: ${nodemailer.getTestMessageUrl( info )}` );
+};
+const logErr = err => logger.error( `Error: ${err.message}` );
+
+let transporter;
+async function getTransporter(){
+  
+  if( transporter ) return transporter;
+  
+  let transport = {
+    port: SMTP_PORT,
+    host: SMTP_HOST,
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASSWORD
+    }
+  };
+  
+  const defaults = {
+    from: {
+      name: EMAIL_FROM,
+      address: EMAIL_FROM_ADDR
+    }
+  };
+  
+  try {
+    // Mock out email transport with Ethereal when !EMAIL_ENABLED
+    if( !EMAIL_ENABLED ){
+      logger.info( `Mocking email transport` );
+      const account = await nodemailer.createTestAccount();
+      logger.info( `Mock email account created`);
+      transport = {
+        host: account.smtp.host,
+        port: account.smtp.port,
+        secure: account.smtp.secure,
+        auth: {
+          user: account.user,
+          pass: account.pass
+        }
+      };
+    }
+
+    return transporter = nodemailer.createTransport( transport, defaults );
+
+  } catch( err ) { 
+    logErr( err ) 
   }
-});
+   
+};
 
-export default transport;
+const sendMail = ( { to, cc, subject, html, text, templateInfo } ) => {
+  const message = { 
+    to, cc, subject, html, text
+  };
+  
+  if( templateInfo ){
+    const headers = {
+      'X-MJ-TemplateID': _.get( templateInfo, 'templateId' ),
+      'X-MJ-TemplateLanguage': '1',
+      'X-MJ-Vars': JSON.stringify( _.get( templateInfo, 'variables' ) )
+    }
+    _.assign( message, { headers } );
+  }
+
+  return getTransporter()
+    .then( transporter => transporter.sendMail( message ) )
+    .then( logInfo )
+    .catch( logErr );
+};
+
+export default sendMail;

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -26,8 +26,8 @@ async function getTransporter(){
       pass: SMTP_PASSWORD
     }
   };
-  
-  const defaults = {
+
+  const messageDefaults = {
     from: {
       name: EMAIL_FROM,
       address: EMAIL_FROM_ADDR
@@ -51,7 +51,7 @@ async function getTransporter(){
       };
     }
 
-    return transporter = nodemailer.createTransport( transport, defaults );
+    return transporter = nodemailer.createTransport( transport, messageDefaults );
 
   } catch( err ) { 
     logErr( err ) 
@@ -59,18 +59,17 @@ async function getTransporter(){
    
 };
 
-const sendMail = ( { to, cc, subject, html, text, templateInfo } ) => {
-  const message = { 
-    to, cc, subject, html, text
-  };
-  
-  if( templateInfo ){
-    const headers = {
-      'X-MJ-TemplateID': _.get( templateInfo, 'templateId' ),
+const sendMail = opts => {
+
+  const message = _.pick( opts, [ 'from', 'to', 'cc', 'bcc', 'subject', 'text', 'html', 'attachments' ] );
+
+  // MailJet-specific: must use a validated domain 
+  if( _.has( opts, 'template' ) ){
+    _.set( message, 'headers', {
+      'X-MJ-TemplateID': _.get( opts, ['template', 'id'] ),
       'X-MJ-TemplateLanguage': '1',
-      'X-MJ-Vars': JSON.stringify( _.get( templateInfo, 'variables' ) )
-    }
-    _.assign( message, { headers } );
+      'X-MJ-Vars': JSON.stringify( _.get( opts, ['template', 'vars'] ) )
+    });
   }
 
   return getTransporter()

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -27,13 +27,21 @@ const createTransporter = ( transportOpts, messageOpts ) => nodemailer.createTra
 
 const configureMessage = opts => {
   let message = _.pick( opts, MSG_FIELDS );  
-  if( _.has( opts, 'mailJet' ) ){
-    const mailJet = _.get( opts, 'mailJet' );
-    return _.assign( {}, message, { headers: {
-      'X-MJ-TemplateID': _.get( mailJet, ['template', 'id'] ),
-      'X-MJ-TemplateLanguage': '1',
-      'X-MJ-Vars': JSON.stringify( _.get( mailJet, ['template', 'vars'] ) )
-    }});
+  if( _.has( opts, [ 'template' ] ) ){
+    const vendor = _.get( opts, ['template', 'vendor'] );
+    
+    switch( vendor ) {
+      case 'Mailjet':
+        message = _.assign( {}, message, { headers: {
+          'X-MJ-TemplateID': _.get( opts, ['template', 'id'] ),
+          'X-MJ-TemplateLanguage': '1',
+          'X-MJ-Vars': JSON.stringify( _.get( ['template', 'vars'] ) )
+        }})
+        break;
+      default:
+    }
+    
+    return message;
   }
 };
 
@@ -70,15 +78,15 @@ const email = {
     }
   },
 
-  sendMail: function( message ) {
+  send: function( message ) {
     return this.getTransporter().then( t => t.sendMail( message ) );
   }
 };
 
 const sendMail = opts => {
   return Promise.resolve( opts )
-    .then(  configureMessage ) 
-    .then( msg => email.sendMail( msg ))  
+    .then( configureMessage ) 
+    .then( msg => email.send( msg ))  
     .then( logInfo )
     .catch( logErr );
 };

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -3,7 +3,8 @@ import nodemailer from 'nodemailer';
 
 import { SMTP_PORT, SMTP_HOST, SMTP_USER, SMTP_PASSWORD, 
   EMAIL_FROM, EMAIL_FROM_ADDR, 
-  EMAIL_ENABLED } from '../config';
+  EMAIL_ENABLED,
+  EMAIL_VENDOR_MAILJET } from '../config';
 import logger from './logger';
 
 const configMap = {
@@ -67,7 +68,7 @@ const configureMessage = opts => {
   if( _.has( opts, [ 'template' ] ) ){
     const vendor = _.get( opts, ['template', 'vendor'] );
     switch( vendor ) { 
-      case 'Mailjet':
+      case EMAIL_VENDOR_MAILJET:
         _.set( message,  'headers', {
           'X-MJ-TemplateID': _.get( opts, ['template', 'id'] ),
           'X-MJ-TemplateLanguage': '1',

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -4,8 +4,9 @@ import nodemailer from 'nodemailer';
 import { SMTP_PORT, SMTP_HOST, SMTP_USER, SMTP_PASSWORD, 
   EMAIL_FROM, EMAIL_FROM_ADDR, 
   EMAIL_ENABLED } from '../config';
-
 import logger from './logger';
+
+const MSG_FIELDS = [ 'from', 'to', 'cc', 'bcc', 'subject', 'text', 'html', 'attachments' ];
 
 const logInfo = info => {
   logger.info( `Email sent: ${info.messageId}` );
@@ -24,7 +25,8 @@ const parseTestAccount = account => ({
 });
 const createTransporter = ( transportOpts, messageOpts ) => nodemailer.createTransport( transportOpts, messageOpts );
 
-const withVendorOpts = ( message, opts ) => {
+const configureMessage = opts => {
+  let message = _.pick( opts, MSG_FIELDS );  
   if( _.has( opts, 'mailJet' ) ){
     const mailJet = _.get( opts, 'mailJet' );
     return _.assign( {}, message, { headers: {
@@ -74,10 +76,9 @@ const email = {
 };
 
 const sendMail = opts => {
-
-  let message = _.pick( opts, [ 'from', 'to', 'cc', 'bcc', 'subject', 'text', 'html', 'attachments' ] );
-  message = withVendorOpts( message, opts );
-  return email.sendMail( message )
+  return Promise.resolve( opts )
+    .then(  configureMessage ) 
+    .then( msg => email.sendMail( msg ))  
     .then( logInfo )
     .catch( logErr );
 };

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -24,14 +24,14 @@ const configMap = {
     }
   },
 
-  MESSAGE_FIELDS: [ 
+  ALLOWED_MESSAGE_FIELDS: [ 
     'from', 'to', 'cc', 'bcc', 'replyTo',
     'subject', 
     'text', 'html', 
     'attachments' 
   ],
 
-  NODEMAILER_INFO_FIELDS: [ 'response','messageId', 'accepted', 'rejected', 'previewUrl' ]
+  NODEMAILER_INFO_FIELDS: [ 'response','messageId', 'accepted', 'rejected' ]
 }; 
 
 const stateMap = {
@@ -63,7 +63,7 @@ const getTestTransportOpts = account => ({
 });
 
 const configureMessage = opts => {
-  let message = _.pick( opts, configMap.MESSAGE_FIELDS );
+  let message = _.pick( opts, configMap.ALLOWED_MESSAGE_FIELDS );
   if( _.has( opts, [ 'template' ] ) ){
     const vendor = _.get( opts, ['template', 'vendor'] );
     switch( vendor ) { 
@@ -109,7 +109,7 @@ const send = message => getSend().then( s => s( message ) );
  * 
  * @param { Object } opts The message data. 
  * @param { String | Object | Array } opts.from (formatted and/or comma separated) email address(es)
- *  OR an oject with 'address' and 'name' fields OR a list of the above.
+ *  OR an oject with 'address' and 'name' fields OR a list of any above.
  * @param { Object } opts.to see opts.from
  * @param { Object } opts.cc see opts.from
  * @param { Object } opts.bcc see opts.from
@@ -118,6 +118,11 @@ const send = message => getSend().then( s => s( message ) );
  * @param { String } opts.html html version
  * @param { String } opts.text text version
  * @param { Array } opts.attachments See https://nodemailer.com/message/attachments/
+ * @param { Object } opts.template 
+ * @param { String } opts.template.vendor The name of the vendor, assuming we support it
+ * @param { String } opts.template.id The vendor template id
+ * @param { Object } opts.template.vars The variables to send to the given template
+ * 
  * @returns { Object } Information regarding the email delivery:
  *   - { String } response from server
  *   - { Array } accepted email addresses 

--- a/src/server/email-transport.js
+++ b/src/server/email-transport.js
@@ -6,15 +6,42 @@ import { SMTP_PORT, SMTP_HOST, SMTP_USER, SMTP_PASSWORD,
   EMAIL_ENABLED } from '../config';
 import logger from './logger';
 
-const MSG_FIELDS = [ 'from', 'to', 'cc', 'bcc', 'subject', 'text', 'html', 'attachments' ];
+const configMap = {
+  transportOpts: {
+    port: SMTP_PORT,
+    host: SMTP_HOST,
+    auth: {
+      user: SMTP_USER,
+      pass: SMTP_PASSWORD
+    }
+  },
+
+  messageOpts: {
+    from: {
+      name: EMAIL_FROM,
+      address: EMAIL_FROM_ADDR
+    }
+  },
+
+  MESSAGE_FIELDS: [ 
+    'from', 'to', 'cc', 'bcc', 'subject', 'text', 'html', 'attachments' 
+  ]
+}; 
+
+const stateMap = {
+  transporter: undefined
+};
 
 const logInfo = info => {
   logger.info( `Email sent: ${info.messageId}` );
   if( !EMAIL_ENABLED ) logger.info( `Preview URL: ${nodemailer.getTestMessageUrl( info )}` );
 };
-const logErr = err => logger.error( `Error: ${err.message}` );
+const logErr = err => {
+  logger.error( `Error: ${err.message}` );
+  throw err;
+};
 const getTestAccount = () => nodemailer.createTestAccount();
-const parseTestAccount = account => ({
+const getTestTransportOpts = account => ({
   host: account.smtp.host,
   port: account.smtp.port,
   secure: account.smtp.secure,
@@ -26,17 +53,16 @@ const parseTestAccount = account => ({
 const createTransporter = ( transportOpts, messageOpts ) => nodemailer.createTransport( transportOpts, messageOpts );
 
 const configureMessage = opts => {
-  let message = _.pick( opts, MSG_FIELDS );  
+  let message = _.pick( opts, configMap.MESSAGE_FIELDS );
   if( _.has( opts, [ 'template' ] ) ){
     const vendor = _.get( opts, ['template', 'vendor'] );
-    
-    switch( vendor ) {
+    switch( vendor ) { 
       case 'Mailjet':
         message = _.assign( {}, message, { headers: {
           'X-MJ-TemplateID': _.get( opts, ['template', 'id'] ),
           'X-MJ-TemplateLanguage': '1',
           'X-MJ-Vars': JSON.stringify( _.get( ['template', 'vars'] ) )
-        }})
+        }});
         break;
       default:
     }
@@ -45,48 +71,23 @@ const configureMessage = opts => {
   }
 };
 
-const email = {
-
-  transportDefaults: {
-    port: SMTP_PORT,
-    host: SMTP_HOST,
-    auth: {
-      user: SMTP_USER,
-      pass: SMTP_PASSWORD
-    }
-  },
+const getTransporter = async () => {
+  if( stateMap.transporter ) return stateMap.transporter;
   
-  messageDefaults: {
-    from: {
-      name: EMAIL_FROM,
-      address: EMAIL_FROM_ADDR
-    }
-  },
-
-  getTransporter: async function(){
-    if( this.transporter ){
-      return this.transporter;
-    } else {
-      let transportOpts = _.assign( {}, this.transportDefaults );
-      let messageOpts = _.assign( {}, this.messageDefaults );
-      if( !EMAIL_ENABLED ) {
-        logger.info( `Mocking email transport` );
-        const account = await getTestAccount();
-        _.assign( transportOpts, parseTestAccount( account ) );
-      }
-      return this.transporter = createTransporter( transportOpts, messageOpts );
-    }
-  },
-
-  send: function( message ) {
-    return this.getTransporter().then( t => t.sendMail( message ) );
+  if( !EMAIL_ENABLED ) {
+    logger.info( `Mocking email transport` );
+    const account = await getTestAccount();
+    configMap.transportOpts = getTestTransportOpts( account );
   }
+  return stateMap.transporter = createTransporter( configMap.transportOpts, configMap.messageOpts );
 };
+
+const send = message => getTransporter().then( t => t.sendMail( message ) );
 
 const sendMail = opts => {
   return Promise.resolve( opts )
     .then( configureMessage ) 
-    .then( msg => email.send( msg ))  
+    .then( send )
     .then( logInfo )
     .catch( logErr );
 };

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -103,11 +103,13 @@ let email = json => sendMail({
     cc: { name: json.editorName, address: json.editorEmail },
     subject: `Action required: "${json.name}"`,
     html: '<h1>Test email</h1>',
-    template: {
-      id: INVITE_SIGNUP_TMPLID,
-      vars: {
-        citation: `${json.authors} ${json.title}`,
-        privateUrl: `${BASE_URL}${json.privateUrl}`
+    mailJet: {
+      template: {
+        id: INVITE_SIGNUP_TMPLID,
+        vars: {
+          citation: `${json.authors} ${json.title}`,
+          privateUrl: `${BASE_URL}${json.privateUrl}`
+        }
       }
     }
 });

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -2,10 +2,10 @@ import Express from 'express';
 import _ from 'lodash';
 import uuid from 'uuid';
 import fetch from 'node-fetch';
+
+import { INVITE_SIGNUP_TMPLID } from '../../../../config';
 import { tryPromise } from '../../../../util';
 import sendMail from '../../../email-transport';
-import h from 'hyperscript';
-
 import Document from '../../../../model/document';
 import db from '../../../db';
 import logger from '../../../logger';
@@ -104,9 +104,9 @@ let email = json => sendMail({
     subject: `Action required: "${json.name}"`,
     html: '<h1>Test email</h1>',
     template: {
-      id: '1007008',
+      id: INVITE_SIGNUP_TMPLID,
       vars: {
-        citation: 'Doe et al. (2019). A really important pathway. J. Bio. 58',
+        citation: `${json.authors} ${json.title}`,
         privateUrl: `${BASE_URL}${json.privateUrl}`
       }
     }

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -14,7 +14,7 @@ import * as provider from './reach';
 
 const ENABLE_TEXTMINING = false;
 
-import { BIOPAX_CONVERTER_URL, BASE_URL, EMAIL_ENABLED, EMAIL_FROM, EMAIL_FROM_ADDR, API_KEY } from '../../../../config';
+import { BIOPAX_CONVERTER_URL, BASE_URL, API_KEY } from '../../../../config';
 
 const http = Express.Router();
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -103,14 +103,13 @@ let email = json => sendMail({
     cc: { name: json.editorName, address: json.editorEmail },
     subject: `Action required: "${json.name}"`,
     html: '<h1>Test email</h1>',
-    mailJet: {
-      template: {
+    template: {
+        vendor: "Mailjet",
         id: INVITE_SIGNUP_TMPLID,
         vars: {
           citation: `${json.authors} ${json.title}`,
           privateUrl: `${BASE_URL}${json.privateUrl}`
         }
-      }
     }
 });
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -17,6 +17,7 @@ import { BIOPAX_CONVERTER_URL,
   EMAIL_CONTEXT_JOURNAL,
   BASE_URL, 
   INVITE_TMPLID,
+  EMAIL_VENDOR_MAILJET,
   API_KEY } from '../../../../config';
 
 const http = Express.Router();
@@ -110,7 +111,7 @@ let email = json => {
     subject: `Action required: "${json.contributorName}"`,
     html: `<pre>${JSON.stringify(json, null, 2)}</pre>`,
     template: {
-        vendor: 'Mailjet',
+        vendor: EMAIL_VENDOR_MAILJET,
         id: INVITE_TMPLID,
         vars: {
           citation: `${json.authors} ${json.title}`,

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -97,20 +97,20 @@ let getSbgnFromTemplates = templates => {
     .then(handleResponseError);
 };
 
-let email = json => {
-  return sendMail({
+let email = json => sendMail({
+    from: { name: 'Ricky', address: 'ricky@biofactoid.org' },
     to: { name: json.contributorName, address: json.contributorEmail },
     cc: { name: json.editorName, address: json.editorEmail },
     subject: `Action required: "${json.name}"`,
-    templateInfo: {
-      templateId: '1007008',
-      variables: {
+    html: '<h1>Test email</h1>',
+    template: {
+      id: '1007008',
+      vars: {
         citation: 'Doe et al. (2019). A really important pathway. J. Bio. 58',
         privateUrl: `${BASE_URL}${json.privateUrl}`
       }
     }
-  });
-};
+});
 
 http.get('/', function( req, res, next ){
   let limit = req.params.limit || 50;

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -98,11 +98,11 @@ let getSbgnFromTemplates = templates => {
 };
 
 let email = json => sendMail({
-    from: { name: 'Ricky', address: 'ricky@biofactoid.org' },
+    from: { name: 'Biofactoid', address: 'support@biofactoid.org' },
     to: { name: json.contributorName, address: json.contributorEmail },
     cc: { name: json.editorName, address: json.editorEmail },
     subject: `Action required: "${json.name}"`,
-    html: '<h1>Test email</h1>',
+    html: `<pre>${JSON.stringify(json, null, 2)}</pre>`,
     template: {
         vendor: "Mailjet",
         id: INVITE_SIGNUP_TMPLID,
@@ -170,21 +170,10 @@ http.post('/', function( req, res, next ){
       return json;
     } )
     .then(json => {
-      if( !json.contributorEmail ){
-        logger.info(`Contributor email address missing for new doc ${json.id}; not sending email`);
-
-        return Promise.resolve(json);
-      }
-
-      if( !json.editorEmail ){
-        logger.info(`Editor email address missing for new doc ${json.id}; not sending email`);
-
-        return Promise.resolve(json);
-      }
-
-      logger.info(`Sending new doc ${json.id} to ${json.contributorEmail} and copying to ${json.editorEmail}`);
-
-      return email( json ).then(() => json);
+      return email( json ).then( info => { 
+        logger.info( `Email sent to ${info.accepted}` );
+        return json; 
+      });
     })
     .then(json => {
       return res.json( json );


### PR DESCRIPTION
- exposes a `sendMail` function that takes in configuration options 
- options include `template` used for configuring mail delivery providers, i.e. Mailjet
- when `!EMAIL_ENABLED`, using nodemailer's Ethereal mail catcher

NB: Intend to remove the document-creation trigger for emailing; kept it to illustrate how the module would be called 

Refs #555 