### PR TITLE
Autoground tweaks

### DIFF
--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -27,7 +27,8 @@ let protein = (m, searchTerms) => {
       h('span.entity-info-title', 'Synonyms'),
       ...m.shortSynonyms.map( name => h('span.entity-info-alt-name', [
         h(Highlighter, { text: name, terms: searchTerms })
-      ]))
+      ])),
+      m.shortSynonyms.length === 0 ? '-' : ''
     ])
   ];
 };

--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -5,12 +5,12 @@ import Tooltip from '../popover/tooltip';
 
 const { UNIPROT_LINK_BASE_URL, PUBCHEM_LINK_BASE_URL, NCBI_LINK_BASE_URL, CHEBI_LINK_BASE_URL } = require('../../../config');
 
-let protein = (m, searchTerms) => {
+let protein = (m, searchTerms, includeOrganism = true) => {
   return [
-    h('div.entity-info-section', [
+    includeOrganism ? h('div.entity-info-section', [
       h('span.entity-info-title', 'Organism'),
       h('span', m.organismName)
-    ]),
+    ]) : null,
     h('div.entity-info-section', !m.proteinNames ? [] : [
       h('span.entity-info-title', 'Protein names'),
       ...m.proteinNames.map( name => h('span.entity-info-alt-name', [

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -524,10 +524,10 @@ class EntityInfo extends DataComponent {
 
         children.push(
           h('div.entity-info-assoc-manual', [
-            h('button.entity-info-assoc-button', {
+            h('button.salient-button.entity-info-assoc-button', {
               onClick: () => this.enableManualMatchMode()
             }, [
-              `This isn't the "${s.name}" that I meant`
+              `Select a better match for "${s.name}"`
             ])
           ])
         );

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -355,7 +355,7 @@ class EntityInfo extends DataComponent {
       assoc = null;
     }
 
-    let targetFromAssoc = (m, complete = false, showSubtype = false) => {
+    let targetFromAssoc = (m, complete = false, showRefinement = false) => {
       let highlight = !complete;
       let searchStr = highlight ? s.name : null;
       let searchTerms = searchStr ? searchStr.split(/\s+/) : [];
@@ -383,9 +383,11 @@ class EntityInfo extends DataComponent {
         h('div.entity-info-name', nameChildren.filter( domEl => domEl != null ))
       ];
 
-      let subtype;
+      let refineEditableGgp = doc.editable() && complete && showRefinement && isGGP(m.type);
 
-      if( doc.editable() && complete && showSubtype && isGGP(m.type) ){
+      let subtype = null;
+
+      if( refineEditableGgp ){
         let radios = [];
 
         let addType = (typeVal, displayName) => {
@@ -416,23 +418,80 @@ class EntityInfo extends DataComponent {
 
         let radioParent = h('div.radioset', radios);
 
-        subtype = h('div.entity-info-subtype', [
+        subtype = h('div.entity-info-subtype.entity-info-section', [
           h('span.entity-info-title', 'Type'),
           radioParent
         ]);
-      } else {
-        subtype = null;
       }
 
-      let body = assocDisp[ m.type ]( m, searchTerms );
+      let organism = null;
+
+      if( refineEditableGgp ){
+        let isPerfectNameMatch = m => m.distance === 0;
+        let orgMatches = s.matches.filter(isPerfectNameMatch);
+        let orgToMatches = new Map();
+        const selectedIndex = _.findIndex(orgMatches, match => match.id === m.id && match.namespace === m.namespace);
+
+        orgMatches.forEach(om => {
+          let org = om.organism;
+          let arr;
+
+          if( orgToMatches.has(org) ){
+            arr = orgToMatches.get(org);
+          } else {
+            arr = [];
+            orgToMatches.set(org, arr);
+          }
+
+          arr.push(om);
+        });
+
+        const getSelectDisplay = (om, includeName = false) => {
+          const matches = orgToMatches.get(om.organism) || [];
+          let count = matches.length;
+
+          if( count > 1 || includeName ){
+            return `${om.organismName} (${om.name})`;
+          } else {
+            return `${om.organismName}`;
+          }
+        };
+
+        organism = h('div.entity-info-section.entity-info-organism-refinement', [
+          h('span.entity-info-title', 'Organism'),
+          h('select.entity-info-organism-dropdown', {
+            defaultValue: selectedIndex,
+            onChange: e => {
+              const val = e.target.value;
+              const index = parseInt(val);
+              const om = orgMatches[index];
+
+              if( om ){
+                this.associate(om);
+              } else {
+                this.enableManualMatchMode();
+              }
+            }
+          }, orgMatches.map((om, index) => {
+            const value = index;
+
+            return h('option', { value }, getSelectDisplay(om));
+          }).concat([
+            selectedIndex < 0 ? h('option', { value: -1 }, getSelectDisplay(m, true)) : null,
+            h('option', { value: -2 }, 'Other')
+          ]))
+        ]);
+      }
+
+      let body = assocDisp[ m.type ]( m, searchTerms, !showRefinement );
 
       let post = [];
 
-      return _.concat( pre, subtype, body, post );
+      return _.concat( pre, subtype, organism, body, post );
     };
 
-    let allAssoc = (m, complete = false, showSubtype = false) => _.concat(
-      targetFromAssoc(m, complete, showSubtype),
+    let allAssoc = (m, complete = false, showRefinement = false) => _.concat(
+      targetFromAssoc(m, complete, showRefinement),
       assocDisp.link(m)
     );
 
@@ -520,7 +579,7 @@ class EntityInfo extends DataComponent {
           h(Loader, { loading: s.gettingMoreMatches })
         ] ) );
       } else if( s.name && assoc ){
-        children.push( h('div.entity-info-assoc', allAssoc( assoc, true, true )) );
+        children.push( h('div.entity-info-assoc.entity-info-assoc-refinement', allAssoc( assoc, true, true )) );
 
         children.push(
           h('div.entity-info-assoc-manual', [

--- a/src/styles/element-info/entity-info.css
+++ b/src/styles/element-info/entity-info.css
@@ -126,11 +126,8 @@
   margin: 0.25em 0 0.5em;
 }
 
-.entity-info-subtype {
-  font-size: var(--smallFontSize);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
+.entity-info-subtype .radioset {
+  display: inline-block;
 }
 
 button.entity-info-edit {
@@ -164,7 +161,7 @@ button.entity-info-edit {
 .entity-info-formula {
   display: inline;
   overflow-wrap: break-word;
-  
+
   &::after {
     content: '; ';
   }
@@ -195,4 +192,19 @@ button.entity-info-edit {
 .entity-info-assoc-button {
   display: inline-block;
   height: auto;
+}
+
+.entity-info-organism-refinement,
+.entity-info-subtype {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.entity-info-assoc-refinement .entity-info-section {
+  margin: 0.75em 0;
+}
+
+.entity-info-organism-dropdown {
+  width: 20em;
 }


### PR DESCRIPTION
Changes:

- The wording and salience of the grounding revision button have been revised.
- A (rare) grounding with an empty synonym list has "-" shown instead of whitespace.
- Allow specifying the grounding by organism dropdown.  This turned out to be a smaller change than expected, so I'm including it here.

Ref : User testing: Entity grounding #550

-- 

Preview:

![beam11](https://user-images.githubusercontent.com/989043/67032703-21b07b80-f0e2-11e9-8dea-fc5014a10cdb.gif)
