### PR TITLE
Module for searching pubmed

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ export const CHEBI_LINK_BASE_URL = env('CHEBI_LINK_BASE_URL', 'https://www.ebi.a
 export const PUBCHEM_LINK_BASE_URL = env('PUBCHEM_LINK_BASE_URL', 'https://pubchem.ncbi.nlm.nih.gov/compound/');
 export const NCBI_LINK_BASE_URL = env('NCBI_LINK_BASE_URL', 'https://www.ncbi.nlm.nih.gov/gene/');
 export const PUBMED_LINK_BASE_URL = env('PUBMED_LINK_BASE_URL', 'https://www.ncbi.nlm.nih.gov/pubmed/');
+export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
 
 // Email
 export const EMAIL_ENABLED = env('EMAIL_ENABLED', false);

--- a/src/config.js
+++ b/src/config.js
@@ -47,6 +47,7 @@ export const PUBCHEM_LINK_BASE_URL = env('PUBCHEM_LINK_BASE_URL', 'https://pubch
 export const NCBI_LINK_BASE_URL = env('NCBI_LINK_BASE_URL', 'https://www.ncbi.nlm.nih.gov/gene/');
 export const PUBMED_LINK_BASE_URL = env('PUBMED_LINK_BASE_URL', 'https://www.ncbi.nlm.nih.gov/pubmed/');
 export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
+export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', '');
 
 // Email
 export const EMAIL_ENABLED = env('EMAIL_ENABLED', false);

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -1,3 +1,4 @@
-import fetchPubmed from './fetchPubmed';
+import { fetchPubmed } from './fetchPubmed';
+import { searchPubmed } from './searchPubmed';
 
-module.exports = { fetchPubmed };
+module.exports = { fetchPubmed, searchPubmed };

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -1,0 +1,20 @@
+// import _ from 'lodash';
+// import queryString from 'query-string';
+
+// import { NCBI_EUTILS_BASE_URL } from '../../../../../config';
+
+// const EUTILS_SEARCH_URL = NCBI_EUTILS_BASE_URL + 'esearch.fcgi';
+// const DEFAULT_ESEARCH_PARAMS = {
+//   db: 'pubmed',
+//   usehistory: 'y',
+//   retmode: 'json',
+//   term: undefined
+// };
+
+const pubmedDataConverter = json => json;
+
+const eSearchPubmed = term => term;
+
+const searchPubmed = q => eSearchPubmed( q );
+
+export { searchPubmed, pubmedDataConverter };

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -1,17 +1,32 @@
-// import _ from 'lodash';
+import _ from 'lodash';
 // import queryString from 'query-string';
 
 // import { NCBI_EUTILS_BASE_URL } from '../../../../../config';
 
 // const EUTILS_SEARCH_URL = NCBI_EUTILS_BASE_URL + 'esearch.fcgi';
 // const DEFAULT_ESEARCH_PARAMS = {
+//   term: undefined,
 //   db: 'pubmed',
-//   usehistory: 'y',
+//   rettype: 'uilist'
 //   retmode: 'json',
-//   term: undefined
+//   retmax: 10,
+//   usehistory: 'y',
+//   field: undefined
 // };
 
-const pubmedDataConverter = json => json;
+const pubmedDataConverter = json => {
+
+  const esearchresult =  _.get( json, ['esearchresult'] );
+
+  const data = {
+    searchHits: _.get( esearchresult, ['idlist'], [] ),
+    count: _.parseInt( _.get( esearchresult, ['count'], '0' ) ),
+    query_key: _.get( esearchresult, ['querykey'], null ),
+    webenv: _.get( esearchresult, ['webenv'], null )
+  };
+
+  return data;
+};
 
 const eSearchPubmed = term => term;
 

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import queryString from 'query-string';
 import fetch from 'node-fetch';
 
-import { NCBI_EUTILS_BASE_URL } from '../../../../../config';
+import { NCBI_EUTILS_BASE_URL, NCBI_EUTILS_API_KEY } from '../../../../../config';
 
 const EUTILS_SEARCH_URL = NCBI_EUTILS_BASE_URL + 'esearch.fcgi';
 const DEFAULT_ESEARCH_PARAMS = {
@@ -12,7 +12,8 @@ const DEFAULT_ESEARCH_PARAMS = {
   retmode: 'json',
   retmax: 10,
   usehistory: 'y',
-  field: undefined
+  field: undefined,
+  api_key: NCBI_EUTILS_API_KEY
 };
 
 const pubmedDataConverter = json => {
@@ -38,11 +39,11 @@ const eSearchPubmed = term => {
 /**
  * searchPubmed
  * Query the PubMed database for matching UIDs.
- * 
+ *
  * @param { String } q The query term
  * @returns { Object } result The search results from PubMed
  * @returns { Array } result.searchHits A list of PMIDs
- * @returns { Number } result.count The number of searchHits containing PMIDs 
+ * @returns { Number } result.count The number of searchHits containing PMIDs
  * @returns { String } result.query_key See {@link https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch|EUTILS docs }
  * @returns { String } result.webenv See {@link https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch|EUTILS docs }
  */

--- a/test/pubmed/searchPubmed.js
+++ b/test/pubmed/searchPubmed.js
@@ -1,0 +1,43 @@
+import _ from 'lodash';
+import fs from 'fs';
+import path from 'path';
+import { expect } from 'chai';
+
+import { pubmedDataConverter } from '../../src/server/routes/api/document/pubmed/searchPubmed';
+import searchPubmedData from './searchPubmedData';
+
+const TEST_PUBMED_DATA = new Map( _.entries( searchPubmedData ) );
+
+describe('searchPubmed', function(){
+
+  for( const [ query, response ] of TEST_PUBMED_DATA.entries() ) {
+
+    describe('pubmedDataConverter', function(){
+
+      let pubmedInfo;
+
+      before( async () => {
+        pubmedInfo = await pubmedDataConverter( response );
+      });
+
+      after( () => {
+      });
+
+      it('Should return a result', () => {
+        expect( pubmedInfo ).to.exist;
+      });
+
+      it('Should contain top-level attributes', () => {
+        // expect( pubmedInfo ).to.have.property( 'PubmedArticleSet' );
+      });
+
+      // describe( 'PubmedArticleSet', () => {});
+
+        
+
+    }); // pubmedDataConverter
+
+  }; // endfor
+
+}); // searchPubmed
+

--- a/test/pubmed/searchPubmed.js
+++ b/test/pubmed/searchPubmed.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { expect } from 'chai';
 
-import { pubmedDataConverter } from '../../src/server/routes/api/document/pubmed/searchPubmed';
+import { searchPubmed, pubmedDataConverter } from '../../src/server/routes/api/document/pubmed/searchPubmed';
 import searchPubmedData from './searchPubmedData';
 
 const TEST_PUBMED_DATA = new Map( _.entries( searchPubmedData ) );
@@ -140,6 +140,18 @@ describe('searchPubmed', function(){
     }); // nonunique term
 
   }); // pubmedDataConverter
+
+  // describe('searchPubmed', function(){
+  //   let pubmedInfo;
+  //   before( async () => {
+  //     pubmedInfo = await searchPubmed( 'GDF15 expression.' );
+  //   });
+
+  //   it( 'should return live data', async ()=> {
+  //     expect( pubmedInfo ).to.exist;
+  //     console.log( JSON.stringify(pubmedInfo,null,2) );
+  //   });
+  // });
 
 }); // searchPubmed
 

--- a/test/pubmed/searchPubmed.js
+++ b/test/pubmed/searchPubmed.js
@@ -1,43 +1,145 @@
 import _ from 'lodash';
-import fs from 'fs';
-import path from 'path';
 import { expect } from 'chai';
 
 import { pubmedDataConverter } from '../../src/server/routes/api/document/pubmed/searchPubmed';
 import searchPubmedData from './searchPubmedData';
 
 const TEST_PUBMED_DATA = new Map( _.entries( searchPubmedData ) );
+const DEFAULT_ESEARCH_PARAMS = {
+  db: 'pubmed',
+  rettype: 'uilist',
+  retmode: 'json',
+  retmax: 10,
+  usehistory: 'y',
+  field: undefined
+};
 
 describe('searchPubmed', function(){
+  
+  describe('pubmedDataConverter', function(){
+    
+    describe( 'undefined term', () => {
 
-  for( const [ query, response ] of TEST_PUBMED_DATA.entries() ) {
-
-    describe('pubmedDataConverter', function(){
-
-      let pubmedInfo;
-
+      let pubmedInfo; 
+      const queryType = 'undefined_term';
+      const json = TEST_PUBMED_DATA.get( queryType );
+      
       before( async () => {
-        pubmedInfo = await pubmedDataConverter( response );
-      });
-
-      after( () => {
+        pubmedInfo = await pubmedDataConverter( json );
       });
 
       it('Should return a result', () => {
         expect( pubmedInfo ).to.exist;
       });
-
+  
       it('Should contain top-level attributes', () => {
-        // expect( pubmedInfo ).to.have.property( 'PubmedArticleSet' );
+        expect( pubmedInfo ).to.have.property( 'count' );
+        expect( pubmedInfo ).to.have.property( 'searchHits' );
+        expect( pubmedInfo ).to.have.property( 'query_key' );
+        expect( pubmedInfo ).to.have.property( 'webenv' );
       });
 
-      // describe( 'PubmedArticleSet', () => {});
+      it('Should have correct top-level values', () => {
+        expect( pubmedInfo.count ).to.equal( 0 );
+        expect( pubmedInfo.searchHits ).to.be.empty;
+        expect( pubmedInfo.query_key ).to.be.a('null');
+        expect( pubmedInfo.webenv ).to.be.a('null');
+      });
+  
+    }); // empty term
 
-        
+    describe( 'empty term', () => {
 
-    }); // pubmedDataConverter
+      let pubmedInfo; 
+      const queryType = 'empty_term';
+      const json = TEST_PUBMED_DATA.get( queryType );
+      
+      before( async () => {
+        pubmedInfo = await pubmedDataConverter( json );
+      });
 
-  }; // endfor
+      it('Should return a result', () => {
+        expect( pubmedInfo ).to.exist;
+      });
+  
+      it('Should contain top-level attributes', () => {
+        expect( pubmedInfo ).to.have.property( 'count' );
+        expect( pubmedInfo ).to.have.property( 'searchHits' );
+        expect( pubmedInfo ).to.have.property( 'query_key' );
+        expect( pubmedInfo ).to.have.property( 'webenv' );
+      });
+
+      it('Should have correct top-level values', () => {
+        expect( pubmedInfo.count ).to.equal( 0 );
+        expect( pubmedInfo.searchHits ).to.be.empty;
+        expect( pubmedInfo.query_key ).to.not.be.a('null');
+        expect( pubmedInfo.webenv ).to.not.be.a('null');
+      });
+  
+    }); // empty term
+
+    describe( 'unique term', () => {
+
+      let pubmedInfo; 
+      const queryType = 'unique_term';
+      const json = TEST_PUBMED_DATA.get( queryType );
+      
+      before( async () => {
+        pubmedInfo = await pubmedDataConverter( json );
+      });
+
+      it('Should return a result', () => {
+        expect( pubmedInfo ).to.exist;
+      });
+  
+      it('Should contain top-level attributes', () => {
+        expect( pubmedInfo ).to.have.property( 'count' );
+        expect( pubmedInfo ).to.have.property( 'searchHits' );
+        expect( pubmedInfo ).to.have.property( 'query_key' );
+        expect( pubmedInfo ).to.have.property( 'webenv' );
+      });
+
+      it('Should have correct top-level values', () => {
+        expect( pubmedInfo.count ).to.equal( 1 );
+        expect( pubmedInfo.searchHits ).to.have.lengthOf( 1 );
+        expect( pubmedInfo.query_key ).to.not.be.a('null');
+        expect( pubmedInfo.webenv ).to.not.be.a('null');
+      });
+  
+    }); // unique term
+
+
+    describe( 'nonunique term', () => {
+
+      let pubmedInfo; 
+      const queryType = 'nonunique_term';
+      const json = TEST_PUBMED_DATA.get( queryType );
+      
+      before( async () => {
+        pubmedInfo = await pubmedDataConverter( json );
+      });
+
+      it('Should return a result', () => {
+        expect( pubmedInfo ).to.exist;
+      });
+  
+      it('Should contain top-level attributes', () => {
+        expect( pubmedInfo ).to.have.property( 'count' );
+        expect( pubmedInfo ).to.have.property( 'searchHits' );
+        expect( pubmedInfo ).to.have.property( 'query_key' );
+        expect( pubmedInfo ).to.have.property( 'webenv' );
+      });
+
+      it('Should have correct top-level values', () => {
+        expect( pubmedInfo.count ).to.be.greaterThan( DEFAULT_ESEARCH_PARAMS.retmax );
+        expect( pubmedInfo.searchHits ).to.have.lengthOf( DEFAULT_ESEARCH_PARAMS.retmax );
+        expect( pubmedInfo.query_key ).to.not.be.a('null');
+        expect( pubmedInfo.webenv ).to.not.be.a('null');
+      });
+  
+    }); // nonunique term
+
+  }); // pubmedDataConverter
 
 }); // searchPubmed
 

--- a/test/pubmed/searchPubmedData.js
+++ b/test/pubmed/searchPubmedData.js
@@ -1,0 +1,124 @@
+export default {
+  
+  "undefined_term": {
+    "header": {
+      "type": "esearch",
+      "version": "0.3"
+    },
+    "esearchresult": {
+      "ERROR": "Empty term and query_key - nothing todo"
+    }
+  },
+
+  "empty_term": {
+    "header": {
+      "type": "esearch",
+      "version": "0.3"
+    },
+    "esearchresult": {
+      "count": "0",
+      "retmax": "0",
+      "retstart": "0",
+      "querykey": "1",
+      "webenv": "NCID_1_108897549_130.14.18.48_9001_1572460137_1278172449_0MetA0_S_MegaStore",
+      "idlist": [
+      ],
+      "translationset": [
+      ],
+      "querytranslation": "(''[All Fields])",
+      "errorlist": {
+        "phrasesnotfound": [
+          "''"
+        ],
+        "fieldsnotfound": [
+        ]
+      },
+      "warninglist": {
+        "phrasesignored": [
+        ],
+        "quotedphrasesnotfound": [
+        ],
+        "outputmessages": [
+          "No items found."
+        ]
+      }
+    }
+  },
+
+  "unique_result": {
+    "header": {
+      "type": "esearch",
+      "version": "0.3"
+    },
+    "esearchresult": {
+      "count": "1",
+      "retmax": "1",
+      "retstart": "0",
+      "querykey": "1",
+      "webenv": "NCID_1_109057525_130.14.22.76_9001_1572460357_1321674198_0MetA0_S_MegaStore",
+      "idlist": [
+        "29440426"
+      ],
+      "translationset": [
+      ],
+      "translationstack": [
+        {
+          "term": "29440426[UID]",
+          "field": "UID",
+          "count": "-1",
+          "explode": "N"
+        },
+        "GROUP"
+      ],
+      "querytranslation": "29440426[UID]"
+    }
+  },
+
+  "nonunique_result": {
+    "header": {
+      "type": "esearch",
+      "version": "0.3"
+    },
+    "esearchresult": {
+      "count": "97451",
+      "retmax": "20",
+      "retstart": "0",
+      "querykey": "1",
+      "webenv": "NCID_1_187829384_130.14.22.33_9001_1572460399_412420505_0MetA0_S_MegaStore",
+      "idlist": [
+        "31661692",
+        "31661126",
+        "31659693",
+        "31659281",
+        "31659245",
+        "31659152",
+        "31659107",
+        "31658995",
+        "31658727",
+        "31658318",
+        "31657880",
+        "31657556",
+        "31657162",
+        "31657074",
+        "31656929",
+        "31656277",
+        "31656084",
+        "31656006",
+        "31655998",
+        "31655030"
+      ],
+      "translationset": [
+      ],
+      "translationstack": [
+        {
+          "term": "p53[All Fields]",
+          "field": "All Fields",
+          "count": "97452",
+          "explode": "N"
+        },
+        "GROUP"
+      ],
+      "querytranslation": "p53[All Fields]"
+    }
+  }
+}

--- a/test/pubmed/searchPubmedData.js
+++ b/test/pubmed/searchPubmedData.js
@@ -45,7 +45,7 @@ export default {
     }
   },
 
-  "unique_result": {
+  "unique_term": {
     "header": {
       "type": "esearch",
       "version": "0.3"
@@ -74,7 +74,7 @@ export default {
     }
   },
 
-  "nonunique_result": {
+  "nonunique_term": {
     "header": {
       "type": "esearch",
       "version": "0.3"
@@ -95,17 +95,7 @@ export default {
         "31659107",
         "31658995",
         "31658727",
-        "31658318",
-        "31657880",
-        "31657556",
-        "31657162",
-        "31657074",
-        "31656929",
-        "31656277",
-        "31656084",
-        "31656006",
-        "31655998",
-        "31655030"
+        "31658318"
       ],
       "translationset": [
       ],


### PR DESCRIPTION
Wrapper for NCBI EUTILS search of PubMed database.

- input: a 'term', which is any text
- output: 
  - `searchHits`: List of UIDs
  - `count`
  - `web_env` and `query_key` useful for retrieving those UID record(s)

Refs #570, Part 2.