### PR TITLE
Wrapper to Efetch from Pubmed 

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -47,7 +47,7 @@ export const PUBCHEM_LINK_BASE_URL = env('PUBCHEM_LINK_BASE_URL', 'https://pubch
 export const NCBI_LINK_BASE_URL = env('NCBI_LINK_BASE_URL', 'https://www.ncbi.nlm.nih.gov/gene/');
 export const PUBMED_LINK_BASE_URL = env('PUBMED_LINK_BASE_URL', 'https://www.ncbi.nlm.nih.gov/pubmed/');
 export const NCBI_EUTILS_BASE_URL = env('NCBI_EUTILS_BASE_URL', 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/');
-export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', '');
+export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815a7a99f18403aab08008');
 
 // Email
 export const EMAIL_ENABLED = env('EMAIL_ENABLED', false);


### PR DESCRIPTION
- Simple wrapper for EFETCH from NCBI  EUTILS. Pipts result to existing JSON converter. 
- Using the development `NCBI_API_KEY` from app-ui into config, otherwise we'll have to put this as env variable in development...