### PR TITLE
Error in api/document GET returning json list of docs

### DIFF
--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -405,7 +405,7 @@ class Document {
       secret: this.secret(),
       title: this.title(),
       summary: this.toText(),
-      organisms: this.organisms().map( toJson ),
+      organisms: this.organisms(),
       elements: this.elements().map( toJson ),
       publicUrl: this.publicUrl(),
       privateUrl: this.privateUrl(),


### PR DESCRIPTION
I believe the document `organisms` function just returns a list of strings.
Refs #577 