### PR TITLE
Support for the journal name abbreviation, if available.

### DIFF
--- a/src/server/routes/api/document/pubmed/fetchPubmed.js
+++ b/src/server/routes/api/document/pubmed/fetchPubmed.js
@@ -105,7 +105,7 @@ const getJournal = Article => {
   const Journal = _.get( Article, ['Journal', '0'] );
   const Title = _.get( Journal, ['Title', '0'], null );
   const ISSN = _.get( Journal, ['ISSN', '0', '_' ], null );
-
+  const ISOAbbreviation = _.get( Journal, ['ISOAbbreviation', '0'], null );
   //<!ELEMENT	JournalIssue (Volume?, Issue?, PubDate) >
   const JournalIssue = _.get( Journal, ['JournalIssue', '0'] );
   const Volume = _.get( JournalIssue, ['Volume', '0'], null );
@@ -117,7 +117,8 @@ const getJournal = Article => {
     Volume,
     Issue,
     PubDate,
-    ISSN
+    ISSN,
+    ISOAbbreviation
   };
 };
 

--- a/test/pubmed/fetchPubmed.js
+++ b/test/pubmed/fetchPubmed.js
@@ -90,6 +90,7 @@ describe('fetchPubmed', function(){
                 expect( Journal ).to.have.property( 'Issue' );
                 expect( Journal ).to.have.property( 'PubDate' );
                 expect( Journal ).to.have.property( 'ISSN' );
+                expect( Journal ).to.have.property( 'ISOAbbreviation' );
               });
             });
 


### PR DESCRIPTION
Make available the journal name abbreviation, so we can display 'Mol Cel' instead of 'Molecular Cell'.