### PR TITLE
A pubmed service wrapper 

### DIFF
--- a/src/server/routes/api/document/pubmed/demoPubmedArticle.js
+++ b/src/server/routes/api/document/pubmed/demoPubmedArticle.js
@@ -1,0 +1,277 @@
+export default {
+  "MedlineCitation": {
+    "Article": {
+      "Journal": {
+        "Title": "Journal of Example",
+        "Volume": "1",
+        "Issue": "1",
+        "PubDate": {
+          "Year": "2019",
+          "Month": "Jan",
+          "Day": "01"
+        },
+        "ISSN": "0000-0000",
+        "ISOAbbreviation": "J. Example"
+      },
+      "ArticleTitle": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+      "Abstract": [
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+      ],
+      "AuthorList": [
+        {
+          "LastName": "Doe",
+          "ForeName": "Jane",
+          "Initials": "A",
+          "CollectiveName": null,
+          "AffiliationInfo": [
+            {
+              "Affiliation": "Centre for Medical Research, Research Institute, City, Country.",
+              "email": null
+            }
+          ],
+          "Identifier": null
+        },
+        {
+          "LastName": "Doe",
+          "ForeName": "Jon",
+          "Initials": "A",
+          "CollectiveName": null,
+          "AffiliationInfo": [
+            {
+              "Affiliation": "Centre for Medical Research, Research Institute, City, Country.",
+              "email": null
+            }
+          ],
+          "Identifier": null
+        },
+        {
+          "LastName": "Public",
+          "ForeName": "Joseph",
+          "Initials": "E",
+          "CollectiveName": null,
+          "AffiliationInfo": [
+            {
+              "Affiliation": "Centre for Medical Research, Research Institute, City, Country.",
+              "email": "jepublic@example.com"
+            }
+          ],
+          "Identifier": null
+        }
+      ]
+    },
+    "ChemicalList": [
+      {
+        "RegistryNumber": "0",
+        "NameOfSubstance": "DNA-Binding Proteins"
+      },
+      {
+        "RegistryNumber": "0",
+        "NameOfSubstance": "PLAG1 protein, human"
+      },
+      {
+        "RegistryNumber": "EC 1.4.1.2",
+        "NameOfSubstance": "Glutamate Dehydrogenase"
+      },
+      {
+        "RegistryNumber": "EC 2.7.1.-",
+        "NameOfSubstance": "STK11 protein, human"
+      },
+      {
+        "RegistryNumber": "EC 2.7.11.1",
+        "NameOfSubstance": "Protein-Serine-Threonine Kinases"
+      },
+      {
+        "RegistryNumber": "EC 2.7.11.17",
+        "NameOfSubstance": "CAMKK2 protein, human"
+      },
+      {
+        "RegistryNumber": "EC 2.7.11.17",
+        "NameOfSubstance": "Calcium-Calmodulin-Dependent Protein Kinase Kinase"
+      },
+      {
+        "RegistryNumber": "EC 2.7.11.31",
+        "NameOfSubstance": "AMP-Activated Protein Kinases"
+      }
+    ],
+    "KeywordList": [
+      "AMPKa",
+      "CamKK2",
+      "GLUD1",
+      "LKB1 deficient",
+      "anoikis",
+      "metastasis"
+    ],
+    "MeshheadingList": [
+      {
+        "DescriptorName": "A549 Cells",
+        "ID": "D000072283",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "AMP-Activated Protein Kinases",
+        "ID": "D055372",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Animals",
+        "ID": "D000818",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Anoikis",
+        "ID": "D023102",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Calcium-Calmodulin-Dependent Protein Kinase Kinase",
+        "ID": "D054737",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Cell Line, Tumor",
+        "ID": "D045744",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "DNA-Binding Proteins",
+        "ID": "D004268",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Enzyme Activation",
+        "ID": "D004789",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Female",
+        "ID": "D005260",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Glutamate Dehydrogenase",
+        "ID": "D005969",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "HEK293 Cells",
+        "ID": "D057809",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Humans",
+        "ID": "D006801",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Lung Neoplasms",
+        "ID": "D008175",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Mice",
+        "ID": "D051379",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Mice, Inbred NOD",
+        "ID": "D016688",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Mice, Nude",
+        "ID": "D008819",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Mice, SCID",
+        "ID": "D016513",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Neoplasm Metastasis",
+        "ID": "D009362",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Neoplasm Transplantation",
+        "ID": "D009368",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Protein-Serine-Threonine Kinases",
+        "ID": "D017346",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Small Cell Lung Carcinoma",
+        "ID": "D055752",
+        "isMajorTopicYN": false
+      },
+      {
+        "DescriptorName": "Transplantation, Heterologous",
+        "ID": "D014183",
+        "isMajorTopicYN": false
+      }
+    ],
+    "InvestigatorList": null
+  },
+  "PubmedData": {
+    "History": [
+      {
+        "PubStatus": "received",
+        "PubMedPubDate": {
+          "Year": "2019",
+          "Month": "01",
+          "Day": "01"
+        }
+      },
+      {
+        "PubStatus": "accepted",
+        "PubMedPubDate": {
+          "Year": "2019",
+          "Month": "01",
+          "Day": "01"
+        }
+      },
+      {
+        "PubStatus": "entrez",
+        "PubMedPubDate": {
+          "Year": "2019",
+          "Month": "01",
+          "Day": "01"
+        }
+      },
+      {
+        "PubStatus": "pubmed",
+        "PubMedPubDate": {
+          "Year": "2019",
+          "Month": "01",
+          "Day": "01"
+        }
+      },
+      {
+        "PubStatus": "medline",
+        "PubMedPubDate": {
+          "Year": "2019",
+          "Month": "01",
+          "Day": "01"
+        }
+      }
+    ],
+    "ArticleIdList": [
+      {
+        "IdType": "pubmed",
+        "id": "000000"
+      },
+      {
+        "IdType": "doi",
+        "id": "10.1038/s00000-000-0000-0"
+      },
+      {
+        "IdType": "pmc",
+        "id": "PMC0000000"
+      }
+    ],
+    "ReferenceList": null
+  }
+};

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -1,4 +1,69 @@
+import _ from 'lodash';
+import { URL } from 'url';
 import { fetchPubmed } from './fetchPubmed';
-import { searchPubmed } from './searchPubmed';
+import demoPubmedArticle from './demoPubmedArticle';
+//import { searchPubmed } from './searchPubmed';
 
-module.exports = { fetchPubmed, searchPubmed };
+import {
+  PUBMED_LINK_BASE_URL
+} from '../../../../../config';
+
+const digitsRegex = /^[0-9]+$/;
+
+const findPubmedId = paperId => {
+
+  let id;
+  if( !_.isString( paperId ) ) throw new TypeError( 'Unrecognized paperId' );
+  const isUidLike = digitsRegex.test( paperId );
+  const isPubMedUrlLike = paperId.startsWith( PUBMED_LINK_BASE_URL );
+
+  if( isUidLike ){
+    id = paperId;
+
+  } else if( isPubMedUrlLike ){
+    const pubmedUrl = new URL( PUBMED_LINK_BASE_URL );
+    const providedUrl = new URL( paperId );
+
+    const isSameHost = providedUrl.hostname === pubmedUrl.hostname;
+    const pathUidMatchResult = providedUrl.pathname.match( /^\/pubmed\/(?<uid>\d+)$/ );
+    const hasPathMatch = !_.isNull( pathUidMatchResult );
+
+    if( isSameHost && hasPathMatch ){
+      const { groups: { uid } } = pathUidMatchResult;
+      id = uid;
+    }
+  } else {
+    throw new TypeError( 'Unrecognized paperId' );
+  }
+
+  return id;
+};
+
+/**
+ * getPubmedRecord
+ * 
+ * Retrieve a single PubmedArticle. Shall interpret an input as either: 
+ *   - A set of digits 
+ *   - A url 
+ *     - Containing a set of digits e.g. 'https://www.ncbi.nlm.nih.gov/pubmed/123456'
+ *     - A search returning a single PubMed UID 
+ * 
+ * @param {String} paperId Contains or references a single PubMed uid (see above). If 'demo' return canned demo data.
+ * @return {Object} The unique PubMedArticle (see [NLM DTD]{@link https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd} )
+ * @throws {TypeError} When paperId falls outside of the above cases
+ */
+const getPubmedArticle = async paperId => { 
+  if( paperId === 'demo' ) return demoPubmedArticle;
+  const candidateId = findPubmedId( paperId );
+  const { PubmedArticleSet } = await fetchPubmed({
+    uids: [ candidateId ]
+  });
+
+  if( !_.isEmpty( PubmedArticleSet ) ){
+    return _.head( PubmedArticleSet );
+  } else {
+    throw new Error( `No PubMed record for ${paperId}` );
+  }
+};
+
+export { getPubmedArticle }; 

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -25,12 +25,11 @@ const findPubmedId = async paperId => {
     const paperIdUrl = new URL( paperId );
     const isSameHost = paperIdUrl.hostname === pubmedUrl.hostname;
     
-    const pathUidMatchResult = paperIdUrl.pathname.match( /^\/pubmed\/(?<uid>\d+)$/ );
+    const pathUidMatchResult = paperIdUrl.pathname.match( /^\/pubmed\/(\d+)$/ );
     const paperIdUrlSearchTerm = paperIdUrl.searchParams.get('term');
     
     if( isSameHost && !_.isNull( pathUidMatchResult ) ){
-      const { groups: { uid } } = pathUidMatchResult;
-      id = uid;
+      id = pathUidMatchResult[1];
       
     } else if( isSameHost && paperIdUrlSearchTerm ) {
       const { searchHits, count } = await searchPubmed( paperIdUrlSearchTerm );


### PR DESCRIPTION
Expose `getPubmedArticle` that takes a `paperId` (e.g. signup). Tries to figure out if there's a Pubmed UID in the input and return the PubmedArticle metadata. 
  - Case 1: Demo, where input is exactly `demo`
  - Case 2: Numeric input, like a UID  e.g. '29249655'
  - Case 3: URL-like input starting with `https://www.ncbi.nlm.nih.gov/pubmed/`
    - a: Contains numeric item in path  e.g. `https://www.ncbi.nlm.nih.gov/pubmed/29249655`
    - b: Contains `term` URL search parameter with unique Pubmed Search result  
      - e.g. `https://www.ncbi.nlm.nih.gov/pubmed/?term=CtIP-Mediated+Fork+Protection+Synergizes+with+BRCA1+to+Suppress+Genomic+Instability+upon+DNA+Replication+Stress` 
      - e.g. `https://www.ncbi.nlm.nih.gov/pubmed/?term=30344097`


refs #570 
  