### PR TITLE
Doc navigation: Filtering by Document 'status'

### DIFF
--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -367,7 +367,7 @@ class DocumentManagement extends DirtyComponent {
             name: `document-status-filter`,
             id: `document-status-filter-checkbox-${statusVal}`,
             value: statusVal,
-            defaultChecked: _.includes( DEFAULT_STATUS_FIELDS, statusVal ),
+            defaultChecked: _.includes( this.state.status, statusVal ),
             onChange: e => this.handleStatusChange(e)
           }),
           h('label', {

--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -294,14 +294,14 @@ class DocumentManagement extends DirtyComponent {
             doc,
             type: CORRESPONDENCE_INVITE_TYPE,
             label: _.capitalize( CORRESPONDENCE_INVITE_TYPE ),
-            disableWhen: doc.requested() || doc.trashed() || doc.submitted(),
+            disableWhen: doc.requested(),
             apiKey: this.state.apiKey
           }),
           h( EmailButtton, {
             doc,
             type: CORRESPONDENCE_FOLLOWUP_TYPE,
             label: _.upperFirst( CORRESPONDENCE_FOLLOWUP_TYPE.replace(/([A-Z])/g, (match, letter) => '-' + letter) ),
-            disableWhen: doc.requested() || doc.trashed() || !doc.submitted(),
+            disableWhen: doc.requested(),
             apiKey: this.state.apiKey
           })
         ]);

--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -159,6 +159,28 @@ class DocumentManagement extends DirtyComponent {
         }, 'Submit' )
       ]);
 
+    // const hideMenu = h('select.entity-info-organism-dropdown', {
+    //   defaultValue: selectedIndex,
+    //   onChange: e => {
+    //     const val = e.target.value;
+    //     const index = parseInt(val);
+    //     const om = orgMatches[index];
+
+    //     if( om ){
+    //       this.associate(om);
+    //     } else {
+    //       this.enableManualMatchMode();
+    //     }
+    //   }
+    // }, orgMatches.map((om, index) => {
+    //   const value = index;
+
+    //   return h('option', { value }, getSelectDisplay(om));
+    // }).concat([
+    //   selectedIndex < 0 ? h('option', { value: -1 }, getSelectDisplay(m, true)) : null,
+    //   h('option', { value: -2 }, 'Other')
+    // ]));
+
     // Document Header & Footer
     const getDocumentHeader = doc => {
       return h( 'div.document-management-document-section.meta', [

--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -84,13 +84,13 @@ class DocumentManagement extends DirtyComponent {
       .catch( () => {} ); //swallow
   }
 
-  getUrlParams( opts ){
-    const { apiKey, status } = _.defaultsDeep( {}, opts, _.pick( this.state, ['apiKey', 'status'] ) );
+  getUrlParams(){
+    const { apiKey, status } = this.state;
     return queryString.stringify( { apiKey, status: status.join(',') } );
   }
 
-  updateUrlParams( opts ){
-    const urlParams = this.getUrlParams( opts );
+  updateUrlParams(){
+    const urlParams = this.getUrlParams();
     this.props.history.push(`/document?${urlParams}`);
   }
 

--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -294,14 +294,14 @@ class DocumentManagement extends DirtyComponent {
             doc,
             type: CORRESPONDENCE_INVITE_TYPE,
             label: _.capitalize( CORRESPONDENCE_INVITE_TYPE ),
-            disableWhen: doc.requested(),
+            disableWhen: doc.requested() || doc.trashed(),
             apiKey: this.state.apiKey
           }),
           h( EmailButtton, {
             doc,
             type: CORRESPONDENCE_FOLLOWUP_TYPE,
             label: _.upperFirst( CORRESPONDENCE_FOLLOWUP_TYPE.replace(/([A-Z])/g, (match, letter) => '-' + letter) ),
-            disableWhen: doc.requested(),
+            disableWhen: doc.requested() || doc.trashed(),
             apiKey: this.state.apiKey
           })
         ]);

--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -302,7 +302,7 @@ class DocumentManagement extends DirtyComponent {
     // Status
     const getDocumentStatus = doc => {
       let radios = [];
-      let DOCUMENT_STATUS_FIELDS = doc.statusFields();
+      let DOCUMENT_STATUS_FIELDS = Document.statusFields();
       let addType = (typeVal, displayName) => {
         radios.push(
           h('input', {

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -394,7 +394,7 @@ class Document {
     }
   }
 
-  statusFields(){ return DOCUMENT_STATUS_FIELDS; }
+  static statusFields(){ return DOCUMENT_STATUS_FIELDS; }
   request(){ return this.status( DOCUMENT_STATUS_FIELDS.REQUESTED ); }
   requested(){ return this.status() === DOCUMENT_STATUS_FIELDS.REQUESTED ? true : false; }
   approve(){ return this.status( DOCUMENT_STATUS_FIELDS.APPROVED ); }

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -165,17 +165,18 @@ http.post('/email', function( req, res, next ){
 // - offset: pagination offset
 // - limit: pagination size limit
 // - apiKey: to authorise doc creation
-// - status: only get docs based on Document.statusFields(); no submission filtering on unspecified
+// - omit: exclude docs bearing the specified Document status fields
 // - ids: only get the docs for the specified comma-separated list of ids (disables pagination)
 http.get('/', function( req, res, next ){
-  let { limit, offset, apiKey, status } = Object.assign({
+  let { limit, offset, apiKey, omit } = Object.assign({
     limit: 50,
     offset: 0
   }, req.query);
 
   let ids = req.query.ids ? req.query.ids.split(/\s*,\s*/) : null;
+
   const DOCUMENT_STATUS_FIELDS = Document.statusFields();
-  status = _.get( DOCUMENT_STATUS_FIELDS, status, null );
+  omit = _.get( DOCUMENT_STATUS_FIELDS, omit, null );
 
   let tables;
 
@@ -205,8 +206,8 @@ http.get('/', function( req, res, next ){
         q = q.skip(offset).limit(limit);
       }
 
-      if( status != null ){
-        q = q.filter( r.row('status').eq(status) );
+      if( omit != null ){
+        q = q.filter( r.row('status').ne(omit) );
       }
 
       q = ( q

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -165,18 +165,17 @@ http.post('/email', function( req, res, next ){
 // - offset: pagination offset
 // - limit: pagination size limit
 // - apiKey: to authorise doc creation
-// - submitted: only get submitted docs if true, only get unsubmitted docs if false, no submission filtering on unspecified
+// - status: only get docs based on Document.statusFields(); no submission filtering on unspecified
 // - ids: only get the docs for the specified comma-separated list of ids (disables pagination)
 http.get('/', function( req, res, next ){
-  let { limit, offset, apiKey, submitted } = Object.assign({
+  let { limit, offset, apiKey, status } = Object.assign({
     limit: 50,
     offset: 0
   }, req.query);
 
-  // cast to bool
-  submitted = submitted == 'true' ? true : (submitted == 'false' ? false : null);
-
   let ids = req.query.ids ? req.query.ids.split(/\s*,\s*/) : null;
+  const DOCUMENT_STATUS_FIELDS = Document.statusFields();
+  status = _.get( DOCUMENT_STATUS_FIELDS, status, null );
 
   let tables;
 
@@ -206,12 +205,8 @@ http.get('/', function( req, res, next ){
         q = q.skip(offset).limit(limit);
       }
 
-      if( submitted != null ){
-        if( submitted ){
-          q = q.filter( r.row('submitted').eq(true) );
-        } else {
-          q = q.filter( r.row('submitted').eq(false) );
-        }
+      if( status != null ){
+        q = q.filter( r.row('status').eq(status) );
       }
 
       q = ( q

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -177,7 +177,10 @@ http.get('/', function( req, res, next ){
 
   let ids = req.query.ids ? req.query.ids.split(/\s*,\s*/) : null;
 
-  const status = req.query.status ? req.query.status.split(/\s*,\s*/) : null;
+  let status;
+  if( _.has( req.query, 'status' ) ){
+    status = _.compact( req.query.status.split(/\s*,\s*/) );
+  }
 
   let tables;
 
@@ -207,12 +210,12 @@ http.get('/', function( req, res, next ){
         q = q.skip(offset).limit(limit);
       }
 
-      if( status != null ){
+      if( status ){
         const values =  _.intersection( _.values( DOCUMENT_STATUS_FIELDS ), status );
-        let byStatus = r;
+        let byStatus = { foo: true };
         values.forEach( ( value, index ) => {
           if( index == 0 ){
-            byStatus = byStatus.row('status').default('unset').eq( value );
+            byStatus = r.row('status').default('unset').eq( value );
           } else {
             byStatus = byStatus.or( r.row('status').default('unset').eq( value ) );
           }

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -208,7 +208,7 @@ http.get('/', function( req, res, next ){
       }
 
       if( status != null ){
-        const values =  _.compact( _.at( DOCUMENT_STATUS_FIELDS, status ) );
+        const values =  _.intersection( _.values( DOCUMENT_STATUS_FIELDS ), status );
         let byStatus = r;
         values.forEach( ( value, index ) => {
           if( index == 0 ){

--- a/src/styles/document-management.css
+++ b/src/styles/document-management.css
@@ -27,7 +27,7 @@
   }
 }
 
-.document-management-content {
+.document-management-document-container {
   width: 100%;
 
   & ul {


### PR DESCRIPTION
- Enable admin client to submit comma-separated list of `status` fields (e.g. 'submitted', 'trashed') to filter documents by
- Exposed the set of Document status values as static method 