### PR TITLE
Docker: Enable the BASE_URL to be configured at build time and run time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,12 @@
 FROM node:10.15.3
 
 # Allow user configuration of variable at build-time using --build-arg flag
+# See src/client-env-vars.json
 ARG NODE_ENV
+ARG BASE_URL
 
-# Initialize NODE_ENV and override with build-time flag, if set
+# Initialize environment and override with build-time flag, if set
+RUN test -n "$BASE_URL"
 ENV NODE_ENV ${NODE_ENV:-production}
 
 # Create an unprivileged user w/ home directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ARG NODE_ENV
 ARG BASE_URL
 
 # Initialize environment and override with build-time flag, if set
-RUN test -n "$BASE_URL"
 ENV NODE_ENV ${NODE_ENV:-production}
 
 # Create an unprivileged user w/ home directory

--- a/docker/.env
+++ b/docker/.env
@@ -1,6 +1,7 @@
 # Environment variables for Docker Compose services
 
 # webapp
+BASE_URL=
 FACTOID_IMAGE_TAG=unstable
 FACTOID_PORT=3000
 API_KEY=

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     ports:
       - "${FACTOID_PORT:-3000}:3000"
     environment:
+      BASE_URL:
       GROUNDING_SEARCH_BASE_URL: "http://grounding:3000"
       DB_HOST: "db"
       API_KEY:


### PR DESCRIPTION
Enable configuration of client and server `BASE_URL` environment variable. 
 
Related to #594.