### PR TITLE
Help page for missing/removed documents

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -78,7 +78,7 @@ export const EMAIL_TYPE_INVITE = env('EMAIL_TYPE_INVITE', 'invite');
 export const EMAIL_TYPE_FOLLOWUP = env('EMAIL_TYPE_FOLLOWUP', 'followUp');
 export const EMAIL_SUBJECT_INVITE = env('EMAIL_SUBJECT_INVITE', 'Your invitation to Biofactoid is ready');
 export const EMAIL_SUBJECT_FOLLOWUP = env('EMAIL_SUBJECT_FOLLOWUP', 'Thank you for sharing your research with Biofactoid');
-
+export const EMAIL_ADDRESS_INFO = env('EMAIL_ADDRESS_INFO', 'info@biofactoid.org');
 
 // Sharing
 export const DOCUMENT_IMAGE_WIDTH = env('DOCUMENT_IMAGE_WIDTH', 2400);

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -84,7 +84,7 @@ app.use(function(err, req, res) {
 
   switch( status ){
     case 404:
-      res.render('404');
+      res.render('404', { EMAIL_ADDRESS_INFO: config.EMAIL_ADDRESS_INFO });
       break;
     default:
       res.render('error');

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { getDocumentJson } from './api/document';
-import { TWITTER_ACCOUNT_NAME, BASE_URL } from '../../config';
+import { TWITTER_ACCOUNT_NAME, BASE_URL, EMAIL_ADDRESS_INFO } from '../../config';
 
 const http = express.Router();
 
@@ -12,6 +12,7 @@ const getDocumentPage = function(req, res) {
       TWITTER_ACCOUNT_NAME,
       BASE_URL
     }))
+    .catch( () => res.render( '404', { EMAIL_ADDRESS_INFO } ) )
   );
 };
 

--- a/src/views/404.ejs
+++ b/src/views/404.ejs
@@ -14,7 +14,8 @@
   <body class="content-page">
     <h1>Not found</h1>
 
-    <p>The resource you are trying to access is not available at this URL.  Please carefully check your address bar and try again, or <a class="plain-link" href="/">return to the app</a>.</p>
+    <p>The resource you are trying to access is not available at this URL. Please carefully check your address bar and try again, or <a class="plain-link" href="/">return to the app</a>.</p>
+    <p>If problems persist, please contact us at <a class="plain-link" href="mailto:<%=EMAIL_ADDRESS_INFO%>"><%=EMAIL_ADDRESS_INFO%></a>.</p>
   </body>
 
 </html>


### PR DESCRIPTION
Send a 404 page response if trying to access a document id/secret that doesn't exist. Updated the 404 to have our help email and added as config variable.

Refs #614 .