### PR TITLE
Automation: Invitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,15 @@ Email:
 - `EMAIL_VENDOR_MAILJET`: name of Mailjet vendor
 - `MAILJET_TMPLID_INVITE`: vendor email template id for an invitation
 - `MAILJET_TMPLID_FOLLOWUP`: vendor email template id for a follow-up
+- `MAILJET_TMPLID_REQUEST_ISSUE`: vendor email template id for a request error notification
 - `EMAIL_CONTEXT_JOURNAL`: email context variable to indicate entry via journal
 - `EMAIL_CONTEXT_SIGNUP`: email context variable to indicate entry via homepage
 - `EMAIL_TYPE_INVITE`:  name to indicate invite email
 - `EMAIL_TYPE_FOLLOWUP`: name to indicate follow-up email
+- `EMAIL_TYPE_REQUEST_ISSUE`: name to indicate request error email
 - `EMAIL_SUBJECT_INVITE`: subject text for invitation email
 - `EMAIL_SUBJECT_FOLLOWUP`: subject text for follow-up email
+- `EMAIL_SUBJECT_REQUEST_ISSUE`: subject text for request error email
 
 The following environment variables should always be set in production instances:
 

--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -340,7 +340,7 @@ class DocumentManagementDocumentComponent extends React.Component {
             doc,
             fieldName: 'paperId',
             value: paperId,
-            label: h( 'span', `${paperIdIssue} ` ),
+            label: h( 'span', `${paperIdIssue.message}` ),
             apiKey
           })
         ];
@@ -440,7 +440,7 @@ class DocumentManagementDocumentComponent extends React.Component {
             doc,
             fieldName: 'authorEmail',
             value: authorEmail,
-            label: h( 'span', `${authorEmailIssue} `),
+            label: h( 'span', `${authorEmailIssue.message} `),
             apiKey
           })
         ]);

--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -138,7 +138,7 @@ class DocumentEmailButtonComponent extends DocumentButtonComponent {
       return h( 'small.mute', [
         h('span', ` ${_.size( infos )}`),
         h('span', ` | ${last}`),
-        error ? h('span.invalid', ` | ${error.statusText}`): null
+        error ? h('span.invalid', ` | ${error.code}`): null
       ]);
     } else {
       return null;

--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -7,7 +7,6 @@ import { format, formatDistanceToNow, isThisMonth } from 'date-fns';
 import Document from '../../model/document';
 import {
   tryPromise,
-  sendMail,
   makeClassList
 } from '../../util';
 import logger from '../logger';
@@ -23,6 +22,32 @@ const DOCUMENT_STATUS_FIELDS = Document.statusFields();
 
 const hasIssues = doc => _.values( doc.issues() ).some( i => !_.isNull( i ) );
 const hasIssue = ( doc, key ) => _.has( doc.issues(), key ) && !_.isNull( _.get( doc.issues(), key ) );
+
+/**
+ * sendMail
+ *
+ * Client-side helper to send email and update doc state
+ *
+ * @param {String} emailType one of the recognized types to configure email template
+ * @param {object} doc the model object
+ * @param {string} apiKey to validate against protected routes
+ */
+const sendMail = ( emailType, doc, apiKey ) => {
+  const url = '/api/document/email';
+  const getDocKeys = doc => Promise.all([ doc.id(), doc.secret() ]);
+
+  return getDocKeys( doc )
+    .then( ( [id, secret ] ) => fetch( url,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify( { apiKey, emailType, id, secret } )
+      })
+    );
+};
 
 class SendingComponent extends React.Component {
   constructor( props ){

--- a/src/config.js
+++ b/src/config.js
@@ -72,12 +72,15 @@ export const SMTP_PASSWORD = env('SMTP_PASSWORD', 'password');
 export const EMAIL_VENDOR_MAILJET = env('EMAIL_VENDOR_MAILJET', 'Mailjet');
 export const MAILJET_TMPLID_INVITE = env('MAILJET_TMPLID_INVITE', '1005099');
 export const MAILJET_TMPLID_FOLLOWUP = env('MAILJET_TMPLID_FOLLOWUP', '988309');
+export const MAILJET_TMPLID_REQUEST_ISSUE = env('MAILJET_TMPLID_REQUEST_ISSUE', '1202251');
 export const EMAIL_CONTEXT_JOURNAL = env('EMAIL_CONTEXT_JOURNAL', 'journal');
 export const EMAIL_CONTEXT_SIGNUP = env('EMAIL_CONTEXT_SIGNUP', 'signup');
 export const EMAIL_TYPE_INVITE = env('EMAIL_TYPE_INVITE', 'invite');
 export const EMAIL_TYPE_FOLLOWUP = env('EMAIL_TYPE_FOLLOWUP', 'followUp');
+export const EMAIL_TYPE_REQUEST_ISSUE = env('EMAIL_TYPE_REQUEST_ISSUE', 'requestIssue');
 export const EMAIL_SUBJECT_INVITE = env('EMAIL_SUBJECT_INVITE', 'Your invitation to Biofactoid is ready');
 export const EMAIL_SUBJECT_FOLLOWUP = env('EMAIL_SUBJECT_FOLLOWUP', 'Thank you for sharing your research with Biofactoid');
+export const EMAIL_SUBJECT_REQUEST_ISSUE = env('EMAIL_SUBJECT_REQUEST_ISSUE', 'Please re-submit your request to Biofactoid');
 export const EMAIL_ADDRESS_INFO = env('EMAIL_ADDRESS_INFO', 'info@biofactoid.org');
 
 // Sharing

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -446,16 +446,15 @@ http.post('/', function( req, res, next ){
 
   const setRequestStatus = doc => doc.request().then( () => doc );
 
-  ( tryPromise( () => checkRequestContext( provided ) )
+  checkRequestContext( provided )
     .then( () => res.end() )
-    .catch( next )
     .then( () => createSecret({ secret }) )
     .then( loadTables )
     .then( ({ docDb, eleDb }) => createDoc({ docDb, eleDb, id, secret, provided }) )
     .then( setRequestStatus )
     .then( fillDoc )
     .then( sendInviteNotification )
-  );
+    .catch( next );
 });
 
 // Update document fields provided and re-apply fillDoc

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -155,13 +155,17 @@ const sendInviteNotification = async doc => {
   const id = doc.id();
   const secret = doc.secret();
   const { context } = doc.provided();
-  const doNotify = context && context !== EMAIL_CONTEXT_JOURNAL; // network error
+  const doNotify = context && context === EMAIL_CONTEXT_JOURNAL;
   const issueExists = hasIssues( doc );
 
-  if( doNotify ){
-    if( issueExists ) emailType = EMAIL_TYPE_REQUEST_ISSUE;
+  if( issueExists ){
+    emailType = EMAIL_TYPE_REQUEST_ISSUE;
+    if( doNotify ) await configureAndSendMail( emailType, id, secret );
+
+  } else {
     await configureAndSendMail( emailType, id, secret );
   }
+
   return doc;
 };
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -414,20 +414,16 @@ http.post('/', function( req, res, next ){
   const id = paperId === DEMO_ID ? DEMO_ID: undefined;
   const secret = paperId === DEMO_ID ? DEMO_SECRET: uuid();
 
-  const handleCreateError = e => { logger.error(`Error creating doc: ${e.message}`); next( e ); };
   const setRequestStatus = doc => doc.request().then( () => doc );
 
   ( tryPromise( () => checkRequestContext( provided ) )
+    .then( () => res.end( 'ok' ) )
     .then( () => createSecret({ secret }) )
     .then( loadTables )
     .then( ({ docDb, eleDb }) => createDoc({ docDb, eleDb, id, secret, provided }) )
-    .catch( handleCreateError )
     .then( setRequestStatus )
     .then( fillDoc )
     .then( sendNotification )
-    .then( getDocJson )
-    .then( json => res.json( json ) )
-    .catch( next )
   );
 });
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -418,6 +418,7 @@ http.post('/', function( req, res, next ){
 
   ( tryPromise( () => checkRequestContext( provided ) )
     .then( () => res.end( 'ok' ) )
+    .catch( next )
     .then( () => createSecret({ secret }) )
     .then( loadTables )
     .then( ({ docDb, eleDb }) => createDoc({ docDb, eleDb, id, secret, provided }) )

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -138,7 +138,9 @@ const composeAndSendMail = async ( emailType, id, secret ) => {
     info =  await sendMail( mailOpts );
 
   } catch ( error ) {
-    info = _.assign( {}, error, { date: new Date() });
+    logger.error( `Error sending email: ${error.message}`);
+    info = _.assign( {}, { error, date: new Date() });
+    throw error;
 
   } finally {
     await updateCorrespondence( doc, info, emailType );

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -444,7 +444,10 @@ http.post('/', function( req, res, next ){
   const id = paperId === DEMO_ID ? DEMO_ID: undefined;
   const secret = paperId === DEMO_ID ? DEMO_SECRET: uuid();
 
-  const setRequestStatus = doc => doc.request().then( () => doc );
+  const setRequestStatus = doc => tryPromise( () => doc.request() ).then( () => doc );
+  const setApprovedStatus = doc => tryPromise( () => hasIssues( doc ) )
+    .then( issueExists => !issueExists ? doc.approve() : null )
+    .then( () => doc );
 
   checkRequestContext( provided )
     .then( () => res.end() )
@@ -453,6 +456,7 @@ http.post('/', function( req, res, next ){
     .then( ({ docDb, eleDb }) => createDoc({ docDb, eleDb, id, secret, provided }) )
     .then( setRequestStatus )
     .then( fillDoc )
+    .then( setApprovedStatus )
     .then( sendInviteNotification )
     .catch( next );
 });

--- a/src/server/routes/api/document/pubmed/fetchPubmed.js
+++ b/src/server/routes/api/document/pubmed/fetchPubmed.js
@@ -284,6 +284,13 @@ const pubmedDataConverter = async xml => {
 };
 
 const toText = res => res.text();
+const checkResponseStatus = response => {
+  const { statusText, ok, status } = response;
+  if ( !ok ) {
+    throw Error( `Error in PubMed EFETCH: ${status} -- ${statusText}` );
+  }
+  return response;
+};
 const eFetchPubmed = ( { uids, query_key, webenv } )=> {
   let params;
   if( !_.isEmpty( uids ) ){
@@ -305,6 +312,7 @@ const eFetchPubmed = ( { uids, query_key, webenv } )=> {
       'User-Agent': userAgent
     }
   })
+  .then( checkResponseStatus )
   .then( toText )
   .then( pubmedDataConverter );
 };

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -11,17 +11,24 @@ import {
 
 const digitsRegex = /^[0-9.]+$/;
 
+class ArticleIDError extends Error {
+  constructor(...params) {
+    super(...params);
+    this.name = 'ArticleIDError';
+  }
+}
+
 const findPubmedId = async paperId => {
 
   let id;
-  if( !_.isString( paperId ) ) throw new TypeError( errMessage );
   const errMessage = `Unrecognized paperId '${paperId}'`;
+  if( !_.isString( paperId ) ) throw new TypeError( errMessage );
   const getUniqueIdOrThrow = async query => {
     const { searchHits, count } = await searchPubmed( query );
     if( count === 1 ){
       return _.first( searchHits );
     } else {
-      throw new TypeError( errMessage );
+      throw new ArticleIDError( errMessage );
     }
   };
   const isUidLike = digitsRegex.test( paperId );
@@ -83,8 +90,8 @@ const getPubmedArticle = async paperId => {
   if( !_.isEmpty( PubmedArticleSet ) ){
     return _.head( PubmedArticleSet );
   } else {
-    throw new Error( `No PubMed record for '${paperId}'` );
+    throw new ArticleIDError( `No PubMed record for '${paperId}'` );
   }
 };
 
-export { getPubmedArticle };
+export { getPubmedArticle, ArticleIDError };

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -28,6 +28,13 @@ const pubmedDataConverter = json => {
   };
 };
 
+const checkResponseStatus = response => {
+  const { statusText, ok, status } = response;
+  if ( !ok ) {
+    throw Error( `Error in PubMed ESEARCH: ${status} -- ${statusText}` );
+  }
+  return response;
+};
 const eSearchPubmed = term => {
   const params = _.assign( {}, DEFAULT_ESEARCH_PARAMS, { term } );
   const url = EUTILS_SEARCH_URL + '?' + queryString.stringify( params );
@@ -38,6 +45,7 @@ const eSearchPubmed = term => {
       'User-Agent': userAgent
     }
   })
+  .then( checkResponseStatus )
   .then( response => response.json() )
   .then( pubmedDataConverter );
 };

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -8,15 +8,20 @@ import {
   EMAIL_VENDOR_MAILJET,
   MAILJET_TMPLID_INVITE,
   MAILJET_TMPLID_FOLLOWUP,
+  MAILJET_TMPLID_REQUEST_ISSUE,
   EMAIL_TYPE_INVITE,
   EMAIL_TYPE_FOLLOWUP,
+  EMAIL_TYPE_REQUEST_ISSUE,
   EMAIL_SUBJECT_INVITE,
-  EMAIL_SUBJECT_FOLLOWUP
+  EMAIL_SUBJECT_FOLLOWUP,
+  EMAIL_SUBJECT_REQUEST_ISSUE
 } from '../config' ;
 
 
 const msgFactory = ( emailType, doc ) => {
   const { authorEmail, context } = doc.correspondence();
+  const provided = doc.provided();
+
   const {
     title = 'Untitled',
     reference = ''
@@ -33,6 +38,8 @@ const msgFactory = ( emailType, doc ) => {
     template: {
       vendor: EMAIL_VENDOR_MAILJET,
       vars: {
+        baseUrl: BASE_URL,
+        provided,
         citation: `${title} ${reference}`
       }
     }
@@ -47,6 +54,10 @@ const msgFactory = ( emailType, doc ) => {
         privateUrl: `${BASE_URL}${doc.privateUrl()}`,
         context
       });
+      break;
+    case EMAIL_TYPE_REQUEST_ISSUE:
+      _.set( data, 'subject', EMAIL_SUBJECT_REQUEST_ISSUE );
+      _.set( data, ['template', 'id'], MAILJET_TMPLID_REQUEST_ISSUE );
       break;
     case EMAIL_TYPE_FOLLOWUP:
       _.set( data, 'subject', EMAIL_SUBJECT_FOLLOWUP );

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -17,7 +17,10 @@ import {
 
 const msgFactory = ( emailType, doc ) => {
   const { authorEmail, context } = doc.correspondence();
-  const { title, authors, reference } = doc.citation();
+  const {
+    title = 'Untitled',
+    reference = ''
+  } = doc.citation();
 
   const DEFAULTS = {
     from: {
@@ -30,7 +33,7 @@ const msgFactory = ( emailType, doc ) => {
     template: {
       vendor: EMAIL_VENDOR_MAILJET,
       vars: {
-        citation: `${title} ${authors}. ${reference}.`
+        citation: `${title} ${reference}`
       }
     }
   };

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -20,7 +20,6 @@ import {
 
 const msgFactory = ( emailType, doc ) => {
   const { authorEmail, context } = doc.correspondence();
-  const provided = doc.provided();
 
   const {
     title = 'Untitled',
@@ -39,7 +38,6 @@ const msgFactory = ( emailType, doc ) => {
       vendor: EMAIL_VENDOR_MAILJET,
       vars: {
         baseUrl: BASE_URL,
-        provided,
         citation: `${title} ${reference}`
       }
     }

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -61,7 +61,6 @@ const msgFactory = ( emailType, doc ) => {
   return mailOpts;
 };
 
-const toJSON = res => res.json();
 /**
  * updateCorrespondence
  *
@@ -80,46 +79,4 @@ const updateCorrespondence = ( doc, info, emailType ) => {
     .then( update => doc.correspondence( update ) );
 };
 
-const handleMailResponse = ( response, doc, emailType ) => {
-  const { statusText, ok, status } = response;
-  if ( !ok ) {
-    const info = _.assign( {}, response, {
-      error: { statusText, status },
-      date: new Date()
-    });
-    return updateCorrespondence( doc, info, emailType )
-      .then( () => { throw Error( response.statusText ); } );
-  }
-  return response;
-};
-
-/**
- * sendMail
- *
- * Client-side helper to send email and update doc state
- *
- * @param {String} emailType one of the recognized types to configure email template
- * @param {object} doc the model object
- * @param {string} apiKey to validate against protected routes
- */
-const sendMail = ( emailType, doc, apiKey ) => {
-  const url = '/api/document/email';
-  const getDocKeys = doc => Promise.all([ doc.id(), doc.secret() ]);
-
-  return getDocKeys( doc )
-    .then( ( [id, secret ] ) => fetch( url,
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        },
-        body: JSON.stringify( { apiKey, emailType, id, secret } )
-      })
-    )
-    .then( response => handleMailResponse( response, doc, emailType ) )
-    .then( toJSON )
-    .then( info => updateCorrespondence( doc, info, emailType ) );
-};
-
-export { sendMail, msgFactory, updateCorrespondence };
+export { msgFactory, updateCorrespondence };

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -13,7 +13,7 @@ const getName = author => {
   } else {
     name = collectiveName;
   }
-  return name; 
+  return name;
 };
 
 const getEmail = author => {
@@ -38,7 +38,7 @@ const getAuthorString = AuthorList => {
   const leadingAuthors = _.take( AuthorList, NUM_AUTHORS_SHOWING - 1 );
   const lastAuthor =  _.last( AuthorList );
   const authorList = leadingAuthors.concat( lastAuthor );
-  
+
   const authorStringList = _.uniq( authorList.map( getName ) );
   if( leadingAuthors.length && leadingAuthors.length < AuthorList.length - 1  ) authorStringList.splice( NUM_AUTHORS_SHOWING - 1, 0, '...' );
   return authorStringList.join(', ');
@@ -56,10 +56,10 @@ const getAuthors = AuthorList => {
 };
 
 const getJournalNameString = Journal => {
-  const hasJournalISOAbbreviation = !_.isNull( _.get( Journal, ['ISOAbbreviation'] ) ); //optional 
-  const hasJournalTitle = !_.isNull( _.get( Journal, ['Title'] ) ); //optional 
+  const hasJournalISOAbbreviation = !_.isNil( _.get( Journal, ['ISOAbbreviation'] ) ); //optional
+  const hasJournalTitle = !_.isNil( _.get( Journal, ['Title'] ) ); //optional
   let name = '';
-  if( hasJournalISOAbbreviation ){ 
+  if( hasJournalISOAbbreviation ){
     name = `${_.get( Journal, ['ISOAbbreviation'] )}.`;
   } else if( hasJournalTitle ) {
     name = `${_.get( Journal, ['Title'] )}.`;
@@ -69,9 +69,9 @@ const getJournalNameString = Journal => {
 };
 
 const getReferenceString = Journal => {
-  const journalName = getJournalNameString( Journal ); 
-  const journalVolume = !_.isNull( _.get( Journal, ['Volume'] ) ) ? _.get( Journal, ['Volume'] ): ''; //optional 
-  const pubDateYear = !_.isNull( _.get( Journal, ['PubDate', 'Year'] ) ) ? `(${_.get( Journal, ['PubDate', 'Year'] )})`: ''; //optional 
+  const journalName = getJournalNameString( Journal );
+  const journalVolume = !_.isNil( _.get( Journal, ['Volume'] ) ) ? _.get( Journal, ['Volume'] ): ''; //optional
+  const pubDateYear = !_.isNil( _.get( Journal, ['PubDate', 'Year'] ) ) ? `(${_.get( Journal, ['PubDate', 'Year'] )})`: ''; //optional
   return _.compact( [ journalName, journalVolume, pubDateYear ] ).join(' ');
 };
 
@@ -79,15 +79,15 @@ const getArticleId = ( PubmedArticle, IdType ) => _.get( _.find( _.get( PubmedAr
 
 /**
  * getPubmedCitation
- * 
+ *
  * Retrieve a nicely formatted set of citation items from a PubmedArticle
  *  -- authors, title, and reference
  * @param {Object} PubmedArticle Returned from fetchPubmed PubmedArticleSet
- * @return {Object} result 
- * @return {String} result.authors The CollectiveName or 'LastName et al.' 
- * @return {String} result.contacts 
- * @return {String} result.title 
- * @return {String} result.reference (<ISOAbbreviation> | <Title>) <Year>; <Volume> 
+ * @return {Object} result
+ * @return {String} result.authors The CollectiveName or 'LastName et al.'
+ * @return {String} result.contacts
+ * @return {String} result.title
+ * @return {String} result.reference (<ISOAbbreviation> | <Title>) <Year>; <Volume>
  * @return {String} result.pmid
  * @return {String} result.doi
  */
@@ -97,13 +97,13 @@ const getPubmedCitation = PubmedArticle => {
   const title = _.get( Article, ['ArticleTitle'] ); //required
   const AuthorList = _.get( Article, ['AuthorList'] ); //optional
 
-  const { authors, contacts } = getAuthors( AuthorList ); 
+  const { authors, contacts } = getAuthors( AuthorList );
   const reference = getReferenceString( Journal );
   const abstract = _.get( Article, 'Abstract' );
   const pmid = getArticleId( PubmedArticle, 'pubmed' );
   const doi = getArticleId( PubmedArticle, 'doi' );
-  
+
   return { authors, contacts, title, reference, abstract, pmid, doi };
 };
 
-export { getPubmedCitation }; 
+export { getPubmedCitation };


### PR DESCRIPTION
This PR automates the dispatching of invitation emails in response to requests. It considers requests made by authors ('signup') as well as journals. Also considered is the scenario where an author provides a paper ID that turns out to be unrecognized; in this instance, they shall receive a re-submit email prompt (below).

Other:
  - removed server-side reference to `isCorrespondingAuthor` flag; intend to remove completely in later PR

 
Refs #620 

<img width="595" alt="image" src="https://user-images.githubusercontent.com/4706307/73390245-b6ab3f00-42a3-11ea-8651-ba0d46ef4f44.png">




