### PR TITLE
Admin automation: Check if provided email should be considered 'verified' 

### DIFF
--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -418,8 +418,8 @@ class DocumentManagementDocumentComponent extends React.Component {
             name: `document-verified-${doc.id()}`,
             id: `document-verified-radio-${doc.id()}-${displayName}`,
             value: typeVal,
-            defaultChecked: typeVal === `${doc.verified()}`,
-            onChange: e => doc.verified( e.target.value )
+            defaultChecked: typeVal === doc.verified(),
+            onChange: () => doc.verified( typeVal )
           }),
           h('label', {
             htmlFor: `document-verified-radio-${doc.id()}-${displayName}`
@@ -427,7 +427,7 @@ class DocumentManagementDocumentComponent extends React.Component {
         );
       };
 
-      [ [ 'false', 'unverified' ], [ 'true', 'verified' ] ].forEach( ([ field, name ]) => addType( field, _.capitalize( name ) ) );
+      [ [ false, 'unverified' ], [ true, 'verified' ] ].forEach( ([ field, name ]) => addType( field, _.capitalize( name ) ) );
       return h( 'small.radioset', radios );
     };
 

--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -409,18 +409,38 @@ class DocumentManagementDocumentComponent extends React.Component {
     };
 
     // Correspondence
+    const getVerified = doc => {
+      let radios = [];
+      let addType = (typeVal, displayName) => {
+        radios.push(
+          h('input', {
+            type: 'radio',
+            name: `document-verified-${doc.id()}`,
+            id: `document-verified-radio-${doc.id()}-${displayName}`,
+            value: typeVal,
+            defaultChecked: typeVal === `${doc.verified()}`,
+            onChange: e => doc.verified( e.target.value )
+          }),
+          h('label', {
+            htmlFor: `document-verified-radio-${doc.id()}-${displayName}`
+          }, displayName)
+        );
+      };
+
+      [ [ 'false', 'unverified' ], [ 'true', 'verified' ] ].forEach( ([ field, name ]) => addType( field, _.capitalize( name ) ) );
+      return h( 'small.radioset', radios );
+    };
+
     const getAuthorEmail = doc => {
       const { authorEmail } = doc.correspondence();
-      const isVerified = doc.verified();
       const element = [`${authorEmail} `];
-      if( isVerified ) element.push( h( 'i.material-icons', 'verified_user' ) );
       return h( TextEditableComponent, {
           doc,
           fieldName: 'authorEmail',
           value: authorEmail,
           label: h( 'span', element ),
           apiKey
-        });
+      });
     };
 
     const getDocumentCorrespondence = doc => {
@@ -441,6 +461,7 @@ class DocumentManagementDocumentComponent extends React.Component {
       } else {
         content = h( 'div.document-management-document-section-items', [
           getAuthorEmail( doc ),
+          getVerified( doc ),
           h( DocumentEmailButtonComponent, {
             params: { doc, apiKey },
             workingMessage: 'Sending...',

--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -409,18 +409,10 @@ class DocumentManagementDocumentComponent extends React.Component {
     };
 
     // Correspondence
-    const getContact = doc => {
-      const { authorEmail } = doc.correspondence();
-      const { contacts } = doc.citation();
-      return _.find( contacts, contact => _.indexOf( _.get( contact, 'email' ), authorEmail ) > -1 );
-    };
-
     const getAuthorEmail = doc => {
       const { authorEmail } = doc.correspondence();
       const isVerified = doc.verified();
-      let contact = getContact( doc );
       const element = [`${authorEmail} `];
-      if( contact ) element.push( h( 'span', ` <${contact.name}> ` ) );
       if( isVerified ) element.push( h( 'i.material-icons', 'verified_user' ) );
       return h( TextEditableComponent, {
           doc,

--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -249,9 +249,13 @@ class TextEditableComponent extends React.Component {
   }
 
   render() {
-    const { doc, label } = this.props;
+    const { doc, label, fullWidth } = this.props;
 
-    const editContent = h('div.document-management-text-editable', [
+    const editContent = h('div.document-management-text-editable', {
+      className: makeClassList({
+        'full-width': fullWidth
+      })
+    }, [
       h('input', {
         className: makeClassList({
           'hide-by-default': true,
@@ -337,6 +341,7 @@ class DocumentManagementDocumentComponent extends React.Component {
         const paperId = _.get( doc.provided(), 'paperId' );
         items = [
           h( TextEditableComponent, {
+            className: 'full-width',
             doc,
             fieldName: 'paperId',
             value: paperId,
@@ -366,6 +371,7 @@ class DocumentManagementDocumentComponent extends React.Component {
             ]),
             h('small.mute', contactList),
             h( TextEditableComponent, {
+              fullWidth: true,
               doc,
               fieldName: 'paperId',
               value: paperId,
@@ -418,7 +424,7 @@ class DocumentManagementDocumentComponent extends React.Component {
             name: `document-verified-${doc.id()}`,
             id: `document-verified-radio-${doc.id()}-${displayName}`,
             value: typeVal,
-            defaultChecked: typeVal === doc.verified(),
+            checked: typeVal === doc.verified(),
             onChange: () => doc.verified( typeVal )
           }),
           h('label', {
@@ -460,8 +466,10 @@ class DocumentManagementDocumentComponent extends React.Component {
 
       } else {
         content = h( 'div.document-management-document-section-items', [
-          getAuthorEmail( doc ),
-          getVerified( doc ),
+          h( 'div.document-management-document-section-items-row', [
+            getAuthorEmail( doc ),
+            getVerified( doc )
+          ]),
           h( DocumentEmailButtonComponent, {
             params: { doc, apiKey },
             workingMessage: 'Sending...',
@@ -499,7 +507,7 @@ class DocumentManagementDocumentComponent extends React.Component {
             name: `document-status-${doc.id()}`,
             id: `document-status-radio-${doc.id()}-${typeVal}`,
             value: typeVal,
-            defaultChecked: _.get( DOCUMENT_STATUS_FIELDS, typeVal ) === doc.status(),
+            checked: _.get( DOCUMENT_STATUS_FIELDS, typeVal ) === doc.status(),
             onChange: e => {
               let newlySelectedStatus = _.get( DOCUMENT_STATUS_FIELDS, e.target.value );
               doc.status( newlySelectedStatus );

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -104,7 +104,6 @@ const fillDocCorrespondence = async ( doc, authorEmail, context ) => {
     const emails = _.get( doc.correspondence(), 'emails' );
     const data = _.defaults( { authorEmail, context, emails }, DEFAULT_CORRESPONDENCE );
     await doc.correspondence( data );
-    // TODO - is this user verified?
     await doc.issues({ authorEmail: null });
   } catch ( error ){
     await doc.issues({ authorEmail: { error, message: error.message } });

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -448,6 +448,12 @@ http.post('/', function( req, res, next ){
   const setApprovedStatus = doc => tryPromise( () => hasIssues( doc ) )
     .then( issueExists => !issueExists ? doc.approve() : null )
     .then( () => doc );
+  const verify = doc => {
+    const { authorEmail } = doc.correspondence();
+    const { contacts } = doc.citation();
+    const hasEmail = _.some( contacts, contact => _.includes( _.get( contact, 'email' ), authorEmail ) );
+    return tryPromise( () => doc.verified( hasEmail ) ).then( () => doc );
+  };
 
   checkRequestContext( provided )
     .then( () => res.end() )
@@ -457,6 +463,7 @@ http.post('/', function( req, res, next ){
     .then( setRequestStatus )
     .then( fillDoc )
     .then( setApprovedStatus )
+    .then( verify )
     .then( sendInviteNotification )
     .catch( next );
 });

--- a/src/styles/document-management.css
+++ b/src/styles/document-management.css
@@ -120,8 +120,10 @@
 }
 
 .document-management-text-editable {
-  width: 100%;
-  min-width: 25em;
+  &.full-width {
+    width: 100%;
+    min-width: 25em;
+  }
 
   & input {
     margin-bottom: 0;


### PR DESCRIPTION
Verify the email when any one applies:
  - request originated from a journal
  - provided email is found in PubMed record
  - verified is set by admin

Once verified, flag must be manually set to `false`. 

References #620