### PR TITLE
Add back submit

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -22,7 +22,7 @@ import * as defs from './defs';
 import EditorButtons from './buttons';
 import MainMenu from '../main-menu';
 import UndoRemove from './undo-remove';
-import { ShareView } from '../share';
+import { TaskView } from '../tasks';
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;
@@ -475,7 +475,7 @@ class Editor extends DataComponent {
   }
 
   render(){
-    let { document, bus, showHelp, cy } = this.data;
+    let { document, bus, showHelp } = this.data;
     let controller = this;
     let { history } = this.props;
 
@@ -494,22 +494,10 @@ class Editor extends DataComponent {
       h('div.editor-main-menu', [
         h(MainMenu, { bus, document, history })
       ]),
-      h('div.editor-share', {
-
-      }, [
-        document.editable() ? (
-          h(Popover, { tippy: { html: h(ShareView, { cy, document, bus } ) } }, [
-            h('button.editor-share-button.super-salient-button', {
-              onClick: () => bus.emit('toggleshare')
-            }, 'Share')
-          ])
-        ) : (
-          !document.hasTweet() ? null : h('a', { href: document.tweetUrl() }, [
-            h('button.editor-tweet-button.super-salient-button', [
-              h('i.icon.icon-t-white')
-            ])
-          ])
-        )
+      h('div.editor-submit', [
+        h(Popover, { tippy: { html: h(TaskView, { document, bus } ) } }, [
+          document.submitted() ? h('button.editor-submit-button', 'Submitted') : h('button.editor-submit-button.super-salient-button', 'Submit')
+        ])
       ]),
       h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),
       h(UndoRemove, { controller, document, bus }),

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -121,7 +121,9 @@ class Editor extends DataComponent {
     doc.on('localadd', updateLastEditDate);
     doc.on('localremove', updateLastEditDate);
 
-    doc.on('submit', () => this.dirty());
+    doc.on('update', change => {
+      if( _.has( change, 'status' ) ) this.dirty();
+    });
 
     doc.on('load', () => {
       doc.interactions().concat( doc.complexes() ).forEach( listenForRmPpt );
@@ -496,7 +498,12 @@ class Editor extends DataComponent {
       ]),
       h('div.editor-submit', [
         h(Popover, { tippy: { html: h(TaskView, { document, bus } ) } }, [
-          document.submitted() ? h('button.editor-submit-button', 'Submitted') : h('button.editor-submit-button.super-salient-button', 'Submit')
+          h('button.editor-submit-button', {
+            disabled: document.trashed(),
+            className: makeClassList({
+              'super-salient-button': !document.trashed() && !document.submitted()
+            })
+          }, document.submitted() ?  'Submitted' : 'Submit')
         ])
       ]),
       h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -234,6 +234,10 @@ class Editor extends DataComponent {
     ;
   }
 
+  done(){
+    return this.data.document.submitted() || this.data.document.published();
+  }
+
   editable(){
     return this.data.document.editable();
   }
@@ -496,16 +500,16 @@ class Editor extends DataComponent {
       h('div.editor-main-menu', [
         h(MainMenu, { bus, document, history })
       ]),
-      h('div.editor-submit', [
+      this.editable() ? h('div.editor-submit', [
         h(Popover, { tippy: { html: h(TaskView, { document, bus } ) } }, [
           h('button.editor-submit-button', {
             disabled: document.trashed(),
             className: makeClassList({
-              'super-salient-button': !document.trashed() && !document.submitted()
+              'super-salient-button': !this.done()
             })
-          }, document.submitted() ?  'Submitted' : 'Submit')
+          }, this.done() ?  'Submitted' : 'Submit')
         ])
-      ]),
+      ]) : null,
       h(EditorButtons, { className: 'editor-buttons', controller, document, bus, history }),
       h(UndoRemove, { controller, document, bus }),
       h('div.editor-graph#editor-graph'),

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -75,7 +75,7 @@ class TaskView extends DataComponent {
       return !ele.completed() && !ele.isInteraction();
     });
 
-    let ntfns = document.entities().concat(document.interactions()).filter(ele => !ele.completed()).map(ele => {
+    let ntfns = document.entities().filter(ele => !ele.completed()).map(ele => {
       let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : '') }`;
       let innerMsg = entMsg(ele);
 

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -1,5 +1,6 @@
 import DataComponent from './data-component';
 import h from 'react-hyperscript';
+import Document from '../../model/document';
 
 const eleEvts = [ 'rename', 'complete', 'uncomplete' ];
 
@@ -42,13 +43,14 @@ class TaskView extends DataComponent {
       this.dirty();
     };
 
-    this.onSubmit = () => {
-      this.dirty();
+    this.onStatusChange = status => {
+      const { SUBMITTED } = Document.statusFields();
+      if( status === SUBMITTED ) this.dirty();
     };
 
     this.props.document.on('add', this.onAdd);
     this.props.document.on('remove', this.onRemove);
-    this.props.document.on('submit', this.onSubmit);
+    this.props.document.on('status', this.onStatusChange);
 
     this.props.document.elements().forEach(ele => bindEleEvts(ele, update));
   }
@@ -115,7 +117,7 @@ class TaskView extends DataComponent {
     } else {
       return h('div.task-view', [
         h('div.task-view-done', [
-          h('div.task-view-done-message', 'Your figure has been submitted, and you will be contacted shortly regarding its publication status.')
+          h('div.task-view-done-message', 'Congratuations and thank you! Check your email for links to your pathway data.')
         ])
       ]);
     }

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -1,0 +1,126 @@
+import DataComponent from './data-component';
+import h from 'react-hyperscript';
+
+const eleEvts = [ 'rename', 'complete', 'uncomplete' ];
+
+let bindEleEvts = (ele, cb) => {
+  eleEvts.forEach(evt => {
+
+    ele.on(evt, cb);
+  });
+};
+
+let unbindEleEvts = (ele, cb) => {
+  eleEvts.forEach(evt => {
+    ele.removeListener(evt, cb);
+  });
+};
+
+
+class TaskView extends DataComponent {
+  constructor(props){
+    super(props);
+
+    this.state = {
+      submitted: false
+    };
+  }
+
+  componentDidMount(){
+    this.eleEvts = eleEvts;
+
+    let update = () => this.dirty();
+    this.update = update;
+
+    this.onAdd = ele => {
+      bindEleEvts(ele, update);
+      this.dirty();
+    };
+
+    this.onRemove = ele => {
+      unbindEleEvts(ele, update);
+      this.dirty();
+    };
+
+    this.onSubmit = () => {
+      this.dirty();
+    };
+
+    this.props.document.on('add', this.onAdd);
+    this.props.document.on('remove', this.onRemove);
+    this.props.document.on('submit', this.onSubmit);
+
+    this.props.document.elements().forEach(ele => bindEleEvts(ele, update));
+  }
+
+  componentWillUnmount(){
+    this.props.document.elements().forEach( ele => unbindEleEvts(ele, this.update));
+
+    this.props.document.removeListener(this.onAdd);
+    this.props.document.removeListener(this.onRemove);
+    this.props.document.removeListener(this.onSubmit);
+  }
+
+  submit(){
+    return this.props.document.submit();
+  }
+
+  render(){
+    let { document, bus } = this.props;
+    let submitted = this.props.document.submitted();
+    let incompleteEles = this.props.document.elements().filter(ele => {
+      return !ele.completed() && !ele.isInteraction();
+    });
+
+    let ntfns = document.entities().concat(document.interactions()).filter(ele => !ele.completed()).map(ele => {
+      let entMsg = ele => `${ele.name() === '' ? 'unnamed entity' : ele.name() + (ele.completed() ? '' : '') }`;
+      let innerMsg = entMsg(ele);
+
+      if( ele.isInteraction() ){
+        let participants = ele.participants();
+        innerMsg = `the interaction between ${participants.map(entMsg).join(' and ')}`;
+      }
+
+      return { ele, msg: innerMsg };
+    });
+
+    let tasksMsg = () => {
+      let numIncompleteEles = incompleteEles.length > 50 ? '50+' : incompleteEles.length;
+      if( numIncompleteEles === 0 ){
+        return `You have no outstanding tasks left`;
+      }
+
+      if( numIncompleteEles === 1 ){
+        return `You have 1 incomplete item:`;
+      }
+
+      return `You have ${numIncompleteEles} incomplete items:`;
+    };
+
+    if( !submitted ){
+      return h('div.task-view', [
+        incompleteEles.length > 0 ? h('div.task-view-header', tasksMsg()) : null,
+        incompleteEles.length > 0 ? h('div.task-view-items', [
+          h('ul', ntfns.map( ({ msg, ele }) => h('li', [
+            h('a.plain-link', {
+              onClick: () => bus.emit('opentip', ele)
+            }, msg)
+          ]) ))
+        ]) : null,
+        h('div.task-view-confirm', 'Are you sure you want to submit?'),
+        h('div.task-view-confirm-button-area', [
+          h('button.salient-button.task-view-confirm-button', { onClick: () => this.submit() }, 'Yes, submit')
+        ])
+      ]);
+    } else {
+      return h('div.task-view', [
+        h('div.task-view-done', [
+          h('div.task-view-done-message', 'Your figure has been submitted, and you will be contacted shortly regarding its publication status.')
+        ])
+      ]);
+    }
+  }
+}
+
+
+export { TaskView };

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import DataComponent from './data-component';
 import h from 'react-hyperscript';
 
+import { BASE_URL } from '../../config';
+
 const eleEvts = [ 'rename', 'complete', 'uncomplete' ];
 
 let bindEleEvts = (ele, cb) => {
@@ -68,7 +70,7 @@ class TaskView extends DataComponent {
 
   render(){
     let { document, bus } = this.props;
-    let submitted = this.props.document.submitted();
+    let done = document.submitted() || document.published();
     let incompleteEles = this.props.document.elements().filter(ele => {
       return !ele.completed() && !ele.isInteraction();
     });
@@ -98,7 +100,7 @@ class TaskView extends DataComponent {
       return `You have ${numIncompleteEles} incomplete items:`;
     };
 
-    if( !submitted ){
+    if( !done ){
       return h('div.task-view', [
         incompleteEles.length > 0 ? h('div.task-view-header', tasksMsg()) : null,
         incompleteEles.length > 0 ? h('div.task-view-items', [
@@ -110,18 +112,22 @@ class TaskView extends DataComponent {
         ]) : null,
         h('div.task-view-confirm', 'Are you sure you want to submit?'),
         h('div.task-view-confirm-button-area', [
-          h('button.salient-button.task-view-confirm-button', { onClick: () => this.submit() }, 'Yes, submit')
+          h('button.salient-button.task-view-confirm-button', {
+            disabled: document.trashed(),
+            onClick: () => this.submit()
+          }, 'Yes, submit')
         ])
       ]);
     } else {
       return h('div.task-view', [
         h('div.task-view-done', [
           h('div.task-view-done-message', [
-            h('p', 'Congratulations! We will email you when your pathway is ready to be accessed.'),
-            h('p', 'In the meantime, please browse recent pathways shared by authors.'),
-            h('a.plain-link', {
-              href: 'https://biofactoid.org/'
-            }, 'here')
+            h('p', 'It\'s submitted! You should receive an email when your pathway is online.'),
+            h('p', [
+              h('a.plain-link', {
+                href: BASE_URL
+              }, 'Browse recent pathways or add another article')
+            ])
           ])
         ])
       ]);

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -1,6 +1,6 @@
+import _ from 'lodash';
 import DataComponent from './data-component';
 import h from 'react-hyperscript';
-import Document from '../../model/document';
 
 const eleEvts = [ 'rename', 'complete', 'uncomplete' ];
 
@@ -43,14 +43,13 @@ class TaskView extends DataComponent {
       this.dirty();
     };
 
-    this.onStatusChange = status => {
-      const { SUBMITTED } = Document.statusFields();
-      if( status === SUBMITTED ) this.dirty();
+    this.onUpdate = change => {
+      if( _.has( change, 'status' ) ) this.dirty();
     };
 
     this.props.document.on('add', this.onAdd);
     this.props.document.on('remove', this.onRemove);
-    this.props.document.on('status', this.onStatusChange);
+    this.props.document.on('update', this.onUpdate);
 
     this.props.document.elements().forEach(ele => bindEleEvts(ele, update));
   }
@@ -117,7 +116,13 @@ class TaskView extends DataComponent {
     } else {
       return h('div.task-view', [
         h('div.task-view-done', [
-          h('div.task-view-done-message', 'Congratuations and thank you! Check your email for links to your pathway data.')
+          h('div.task-view-done-message', [
+            h('p', 'Congratulations! We will email you when your pathway is ready to be accessed.'),
+            h('p', 'In the meantime, please browse recent pathways shared by authors.'),
+            h('a.plain-link', {
+              href: 'https://biofactoid.org/'
+            }, 'here')
+          ])
         ])
       ]);
     }

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -22,6 +22,7 @@ const DOCUMENT_STATUS_FIELDS = Object.freeze({
   REQUESTED: 'requested',
   APPROVED: 'approved',
   SUBMITTED: 'submitted',
+  PUBLISHED: 'published',
   TRASHED: 'trashed'
 });
 
@@ -403,6 +404,8 @@ class Document {
   approved(){ return this.status() === DOCUMENT_STATUS_FIELDS.APPROVED ? true : false; }
   submit(){ return this.status( DOCUMENT_STATUS_FIELDS.SUBMITTED ); }
   submitted(){ return this.status() === DOCUMENT_STATUS_FIELDS.SUBMITTED ? true : false; }
+  publish(){ return this.status( DOCUMENT_STATUS_FIELDS.PUBLISHED ); }
+  published(){ return this.status() === DOCUMENT_STATUS_FIELDS.PUBLISHED ? true : false; }
   trash(){ return this.status( DOCUMENT_STATUS_FIELDS.TRASHED ); }
   trashed(){ return this.status() === DOCUMENT_STATUS_FIELDS.TRASHED ? true : false; }
 

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -35,6 +35,14 @@
   margin: 0.5em;
 }
 
+.editor-submit {
+  position: absolute;
+  right: 0;
+  box-sizing: border-box;
+  z-index: 1;
+  padding: 0.75em 0.5em;
+}
+
 .editor-share {
   position: absolute;
   right: 0;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -17,6 +17,7 @@
 @import "./element-info";
 @import "./document-seeder.css";
 @import "./document-management.css";
+@import "./tasks.css";
 @import "./main-menu.css";
 @import "./copy-field.css";
 @import "./share.css";

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -1,0 +1,32 @@
+.task-view {
+  width: 300px;
+  padding: 0.25em 0.33em;
+}
+
+.task-view-items {
+  margin-left: 1em;
+
+  & li {
+    margin: 0;
+  }
+}
+
+.task-view-confirm {
+  margin-bottom: 1em;
+}
+
+.task-view-confirm-button-area {
+  text-align: right;
+}
+
+.task-view-done {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.task-view-done-icon {
+  font-size: 1.25em;
+  text-align: right;
+}


### PR DESCRIPTION
- Add back the old submit button to editor (editable only)
  - I left the all the validation code that tells you if something isn't 'finished' but doesn't block submit 
  - No button on read-only view
- Button tracks the document 'status' field (e.g. approved, submitted, trashed)
- Addded new doc 'status' value: published, in order to have granularity with what might be released publically

Refs #627

Doc status: requested, approved
![image](https://user-images.githubusercontent.com/4706307/74047113-d1fe0480-499d-11ea-95e5-81c5254bc7bb.png)

Doc status: submitted, published
![image](https://user-images.githubusercontent.com/4706307/74047135-d9251280-499d-11ea-8981-047e4fcccf85.png)





 