### PR TITLE
GET /api/document : remove API key requirement & order by date

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -208,7 +208,7 @@ let getSbgnFromTemplates = templates => {
 // - status: include docs bearing valid Document 'status'
 // - ids: only get the docs for the specified comma-separated list of ids (disables pagination)
 http.get('/', function( req, res, next ){
-  let { limit, offset, apiKey } = Object.assign({
+  let { limit, offset } = Object.assign({
     limit: 50,
     offset: 0
   }, req.query);
@@ -223,8 +223,7 @@ http.get('/', function( req, res, next ){
   let tables;
 
   return (
-    tryPromise( () => checkApiKey(apiKey) )
-    .then( loadTables )
+    tryPromise( () => loadTables() )
     .then( tbls => {
       tables = tbls;
 
@@ -234,6 +233,8 @@ http.get('/', function( req, res, next ){
       let t = tables.docDb;
       let { table, conn, rethink: r } = t;
       let q = table;
+
+      q = q.orderBy(r.desc('createdDate'));
 
       if( ids ){ // doc id must be in specified id list
         let exprs = ids.map(id => r.row('id').eq(id));


### PR DESCRIPTION
It is necessary for the home page exploration list to get the list of recent documents without the API key, because the home page is public.  In order to simplify things, the API key restriction has been removed:  The API key is not necessary in order to list the documents.  All documents are considered public information.

Further, the list of documents in the explore view should be ordered by most recent to least recent.  This ordering is applied by default by this route now.

Ref : #619