### PR TITLE
Increasing robustness to missing PubMed data

### DIFF
--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -353,7 +353,7 @@ class DocumentManagementDocumentComponent extends React.Component {
 
       } else {
         const { authors: { contacts, abbreviation }, title, reference, pmid, doi } = doc.citation();
-        const contactList = contacts.map( contact => `${contact.email} <${contact.name}>` ).join(', ');
+        const contactList = !_.isArray( contacts ) && contacts.map( contact => `${contact.email} <${contact.name}>` ).join(', ');
         const { paperId } = doc.provided();
 
         items =  [


### PR DESCRIPTION
- Include defaults for (possibly empty) citation data returned from PubMed data utility
- Admin check for empty citation 'contacts' field