### PR TITLE
Explore View: Basic

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -506,7 +506,7 @@ class Editor extends DataComponent {
           h( ExpandableListComponent, {
             maxHead: 3,
             maxTail: 2,
-            moreLabelComponent: h('span', 'More authors' )
+            expandLabel: h('span', 'More authors' )
           }, authorList.map( ({ name, email, abbrevName, isCollectiveName }) => {
               const term = `${abbrevName}${ isCollectiveName ? '': '[Author]'}`;
               const pubmedSearchQuery = queryString.stringify({ term });

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -27,7 +27,7 @@ import MainMenu from '../main-menu';
 import UndoRemove from './undo-remove';
 import { TaskView } from '../tasks';
 
-import { ExpandableList } from '../expand-collapse';
+import { ExpandableListComponent } from '../expand-collapse';
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;
@@ -491,8 +491,9 @@ class Editor extends DataComponent {
     let { history } = this.props;
 
     const getTitleContent = document => {
-      let { authors, title = 'Unnamed document', reference, doi } = document.citation();
-      const authorList = _.get( authors, 'authorList', [] );
+      let { authors: { authorList }, title, reference, doi } = document.citation();
+      title = title || 'Untitled';
+      authorList = authorList || [];
       return [
         h('div.editor-title-name', [
           doi ? h( 'a.plain-link', {
@@ -502,9 +503,9 @@ class Editor extends DataComponent {
           title
         ]),
         h('div.editor-title-info', [
-          h( ExpandableList, {
-            maxHead: 3,
-            maxTail: 200
+          h( ExpandableListComponent, {
+            maxHead: 2,
+            maxTail: 2
           }, authorList.map( ({ name, email, abbrevName, isCollectiveName }) => {
               const term = `${abbrevName}${ isCollectiveName ? '': '[Author]'}`;
               const pubmedSearchQuery = queryString.stringify({ term });
@@ -531,7 +532,6 @@ class Editor extends DataComponent {
         ])
       ];
     };
-    // let { authors: { abbreviation }, title = 'Unnamed document', reference, doi } = document.citation();
     let editorContent = this.data.initted ? [
       h('div.editor-title', [
         h('div.editor-title-content', getTitleContent( document ) )

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -491,10 +491,16 @@ class Editor extends DataComponent {
     let { history } = this.props;
 
     const getTitleContent = document => {
-      let { authors: { authorList }, title, reference, doi } = document.citation();
+      let { authors: { authorList, abbreviation }, title, reference, doi } = document.citation();
       title = title || 'Untitled';
       authorList = authorList || [];
-      return [
+      return this.editable() ? [
+        h('div.editor-title-name', title ),
+        h('div.editor-title-info', [
+            h('div', abbreviation ),
+            h('div', reference )
+        ])
+        ] : [
         h('div.editor-title-name', [
           doi ? h( 'a.plain-link', {
             href: DOI_LINK_BASE_URL + doi,

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -504,8 +504,9 @@ class Editor extends DataComponent {
         ]),
         h('div.editor-title-info', [
           h( ExpandableListComponent, {
-            maxHead: 2,
-            maxTail: 2
+            maxHead: 3,
+            maxTail: 2,
+            moreLabelComponent: h('span', 'More authors' )
           }, authorList.map( ({ name, email, abbrevName, isCollectiveName }) => {
               const term = `${abbrevName}${ isCollectiveName ? '': '[Author]'}`;
               const pubmedSearchQuery = queryString.stringify({ term });

--- a/src/client/components/expand-collapse.js
+++ b/src/client/components/expand-collapse.js
@@ -64,7 +64,7 @@ class ExpandableListComponent extends React.Component {
       expanded: false
     };
 
-    this.length = props.children.length;
+    this.length = _.get( props, ['children', 'length'], 0 );
     const { numElidable } = this.calcListStats();
     this.isElidable = numElidable > 0;
   }

--- a/src/client/components/expand-collapse.js
+++ b/src/client/components/expand-collapse.js
@@ -33,13 +33,13 @@ class ElideSymbolComponent extends React.Component {
 
 class ElideToggleComponent extends React.Component {
   render(){
-    const { onToggle, getState, moreLabelComponent, fewerLabelComponent } = this.props;
+    const { onToggle, getState, expandLabel, collapseLabel } = this.props;
     const expanded = getState();
     return h( ExpandableListItemComponent, { classes: { 'elide-toggle-element': true } }, [
       h( Toggle, {
         onToggle, getState, className: 'elide-toggle'
       }, [
-        expanded ? fewerLabelComponent: moreLabelComponent
+        expanded ? collapseLabel: expandLabel
       ])
     ]);
   }
@@ -85,7 +85,7 @@ class ExpandableListComponent extends React.Component {
   }
 
   getItems(){
-    const { children, elideSymbol, moreLabelComponent, fewerLabelComponent } = this.props;
+    const { children, elideSymbol, expandLabel, collapseLabel } = this.props;
     const { headEndIndex, tailStartIndex } = this.calcListStats();
     const shouldElide = i => i >= headEndIndex && i < tailStartIndex;
 
@@ -100,8 +100,8 @@ class ExpandableListComponent extends React.Component {
       const collapseListElement = h( ElideToggleComponent, {
         getState: () => this.state.expanded,
         onToggle: evt => this.handleElideClick( evt ),
-        moreLabelComponent,
-        fewerLabelComponent
+        expandLabel,
+        collapseLabel
       }, h( 'small', 'Collapse' ) );
       items = items.concat( collapseListElement );
     }
@@ -122,8 +122,8 @@ ExpandableListComponent.defaultProps = {
   maxHead: 3,
   maxTail: 1,
   elideSymbol: h('i.material-icons', 'more_horiz'),
-  moreLabelComponent: h('span', 'More' ),
-  fewerLabelComponent: h('span', 'Fewer' )
+  expandLabel: h('span', 'More' ),
+  collapseLabel: h('span', 'Fewer' )
 };
 
 export { ExpandableListComponent };

--- a/src/client/components/expand-collapse.js
+++ b/src/client/components/expand-collapse.js
@@ -2,45 +2,35 @@ import React from 'react';
 import h from 'react-hyperscript';
 import { makeClassList } from '../../util';
 import _ from 'lodash';
+import Toggle from './toggle';
 
+const insertAt = ( arr, start, item ) => [ ...arr.slice(0, start),
+  item,
+  ...arr.slice(start)
+];
 
-const getListItems = ( children, maxHead, maxTail ) => {
-  const N = children.length;
-  let headEndIndex = Math.min( maxHead, N );
-  let numTailItems = N - headEndIndex;
-  let itemsFromEnd = Math.min( numTailItems, maxTail );
-  let tailStartIndex = N - itemsFromEnd;
-
-
-  // const numItemsToHide = tailStartIndex - headEndIndex;
-  const shouldHide = i => i >= headEndIndex && i < tailStartIndex;
-
-  // console.log( `total: ${N}` );
-  // console.log(`Items from start: ${headEndIndex}`);
-  // console.log(`Items from end: ${itemsFromEnd}`);
-  // console.log(`numItemsToHide: ${numItemsToHide}`);
-
-  return children.map( ( child, i ) => {
-    const p = { hidden: false };
-    if( shouldHide( i ) ) _.set( p, 'hidden', true );
-    return h( Item, p, child );
-  });
-};
-
-class Item extends React.Component {
+class ExpandableListItemComponent extends React.Component {
 
   render(){
-    const { children, hidden, lastHead } = this.props;
+    let { children, classes } = this.props;
+    const classList = _.assign( {}, classes );
     return h('li.expandable-list-item', {
-      className: makeClassList({
-        hidden, lastHead
-      })
+      className: makeClassList( classList )
     }, children );
   }
 }
 
+class ElideComponent extends React.Component {
+  render(){
+    const { onToggle, getState } = this.props;
+    return h( ExpandableListItemComponent, { classes: { 'elide-element': true } }, [
+      h( Toggle, { onToggle, getState, className: 'elide-toggle' }, [ h('i.material-icons', 'more_horiz') ] )
+    ]);
+  }
+}
+
 /**
- * ExpandableList
+ * ExpandableListComponent
  *
  * Generate an unordered list from react components which can be toggled to display
  * a given number of items from the start (maxHead) and end (maxTail).
@@ -49,14 +39,76 @@ class Item extends React.Component {
  *   - maxHead {Number} show this many items from beginning of list
  *   - maxTail {Number} show this many items from end of list
  */
-class ExpandableList extends React.Component {
+class ExpandableListComponent extends React.Component {
+
+  constructor( props ){
+    super( props );
+
+    this.state = {
+      expanded: false,
+      numHead: props.maxHead,
+      numTail: props.maxTail
+    };
+
+    this.length = props.children.length;
+    const { numElidable } = this.calcListStats();
+    this.isElidable = numElidable > 0;
+  }
+
+  calcListStats(){
+    const { numHead, numTail } = this.state;
+    const N = this.length;
+    const headEndIndex = Math.min( numHead, N );
+    const numTailItems = N - headEndIndex;
+    const itemsFromEnd = Math.min( numTailItems, numTail );
+    const tailStartIndex = N - itemsFromEnd;
+    const numElidable = tailStartIndex - headEndIndex;
+    return { headEndIndex, tailStartIndex, numElidable };
+  }
+
+  handleElideClick(){
+    this.setState( ( state, props ) => {
+      let numHead = props.maxHead;
+      let numTail = props.maxTail;
+      if( !state.expanded ){
+        numHead = this.length;
+        numTail = 0;
+      }
+      return { expanded: !state.expanded, numHead, numTail };
+    });
+  }
+
+  getItems(){
+    const { children } = this.props;
+    const { headEndIndex, tailStartIndex } = this.calcListStats();
+    const shouldElide = i => i >= headEndIndex && i < tailStartIndex;
+
+    const createItem = ( child, i ) => h( ExpandableListItemComponent, { classes: { elidable: shouldElide(i) ? true: false } }, child );
+    let items = children.map( createItem );
+
+    if( this.isElidable ){
+      const { expanded } = this.state;
+      const startElide = _.findIndex( items, 'props.classes.elidable' );
+      const elideListElement = h( ElideComponent, {
+        getState: () => expanded,
+        onToggle: evt => this.handleElideClick( evt )
+      });
+      if( startElide > -1 ) items = insertAt( items, startElide, elideListElement );
+    }
+
+    return items;
+  }
 
   render(){
-    const { children, maxHead = 3, maxTail = 1 } = this.props;
+    const { children } = this.props;
     if( !children ) return null;
-    return h('ul.expandable-list', getListItems( children, maxHead, maxTail )
-    );
+    return h('ul.expandable-list', this.getItems());
   }
 }
 
-export { ExpandableList };
+ExpandableListComponent.defaultProps = {
+  maxHead: 3,
+  maxTail: 1
+};
+
+export { ExpandableListComponent };

--- a/src/client/components/expand-collapse.js
+++ b/src/client/components/expand-collapse.js
@@ -22,9 +22,17 @@ class ExpandableListItemComponent extends React.Component {
 
 class ElideComponent extends React.Component {
   render(){
-    const { onToggle, getState } = this.props;
     return h( ExpandableListItemComponent, { classes: { 'elide-element': true } }, [
-      h( Toggle, { onToggle, getState, className: 'elide-toggle' }, [ h('i.material-icons', 'more_horiz') ] )
+      h('i.material-icons', 'more_horiz')
+    ]);
+  }
+}
+
+class CollapseComponent extends React.Component {
+  render(){
+    const { onToggle, getState } = this.props;
+    return h( ExpandableListItemComponent, { classes: { 'elide-toggle-element': true } }, [
+      h( Toggle, { onToggle, getState, className: 'elide-toggle' }, [ h('small', 'Show fewer') ] )
     ]);
   }
 }
@@ -87,13 +95,15 @@ class ExpandableListComponent extends React.Component {
     let items = children.map( createItem );
 
     if( this.isElidable ){
-      const { expanded } = this.state;
       const startElide = _.findIndex( items, 'props.classes.elidable' );
-      const elideListElement = h( ElideComponent, {
-        getState: () => expanded,
+      const elidedElement = h( ElideComponent );
+      items = insertAt( items, startElide, elidedElement );
+
+      const collapseListElement = h( CollapseComponent, {
+        getState: () => this.state.expanded,
         onToggle: evt => this.handleElideClick( evt )
-      });
-      if( startElide > -1 ) items = insertAt( items, startElide, elideListElement );
+      }, h( 'small', 'Collapse' ) );
+      items = items.concat( collapseListElement );
     }
 
     return items;
@@ -102,6 +112,7 @@ class ExpandableListComponent extends React.Component {
   render(){
     const { children } = this.props;
     if( !children ) return null;
+    console.log(`isElidable: ${this.isElidable}`);
     return h('ul.expandable-list', this.getItems());
   }
 }

--- a/src/client/components/expand-collapse.js
+++ b/src/client/components/expand-collapse.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import h from 'react-hyperscript';
+import { makeClassList } from '../../util';
+import _ from 'lodash';
+
+
+const getListItems = ( children, maxHead, maxTail ) => {
+  const N = children.length;
+  let headEndIndex = Math.min( maxHead, N );
+  let numTailItems = N - headEndIndex;
+  let itemsFromEnd = Math.min( numTailItems, maxTail );
+  let tailStartIndex = N - itemsFromEnd;
+
+
+  // const numItemsToHide = tailStartIndex - headEndIndex;
+  const shouldHide = i => i >= headEndIndex && i < tailStartIndex;
+
+  // console.log( `total: ${N}` );
+  // console.log(`Items from start: ${headEndIndex}`);
+  // console.log(`Items from end: ${itemsFromEnd}`);
+  // console.log(`numItemsToHide: ${numItemsToHide}`);
+
+  return children.map( ( child, i ) => {
+    const p = { hidden: false };
+    if( shouldHide( i ) ) _.set( p, 'hidden', true );
+    return h( Item, p, child );
+  });
+};
+
+class Item extends React.Component {
+
+  render(){
+    const { children, hidden, lastHead } = this.props;
+    return h('li.expandable-list-item', {
+      className: makeClassList({
+        hidden, lastHead
+      })
+    }, children );
+  }
+}
+
+/**
+ * ExpandableList
+ *
+ * Generate an unordered list from react components which can be toggled to display
+ * a given number of items from the start (maxHead) and end (maxTail).
+ *
+ * props
+ *   - maxHead {Number} show this many items from beginning of list
+ *   - maxTail {Number} show this many items from end of list
+ */
+class ExpandableList extends React.Component {
+
+  render(){
+    const { children, maxHead = 3, maxTail = 1 } = this.props;
+    if( !children ) return null;
+    return h('ul.expandable-list', getListItems( children, maxHead, maxTail )
+    );
+  }
+}
+
+export { ExpandableList };

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -88,6 +88,7 @@
   text-align: center;
   width: 100%;
   pointer-events: none;
+  line-height: normal;
 }
 
 .editor-title-content {

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -112,6 +112,11 @@
   font-size: var(--smallFontSize);
 }
 
+.editor-title-info-authors-email {
+  margin-left: 0.4em;
+  vertical-align: middle;
+}
+
 .editor-task-list-active {
   & .editor-branding {
     left: calc(50% - 11em);

--- a/src/styles/expand-collapse.css
+++ b/src/styles/expand-collapse.css
@@ -14,7 +14,7 @@
   margin-left: 0.2em;
 }
 
-.expandable-list-item:not(.elidable, .elide-element, .elide-toggle-element) ~ .expandable-list-item:not(.elidable, .elide-element, .elide-toggle-element)::before {
+.expandable-list-item:not(.elide-element, .elide-toggle-element) ~ .expandable-list-item:not(.elide-element, .elide-toggle-element)::before {
   content: " • ";
 }
 

--- a/src/styles/expand-collapse.css
+++ b/src/styles/expand-collapse.css
@@ -1,19 +1,37 @@
 .expandable-list {
   margin: 0 auto;
+
+  & .elidable {
+    display: none;
+  }
 }
 
 .expandable-list-item {
   display: inline;
-
-  &.elidable {
-    display: none;
-  }
 }
 
 .expandable-list-item.elide-element {
   margin-left: 0.2em;
 }
 
-.expandable-list-item:not(.elidable, .elide-element) ~ .expandable-list-item:not(.elidable, .elide-element)::before {
+.expandable-list-item:not(.elidable, .elide-element, .elide-toggle-element) ~ .expandable-list-item:not(.elidable, .elide-element, .elide-toggle-element)::before {
   content: " • ";
+}
+
+.expandable-list.expanded {
+  & > .expandable-list-item.elide-element {
+    display: none;
+  }
+
+  & > .expandable-list-item.elidable {
+    display: initial;
+  }
+}
+
+.expandable-list-item .button-toggle.elide-toggle {
+  border: 0;
+  margin: auto 0.4em;
+  background-color: transparent;
+  color: var(--fadedColor);
+  text-decoration: underline;
 }

--- a/src/styles/expand-collapse.css
+++ b/src/styles/expand-collapse.css
@@ -5,11 +5,20 @@
 .expandable-list-item {
   display: inline;
 
-  &.hidden {
+  &.elidable {
     display: none;
   }
 }
 
-.expandable-list-item:not(.hidden) ~ .expandable-list-item:not(.hidden)::before {
+.expandable-list-item .elide-toggle {
+  border: 0;
+  margin-left: 0.2em;
+
+  &.button-toggle-on {
+    display: none;
+  }
+}
+
+.expandable-list-item:not(.elidable, .elide-element) ~ .expandable-list-item:not(.elidable, .elide-element)::before {
   content: " • ";
 }

--- a/src/styles/expand-collapse.css
+++ b/src/styles/expand-collapse.css
@@ -1,0 +1,15 @@
+.expandable-list {
+  margin: 0 auto;
+}
+
+.expandable-list-item {
+  display: inline;
+
+  &.hidden {
+    display: none;
+  }
+}
+
+.expandable-list-item:not(.hidden) ~ .expandable-list-item:not(.hidden)::before {
+  content: " • ";
+}

--- a/src/styles/expand-collapse.css
+++ b/src/styles/expand-collapse.css
@@ -10,13 +10,8 @@
   }
 }
 
-.expandable-list-item .elide-toggle {
-  border: 0;
+.expandable-list-item.elide-element {
   margin-left: 0.2em;
-
-  &.button-toggle-on {
-    display: none;
-  }
 }
 
 .expandable-list-item:not(.elidable, .elide-element) ~ .expandable-list-item:not(.elidable, .elide-element)::before {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -21,3 +21,4 @@
 @import "./main-menu.css";
 @import "./copy-field.css";
 @import "./share.css";
+@import "./expand-collapse.css";


### PR DESCRIPTION
Enhance the editor (non-editable) view with relevant links in the title.

- Links
  - Article title link points to journal by resolving `https://doi.org/<DOI>`
  - Author links point to PubMed author search (e.g. 'Wong JV[Author]')
  - Email icon, if exists, does a link for `mailto:<EMAIL>`
- Component: 'expandable list'
  - configure # leading, trailing items, toggle button etc
  - calculates if and when the toggle can be displayed at all   

Notes: You can see the limitation of the explore view when there are a lot of authors. I wouldn't try to handle this now as we're likely pushing for a 'mobile' first approach anyways.
 
Refs #622 

Below are some examples when I configure the component to show 3 leading and 2 tailing authors in a simulated phone screen (iPhone 8 plus). 

- Left:  Less than the number of leading + tailing authors
- Middle:  A reasonable number of authors
- Left:  Massive number of authors 

![image](https://user-images.githubusercontent.com/4706307/74546070-fa46af80-4f17-11ea-9714-ac7d2ae46314.png)


  


