### PR TITLE
Submit: Email follow-up notification

### DIFF
--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import DataComponent from './data-component';
 import h from 'react-hyperscript';
+import queryString from 'query-string';
 
 import { BASE_URL } from '../../config';
 
@@ -45,8 +46,28 @@ class TaskView extends DataComponent {
       this.dirty();
     };
 
+    this.onSubmit = () => {
+      const id = this.props.document.id();
+      const secret = this.props.document.secret();
+      const apiKey = '';
+      const params = [
+        { op: 'replace', path: 'status', value: 'published' }
+      ];
+      const url = `/api/document/status/${id}/${secret}/?${queryString.stringify({ apiKey })}`;
+      return fetch( url, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify( params )
+      });
+    };
+
     this.onUpdate = change => {
-      if( _.has( change, 'status' ) ) this.dirty();
+      if( _.has( change, 'status' ) ){
+        if( change.status === 'submitted' ) this.onSubmit();
+        this.dirty();
+      }
     };
 
     this.props.document.on('add', this.onAdd);

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import DataComponent from './data-component';
 import h from 'react-hyperscript';
-import queryString from 'query-string';
 
 import { BASE_URL } from '../../config';
 
@@ -49,11 +48,10 @@ class TaskView extends DataComponent {
     this.onSubmit = () => {
       const id = this.props.document.id();
       const secret = this.props.document.secret();
-      const apiKey = '';
       const params = [
         { op: 'replace', path: 'status', value: 'published' }
       ];
-      const url = `/api/document/status/${id}/${secret}/?${queryString.stringify({ apiKey })}`;
+      const url = `/api/document/status/${id}/${secret}`;
       return fetch( url, {
         method: 'PATCH',
         headers: {

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -3,6 +3,7 @@ import DataComponent from './data-component';
 import h from 'react-hyperscript';
 
 import { BASE_URL } from '../../config';
+import Document from '../../model/document';
 
 const eleEvts = [ 'rename', 'complete', 'uncomplete' ];
 
@@ -46,10 +47,11 @@ class TaskView extends DataComponent {
     };
 
     this.onSubmit = () => {
+      const DOCUMENT_STATUS_FIELDS = Document.statusFields();
       const id = this.props.document.id();
       const secret = this.props.document.secret();
       const params = [
-        { op: 'replace', path: 'status', value: 'published' }
+        { op: 'replace', path: 'status', value: DOCUMENT_STATUS_FIELDS.PUBLISHED }
       ];
       const url = `/api/document/status/${id}/${secret}`;
       return fetch( url, {

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -494,8 +494,9 @@ http.patch('/status/:id/:secret', function( req, res, next ){
   const tryPublish = async doc => {
     let didPublish = false;
     const hasEles = doc => doc.elements().length > 0;
+    const hasIncompleteEles = doc => doc.elements().some( ele => !ele.completed() && !ele.isInteraction() );
     const hasSubmittedStatus = doc => doc.status() === DOCUMENT_STATUS_FIELDS.SUBMITTED;
-    const isPublishable = doc => hasEles( doc ) && hasSubmittedStatus( doc );
+    const isPublishable = doc => hasEles( doc ) && !hasIncompleteEles( doc ) && hasSubmittedStatus( doc );
     if( isPublishable( doc ) ){
       await doc.publish();
       didPublish = true;

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -490,7 +490,6 @@ http.patch('/email/:id/:secret', function( req, res, next ){
 // Update document status
 http.patch('/status/:id/:secret', function( req, res, next ){
   const { id, secret } = req.params;
-  const { apiKey } = req.query;
 
   const tryPublish = async doc => {
     let didPublish = false;
@@ -526,8 +525,7 @@ http.patch('/status/:id/:secret', function( req, res, next ){
   };
 
   return (
-    tryPromise( () => checkApiKey( apiKey ) )
-    .then( () => res.end() )
+    tryPromise( () => res.end() )
     .then( loadTables )
     .then( ({ docDb, eleDb }) => loadDoc ({ docDb, eleDb, id, secret }) )
     .then( updateDocStatus )


### PR DESCRIPTION
Upon 'Submit' in editor, attempt to 'publish' and send follow-up email notification automatically.
  - Email notification only occurs when 'Submit' button is clicked in the editor. This avoids a case where updates happen elsewhere, such as the  admin
  - Setting a doc to 'published'   
    - Must not be empty
    - Must not have incomplete entities/nodes
    - Must have status='submitted' 

Refs #627 

> We may want to go directly to "published" and skip "submitted" by default. It's better for a user to see his summary right away, and we can manually demote a document from "published" to "submitted" using the admin interface --- as needed.
>  Note: This may require some basic, automated sanity checks (e.g. don't automatically publish if there are blank nodes).

