### PR TITLE
Email templates: Provide a default for missing title and reference (e…

### DIFF
--- a/src/util/email.js
+++ b/src/util/email.js
@@ -38,7 +38,7 @@ const msgFactory = ( emailType, doc ) => {
       vendor: EMAIL_VENDOR_MAILJET,
       vars: {
         baseUrl: BASE_URL,
-        citation: `${title} ${reference}`
+        citation: _.compact([title, reference]).join(' ')
       }
     }
   };


### PR DESCRIPTION
Currently an email will have a citation with 'null' in the text. 

Instead: Provide email template with a reasonable default when title and/or reference information (e.g. No PubMed record) is absent.