### PR TITLE
Admin: More flexible email formats

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -5,7 +5,6 @@ import _ from 'lodash';
 import uuid from 'uuid';
 import fetch from 'node-fetch';
 import cytosnap from 'cytosnap';
-import emailRegex from 'email-regex';
 import Twitter from 'twitter';
 import LRUCache from 'lru-cache';
 
@@ -103,7 +102,6 @@ const DEFAULT_CORRESPONDENCE = {
 
 const fillDocCorrespondence = async ( doc, authorEmail, context ) => {
   try {
-    if( !emailRegex({exact: true}).test( authorEmail ) ) throw new TypeError( `Could not detect an email for '${authorEmail}'` );
     const emails = _.get( doc.correspondence(), 'emails' );
     const data = _.defaults( { authorEmail, context, emails }, DEFAULT_CORRESPONDENCE );
     await doc.correspondence( data );

--- a/src/util/email.js
+++ b/src/util/email.js
@@ -31,9 +31,7 @@ const msgFactory = ( emailType, doc ) => {
       name: EMAIL_FROM,
       address: EMAIL_FROM_ADDR
     },
-    to: {
-      address: `${authorEmail}`
-    },
+    to: authorEmail,
     template: {
       vendor: EMAIL_VENDOR_MAILJET,
       vars: {


### PR DESCRIPTION
Directly funnel email field to email transport service. Can come in any formats supported by Nodemailer, so more flexible.

See Nodemailer docs for [addresses](https://nodemailer.com/message/addresses/)