### PR TITLE
Refactoring: Populating and accessing document article field with pubmed data 

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -211,7 +211,7 @@ class Editor extends DataComponent {
       .then( () => {
         this.setData({ initted: true, showHelp: this.data.document.editable() });
 
-        const title = _.get(this.data.document.article(), ['MedlineCitation', 'Article', 'ArticleTitle']);
+        const title = _.get(this.data.document.citation(), ['title']);
 
         if( title ){
           document.title = `${title} : Biofactoid`;

--- a/src/client/components/home.js
+++ b/src/client/components/home.js
@@ -225,10 +225,8 @@ class Scroller extends Component {
 
   render(){
     const exploreDocEntry = doc => {
-      const Article = doc.article.MedlineCitation.Article;
-      const title = Article.ArticleTitle;
-      let authorNames = Article.AuthorList.map(a => a.LastName ? `${a.ForeName} ${a.LastName}` : a.CollectiveName );
-      const journalName = Article.Journal.ISOAbbreviation;
+      const { title, authors: { authorList }, reference: journalName } = doc.citation;
+      let authorNames = authorList.map( a => a.name );
       const id = doc.id;
       const link = doc.publicUrl;
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -112,41 +112,9 @@ const fillDocCorrespondence = async ( doc, authorEmail, context ) => {
 };
 
 const fillDocArticle = async ( doc, paperId ) => {
-  try {
-    const pubmedRecord = await getPubmedArticle( paperId );
-    await doc.article( pubmedRecord );
-    // TODO - is this a unique request?
-    await doc.issues({ paperId: null });
-  } catch ( error ){
-    await doc.article({
-      "MedlineCitation": {
-        "Article": {
-          "Abstract": "",
-          "ArticleTitle": `${paperId}`,
-          "AuthorList": [],
-          "Journal": {
-            "ISOAbbreviation": "",
-            "ISSN": null,
-            "Issue": null,
-            "PubDate": null,
-            "Title": "",
-            "Volume": null
-          }
-        },
-        "ChemicalList": null,
-        "InvestigatorList": null,
-        "KeywordList": null,
-        "MeshheadingList": null
-      },
-      "PubmedData": {
-        "ArticleIdList": [],
-        "History": [],
-        "ReferenceList": null
-      }
-    });
-
-    await doc.issues({ paperId: null });
-  }
+  const pubmedRecord = await getPubmedArticle( paperId );
+  await doc.article( pubmedRecord );
+  await doc.issues({ paperId: null });
 };
 
 const fillDoc = async doc => {

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -67,6 +67,38 @@ const findPubmedId = async paperId => {
   return id;
 };
 
+const generatePubmedArticle = title => {
+
+  const PubMedArticle = {
+    "MedlineCitation": {
+      "Article": {
+        "Abstract": null,
+        "ArticleTitle": null,
+        "AuthorList": [],
+        "Journal": {
+          "ISOAbbreviation": null,
+          "ISSN": null,
+          "Issue": null,
+          "PubDate": null,
+          "Title": null,
+          "Volume": null
+        }
+      },
+      "ChemicalList": [],
+      "InvestigatorList": [],
+      "KeywordList": [],
+      "MeshheadingList": []
+    },
+    "PubmedData": {
+      "ArticleIdList": [],
+      "History": [],
+      "ReferenceList": []
+    }
+  };
+
+  return _.set( PubMedArticle, [ 'MedlineCitation', 'Article', 'ArticleTitle' ], title );
+};
+
 /**
  * getPubmedRecord
  *
@@ -74,6 +106,7 @@ const findPubmedId = async paperId => {
  *   - A set of digits
  *   - A url
  *     - Containing a set of digits e.g. 'https://www.ncbi.nlm.nih.gov/pubmed/123456'
+ *     - Containing a query e.g. 'https://www.ncbi.nlm.nih.gov/pubmed/?term=123456'
  *     - A search returning a single PubMed UID
  *
  * @param {String} paperId Contains or references a single PubMed uid (see above). If 'demo' return canned demo data.
@@ -81,16 +114,26 @@ const findPubmedId = async paperId => {
  * @throws {TypeError} When paperId falls outside of the above cases
  */
 const getPubmedArticle = async paperId => {
-  if( paperId === DEMO_ID ) return demoPubmedArticle;
-  const candidateId = await findPubmedId( paperId );
-  const { PubmedArticleSet } = await fetchPubmed({
-    uids: [ candidateId ]
-  });
+  if( paperId === DEMO_ID ){
+    return demoPubmedArticle;
 
-  if( !_.isEmpty( PubmedArticleSet ) ){
-    return _.head( PubmedArticleSet );
   } else {
-    throw new ArticleIDError( `No PubMed record for '${paperId}'` );
+    try {
+      const candidateId = await findPubmedId( paperId );
+      const { PubmedArticleSet } = await fetchPubmed({
+        uids: [ candidateId ]
+      });
+
+      if( !_.isEmpty( PubmedArticleSet ) ){
+        return _.head( PubmedArticleSet );
+      } else {
+        throw new ArticleIDError( `No PubMed record for '${paperId}'` );
+      }
+
+    } catch ( err ) {
+      return generatePubmedArticle( paperId );
+
+    }
   }
 };
 


### PR DESCRIPTION
- PubMed module returns article data or fallback to manually filled-in
- Removed instances where doc 'article' field is accessed, and instead access the 'citation' field which is independent of the data source