### PR TITLE
Admin: Reinstituting password protection

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -268,14 +268,16 @@ http.get('/', function( req, res, next ){
     })
     .then( cursor => cursor.toArray() )
     .then( res => {
-      try {
-        checkApiKey(apiKey);
+      if( !_.isUndefined( apiKey ) ){
+        try {
+          checkApiKey(apiKey);
+          return { res, haveSecretAccess: true };
+        } catch( err ){ throw err; }
 
-        return { res, haveSecretAccess: true };
-      } catch( err ){
+      } else {
         return { res, haveSecretAccess: false };
       }
-    } )
+    })
     .then( ({res, haveSecretAccess}) => { // map ids to full doc json
       return Promise.all(res.map(docDbJson => {
         let { id } = docDbJson;


### PR DESCRIPTION
- If an API_KEY is set on server, then when a client declares an 'apiKey' url parameter, then the server will attempt to validate.
- If no API_KEY env is set on server, but the apiKey is sent by client it returns private fields.
- Otherwise, the route returns read-only versions of docs.

Refs #651 