### PR TITLE
Document route check for apiKey, used by admin  

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -410,6 +410,15 @@ http.post('/:id/tweet', function( req, res, next ){
   );
 });
 
+http.get('/api-key-verify', function( req, res, next ){
+  let apiKey = req.query.apiKey;
+
+  ( tryPromise( () => checkApiKey( apiKey ) )
+    .then( () => res.end() )
+    .catch( next )
+  );
+});
+
 // get existing doc as json
 http.get('/:id', function( req, res, next ){
   let id = req.params.id;


### PR DESCRIPTION
Add a document API route named 'api-key-verify' that throws if not a match. Admin does a check of its apiKey param before trying to loading ('secret'-enabled) docs.