### PR TITLE
Create doc before ending server response

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -542,17 +542,19 @@ http.post('/', function( req, res, next ){
     if( id === DEMO_ID ) await deleteTableRows( API_KEY, secret );
     return await createDoc({ docDb, eleDb, id, secret, provided });
   };
+  const sendJSONResponse = doc => tryPromise( () => doc.json() )
+  .then( json => res.json( json ) );
 
   checkRequestContext( provided )
     .then( () => createSecret({ secret }) )
     .then( loadTables )
     .then( handleDocCreation )
-    .then( doc => { res.end(); return doc; } )
     .then( setRequestStatus )
     .then( fillDoc )
     .then( setApprovedStatus )
     .then( tryVerify )
     .then( sendInviteNotification )
+    .then( sendJSONResponse )
     .catch( next );
 });
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -544,10 +544,10 @@ http.post('/', function( req, res, next ){
   };
 
   checkRequestContext( provided )
-    .then( () => res.end() )
     .then( () => createSecret({ secret }) )
     .then( loadTables )
     .then( handleDocCreation )
+    .then( doc => { res.end(); return doc; } )
     .then( setRequestStatus )
     .then( fillDoc )
     .then( setApprovedStatus )

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -543,7 +543,8 @@ http.post('/', function( req, res, next ){
     return await createDoc({ docDb, eleDb, id, secret, provided });
   };
   const sendJSONResponse = doc => tryPromise( () => doc.json() )
-  .then( json => res.json( json ) );
+  .then( json => res.json( json ) )
+  .then( () => doc );
 
   checkRequestContext( provided )
     .then( () => createSecret({ secret }) )
@@ -553,8 +554,8 @@ http.post('/', function( req, res, next ){
     .then( fillDoc )
     .then( setApprovedStatus )
     .then( tryVerify )
-    .then( sendInviteNotification )
     .then( sendJSONResponse )
+    .then( sendInviteNotification )
     .catch( next );
 });
 


### PR DESCRIPTION
This was noticed on the demo (Editor) page, but updates the server so that POST request to `api/document` now end server response  after the doc is created. 

Refs #676.