### PR TITLE
Limit display of article titles in request form/CTA

### DIFF
--- a/src/client/components/home.js
+++ b/src/client/components/home.js
@@ -4,11 +4,9 @@ import { Component } from 'react';
 import Popover from './popover/popover';
 import { makeClassList, tryPromise } from '../../util';
 import EventEmitter from 'eventemitter3';
+import { truncateString } from '../../util';
 
 import { EMAIL_CONTEXT_SIGNUP, TWITTER_ACCOUNT_NAME, EMAIL_CONTEXT_JOURNAL, DOI_LINK_BASE_URL } from '../../config';
-
-// Truncate long titles by character count
-const MAX_CHARS_TITLE = 150;
 
 const checkStatus = response => {
   if ( response.status >= 200 && response.status < 300 ) {
@@ -18,11 +16,6 @@ const checkStatus = response => {
     error.response = response;
     throw error;
   }
-};
-
-const truncateStr = ( raw, maxChars ) => {
-  const text = raw || '';
-  return text.length > maxChars ? `${text.slice( 0, maxChars )}...` : text;
 };
 
 class RequestForm extends Component {
@@ -114,7 +107,7 @@ class RequestForm extends Component {
     const { done, docJSON } = this.state;
     if( done && docJSON ){
       const { privateUrl, citation: { doi, title, reference } } = docJSON;
-      const articleString = _.compact([ truncateStr( title, MAX_CHARS_TITLE ), reference ]).join(' ');
+      const articleString = _.compact([ truncateString( title ), reference ]).join(' ');
 
       return h('div.home-request-form-container', [
         h('div.home-request-form-done', [

--- a/src/client/components/home.js
+++ b/src/client/components/home.js
@@ -7,6 +7,9 @@ import EventEmitter from 'eventemitter3';
 
 import { EMAIL_CONTEXT_SIGNUP, TWITTER_ACCOUNT_NAME, EMAIL_CONTEXT_JOURNAL, DOI_LINK_BASE_URL } from '../../config';
 
+// Truncate long titles by character count
+const MAX_CHARS_TITLE = 150;
+
 const checkStatus = response => {
   if ( response.status >= 200 && response.status < 300 ) {
     return response;
@@ -15,6 +18,11 @@ const checkStatus = response => {
     error.response = response;
     throw error;
   }
+};
+
+const truncateStr = ( raw, maxChars ) => {
+  const text = raw || '';
+  return text.length > maxChars ? `${text.slice( 0, maxChars )}...` : text;
 };
 
 class RequestForm extends Component {
@@ -106,13 +114,13 @@ class RequestForm extends Component {
     const { done, docJSON } = this.state;
     if( done && docJSON ){
       const { privateUrl, citation: { doi, title, reference } } = docJSON;
-      const articleString = _.compact([ title, reference ]).join(' ');
+      const articleString = _.compact([ truncateStr( title, MAX_CHARS_TITLE ), reference ]).join(' ');
+
       return h('div.home-request-form-container', [
         h('div.home-request-form-done', [
           h( 'a.home-request-form-done-button', { href: privateUrl, target: '_blank', }, 'START BIOFACTOID' ),
           h( 'div.home-request-form-done-body', [
-            h( 'span', 'Article: ' ),
-            h( doi ? 'a.plain-link': 'span', (doi ? { href: `${DOI_LINK_BASE_URL}${doi}`, target: '_blank'}: {}), articleString )
+            h( doi ? 'a.plain-link': 'span', (doi ? { href: `${DOI_LINK_BASE_URL}${doi}`, target: '_blank'}: {}), `Article: ${articleString}` )
           ]),
           h( 'div.home-request-form-done-footer', 'An email invitation has also been sent.' )
         ])

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -18,4 +18,8 @@ function longestCommonPrefixLength(str1, str2){
   return i;
 }
 
-export { stringDistanceMetric, longestCommonPrefixLength };
+const truncateString = ( text, maxChars = 150, texOverflow = '...' ) => {
+  return text.length > maxChars ? `${text.slice( 0, maxChars )}${texOverflow}` : text;
+};
+
+export { stringDistanceMetric, longestCommonPrefixLength, truncateString };


### PR DESCRIPTION
Addendum to #675.

Examples: 

- Real article with long title

<img width="318" alt="Screenshot at Mar 23 14-33-08" src="https://user-images.githubusercontent.com/4706307/77351334-02162280-6d14-11ea-85aa-e5560686ff89.png">

- Bogus long text

<img width="305" alt="Screenshot at Mar 23 14-33-35" src="https://user-images.githubusercontent.com/4706307/77351347-06424000-6d14-11ea-8084-41f5d7536f57.png">

