### PR TITLE
Increase the default new node offset

### DIFF
--- a/src/client/components/editor/defs.js
+++ b/src/client/components/editor/defs.js
@@ -1,3 +1,3 @@
-export const newElementPosition = { x: 160, y: 60 };
+export const newElementPosition = { x: 160, y: 100 };
 export const newElementShift = 60;
 export const newElementMaxShifts = 4;


### PR DESCRIPTION
Ref : A newly added entity can be created behind the paper's title #669

Now, the added node has enough of a minimum offset to avoid overlapping the title -- regardless of the window size.

<img width="612" alt="Screen Shot 2020-03-24 at 4 02 04 PM" src="https://user-images.githubusercontent.com/989043/77471618-ffd1c800-6de8-11ea-9fba-71e9eee91ae2.png">
