### PR TITLE
Home page style tweaks (expand on hover, etc.)

### DIFF
--- a/src/client/components/home.js
+++ b/src/client/components/home.js
@@ -212,6 +212,12 @@ class Scroller extends Component {
 
   componentDidMount(){
     this.refreshDocs().then(() => this.updatePagerAvailabilityDebounced());
+
+    window.addEventListener('resize', this.updatePagerAvailabilityDebounced);
+  }
+
+  componentWillUnmount(){
+    window.removeEventListener('resize', this.updatePagerAvailabilityDebounced);
   }
 
   hoverOverDoc(doc){

--- a/src/client/components/home.js
+++ b/src/client/components/home.js
@@ -435,11 +435,11 @@ class Home extends Component {
                   html: h('div.home-contact-info', [
                     h('p', [
                       'Biofactoid is freely brought to you in collaboration with ',
-                      h('a.plain-link', { href: 'https://baderlab.org' }, 'Bader Lab at the University of Toronto'),
+                      h('a.plain-link', { href: 'https://baderlab.org', target: '_blank' }, 'Bader Lab at the University of Toronto'),
                       ', ',
-                      h('a.plain-link', { href: 'http://sanderlab.org' }, 'Sander Lab at Harvard'),
+                      h('a.plain-link', { href: 'http://sanderlab.org', target: '_blank' }, 'Sander Lab at Harvard'),
                       ', and the ',
-                      h('a.plain-link', { href: 'https://www.ohsu.edu/people/emek-demir/AFE06DC89ED9AAF1634F77D11CCA24C3' }, 'Pathway and Omics Lab at the University of Oregon'),
+                      h('a.plain-link', { href: 'https://www.ohsu.edu/people/emek-demir/AFE06DC89ED9AAF1634F77D11CCA24C3', target: '_blank' }, 'Pathway and Omics Lab at the University of Oregon'),
                       '.'
                     ]),
                     h('p', [
@@ -453,8 +453,8 @@ class Home extends Component {
                 'Contact'
               ])
             ]),
-            h('a.home-nav-link', { href: `https://twitter.com/${TWITTER_ACCOUNT_NAME}` }, 'Twitter'),
-            h('a.home-nav-link', { href: 'https://github.com/PathwayCommons/factoid' }, 'GitHub')
+            h('a.home-nav-link', { href: `https://twitter.com/${TWITTER_ACCOUNT_NAME}`, target: '_blank' }, 'Twitter'),
+            h('a.home-nav-link', { href: 'https://github.com/PathwayCommons/factoid', target: '_blank' }, 'GitHub')
           ]),
           h('div.home-credit-logos', [
             h('i.home-credit-logo'),

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -339,7 +339,7 @@
   text-align: center;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 100%);
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.66) 0%, rgba(116, 116, 116, 0.33) 66%, rgba(0, 0, 0, 0) 100%);
 }
 
 .home-banner-logo {

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -111,8 +111,7 @@
   -webkit-user-select: none;
   overflow: visible;
 
-  &:active,
-  &:hover {
+  &.scroller-doc-hovered {
     z-index: 8;
     background-color: #fff;
 

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -63,11 +63,14 @@
 }
 
 .scroller-content {
-  overflow: auto;
+  z-index: 5;
+  overflow-x: auto;
+  overflow-y: visible;
   scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
   display: flex;
   flex-direction: row;
-  padding: 1em 3em;
+  padding: 3em;
   scroll-padding-left: 3em;
   padding-right: 3em;
   box-sizing: border-box;
@@ -76,6 +79,8 @@
   user-select: none;
   -webkit-touch-callout: none !important;
   -webkit-user-select: none;
+  margin-top: -2em;
+  margin-bottom: -2em;
 }
 
 .scroller-content::-webkit-scrollbar {
@@ -104,13 +109,12 @@
   transform: translate3d(0, 0, 0);
   -webkit-touch-callout: none !important;
   -webkit-user-select: none;
+  overflow: visible;
 
   &:active,
   &:hover {
     z-index: 8;
-    box-shadow: 0 0 1em rgba(0, 0, 0, 0.5);
     background-color: #fff;
-    border-width: 0;
 
     & .scroller-doc-descr > * {
       text-overflow: inherit;
@@ -119,6 +123,15 @@
       display: block;
       position: static;
       color: #000;
+    }
+
+    & .scroller-doc-descr {
+      z-index: 10;
+      top: -3em;
+      bottom: -2.25em;
+      background: linear-gradient(to bottom, #fff 0, #fff 3em, rgba(255, 255, 255, 0) 5em), linear-gradient(to top, #fff 0, #fff 3em, rgba(255, 255, 255, 0) 5em);
+      box-shadow: 0 0 1em rgba(0, 0, 0, 0.5);
+      border-radius: 0.25em;
     }
 
     & .scroller-doc-author {
@@ -131,11 +144,6 @@
       &:first-child::after {
         content: none;
       }
-    }
-
-    & .scroller-doc-figure {
-      opacity: 0.2;
-      filter: blur(2px);
     }
   }
 
@@ -195,16 +203,21 @@
 
 .scroller-doc-descr {
   padding: 0.25em 0.33em;
-  width: 100%;
-  height: 100%;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  transition-property: top bottom;
+  transition-duration: 128ms;
+  transition-timing-function: ease-in-out;
   box-sizing: border-box;
   position: absolute;
   z-index: 3;
   background-color: rgba(255, 255, 255, 0);
-  transition: background-color 250ms ease;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  overflow: visible;
 
   & > * {
     text-overflow: ellipsis;
@@ -215,6 +228,7 @@
 }
 
 .scroller-doc-title {
+  position: relative;
   font-weight: bold;
   flex-grow: 1;
   display: block;
@@ -534,7 +548,7 @@
 
 @media (max-width: 400px) {
   .home-explore {
-    margin-bottom: 6em;
+    margin-bottom: 7.5em;
   }
 
   .home-caption,

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -566,7 +566,7 @@
   }
 }
 
-@media (max-width: 700px) {
+@media (max-width: 800px) {
   .home-figure-footer {
     justify-content: center;
   }


### PR DESCRIPTION
This PR includes a number of style fixes and improvements for the home page, chief among them is the revision to the hover effect for the Netflix-like article scroller:

![hover](https://user-images.githubusercontent.com/989043/78591868-1c6ef680-7812-11ea-917e-fd881eac97b6.gif)

This avoids the figure in each card from overlapping the expanded text.  This change will be important to allow for reusing this scroller component for the related papers UI (#681).  The related papers UI will need this extra space in order to accommodate the data shown for each paper.

There are a number of other minor stylistic improvements that affect the home page that are included in this PR.  I've tried to separate out each item into a corresponding commit to facilitate review.  The changes include:

- Make the title & caption more legible for some small screens
- Revise the hover behaviour for the scroller
  - The scroller card expands on hover to give more room for the title and author list without overlapping the figure.
  - The figure is no longer blurred out on hover, as there is no overlap.
  - The scroller on the home page is shifted up to accommodate the extra space needed for card expansion.
- Improve the reliability of hovering w.r.t. scrolling
  - Hovering is faster to activate on mobile.
  - The hover state is removed when scrolling.
- The visibility of the pager icons is updated on window resize
- Links on the home page go out to new tabs
- Improve max screen size threshold for hiding the institution logos in the footer