### PR TITLE
Workaround for mobile page size

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -581,6 +581,32 @@ class Editor extends DataComponent {
   }
 
   componentDidMount(){
+    const container = document.querySelector('.editor');
+
+    this.fixPageHeight = () => {
+      const h = window.innerHeight + 'px';
+   
+      document.body.style.height = h;
+      document.documentElement.style.height = h;
+      container.style.height = h;
+      window.scrollTo(0, 0);
+
+      if( this.data.cy ){
+        this.data.cy.resize().fit();
+      }
+    };
+
+    this.resetPageHeight = () => {
+      document.body.removeAttribute('style');
+      document.documentElement.removeAttribute('style');
+    };
+
+    window.addEventListener('resize', () => {
+      this.fixPageHeight();
+    });
+
+    this.fixPageHeight();
+    
     this.data.mountDeferred.resolve();
 
     keyEmitter.on('escape', this.hideHelp);
@@ -599,6 +625,9 @@ class Editor extends DataComponent {
     document.removeAllListeners();
     bus.removeAllListeners();
     clearTimeout( this.rmAvailTimeout );
+
+    window.removeEventListener('resize', this.fixPageHeight);
+    this.resetPageHeight();
 
     keyEmitter.removeListener('escape', this.hideHelp);
   }

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -1,6 +1,8 @@
 .editor {
-  height: 100%;
-  width: 100%;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   position: absolute;
   opacity: 0.01;
   transition-duration: 300ms;
@@ -126,16 +128,9 @@
   z-index: 0;
   position: absolute;
   left: 0;
+  right: 0;
+  bottom: 0;
   top: 0;
-  width: 100%;
-  height: 100%;
-  transform: translate3d(0, 0, 0);
-  transition: transform 200ms ease-out;
-}
-
-.editor-graph-shifted {
-  transform: translate3d(-21.5em, 0, 0);
-  transition: transform 200ms ease-out;
 }
 
 .editor-menu-content {


### PR DESCRIPTION
- Apply a fixed pixel size to the editor page on load.
- Scroll to the top of the document upon loading the editor page.
- The fix is reapplied each time the page is resized.

Ref : #672