### PR TITLE
Swagger API docs routing

### DIFF
--- a/src/server/routes/api/index.js
+++ b/src/server/routes/api/index.js
@@ -28,8 +28,8 @@ const swaggerOpts = {
 
 const swaggerDocument = swaggerJSDoc( swaggerOpts );
 
-http.get('/api-docs', swaggerUi.setup( swaggerDocument ));
-http.use('/api-docs', swaggerUi.serve);
+http.use('/', swaggerUi.serve);
+http.get('/', swaggerUi.setup( swaggerDocument ));
 
 http.use('/element-association', ElementAssociation);
 http.use('/document', Document);


### PR DESCRIPTION
- Set API docs at `/api(/)`
