### PR TITLE
Misc homepage fixes

### DIFF
--- a/src/client/components/home.js
+++ b/src/client/components/home.js
@@ -476,7 +476,8 @@ class Home extends Component {
             type: 'video/mp4',
             autoPlay: true,
             loop: true,
-            muted: true
+            muted: true,
+            playsInline: true
           })
         ]),
         h('div.home-cta', [

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -672,4 +672,8 @@
   .home-nav-top {
     display: none;
   }
+
+  .home-figure-fg-2 {
+    background-size: cover;
+  }
 }


### PR DESCRIPTION
- Make the figure bigger for small screens in the 'your pathway to share and explore' section.
- Add `playsInline` to allow iPhones to play the video in the background.