### PR TITLE
Submit: Wait for server response before showing 'done' panel

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -123,14 +123,6 @@ class Editor extends DataComponent {
     doc.on('localadd', updateLastEditDate);
     doc.on('localremove', updateLastEditDate);
 
-    doc.on('update', change => {
-      if( _.has( change, 'status' ) ){
-        return new Promise( resolve => this.setData({
-          done: this.data.document.submitted() || this.data.document.published()
-        }, resolve) );
-      }
-    });
-
     doc.on('load', () => {
       doc.interactions().concat( doc.complexes() ).forEach( listenForRmPpt );
 

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -95,7 +95,12 @@ class TaskView extends DataComponent {
       if( _.has( change, 'status' ) ){
         if( change.status === 'submitted' ){
           this.onSubmit()
-            .finally( () => {
+            .then( res => res.json() )
+            .then( () => {
+              new Promise( resolve => this.setState({ submitting: false }, resolve ) )
+              .then( () => this.props.controller.done( true ) );
+            })
+            .catch( () => {
               new Promise( resolve => this.setState({ submitting: false }, resolve ) )
               .then( () => this.props.controller.done( true ) );
             });

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -95,7 +95,6 @@ class TaskView extends DataComponent {
       if( _.has( change, 'status' ) ){
         if( change.status === 'submitted' ){
           this.onSubmit()
-            .then( res => res.json() )
             .then( () => {
               new Promise( resolve => this.setState({ submitting: false }, resolve ) )
               .then( () => this.props.controller.done( true ) );

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -1354,7 +1354,7 @@ http.patch('/status/:id/:secret', function( req, res, next ){
     if ( !doc.hasTweet() ) {
       try {
         let text = truncateString( doc.toText(), MAX_TWEET_LENGTH ); // TODO?
-        return tweetDoc( doc.id(), doc.secret(), text );
+        return await tweetDoc( doc.id(), doc.secret(), text );
       } catch ( e ) {
         logger.error( `Error attempting to Tweet: ${JSON.stringify(e)}` ); //swallow
       }
@@ -1587,7 +1587,7 @@ http.get('/related-papers/:id', function( req, res, next ){
   // 5000000ms correspons to 83.3333333 mins
   let timout = 5000000;
   res.setTimeout(timout);
-  
+
   let id = req.params.id;
   let queryObject = url.parse(req.url, true).query;
   let { interactionId } = queryObject;


### PR DESCRIPTION
On clicking submit, the client waits for the server response to a 'published' status request. 
Ref #743 