### PR TITLE
Disable rethinkdb in travis & use only node@10,12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: required
 language: node_js
 node_js:
-  - "8"
   - "10"
-addons:
-  rethinkdb: '2.3.6'
-before_script:
-  - sudo service rethinkdb start
-  - sleep 60
+  - "12"
+#addons:
+#  rethinkdb: '2.3.6'
+#before_script:
+#  - sudo service rethinkdb start
+#  - sleep 60
 script: npm run test:travis


### PR DESCRIPTION
This is just a simple change to switch off rethink in travis, since it seems to be causing the erratic "x" status for new PRs.