### PR TITLE
No related papers results #742

### DIFF
--- a/src/server/routes/api/document/indra.js
+++ b/src/server/routes/api/document/indra.js
@@ -144,18 +144,25 @@ const getDocuments = ( templates, queryArticle ) => {
         let dateJs = article.Journal.JournalIssue.PubDate;
         let { Day: day, Year: year, Month: month, MedlineDate: medlineDate } = dateJs;
 
-        if ( medlineDate ) {
-          return new Date( medlineDate );
+        try {
+          if ( medlineDate ) {
+            return new Date( medlineDate ).getTime();
+          }
+
+          if ( month != null && isNaN( month ) ) {
+              month = dateParse(month, 'MMM', new Date()).getMonth() + 1;
+          }
+
+          // Date class accepts the moth indices starting by 0
+          month = month - 1;
+
+          return new Date( year, month, day ).getTime();
         }
-
-        if ( month != null && isNaN( month ) ) {
-            month = dateParse(month, 'MMM', new Date()).getMonth() + 1;
+        catch ( e ) {
+          logger.error( e );
+          // if date could not be parsed return the minimum integer value
+          return Number.MIN_SAFE_INTEGER;
         }
-
-        // Date class accepts the moth indices starting by 0
-        month = month - 1;
-
-        return new Date( year, month, day ).getTime();
     };
 
     const filterByDate = articles => {

--- a/src/server/routes/api/document/indra.js
+++ b/src/server/routes/api/document/indra.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import _ from 'lodash';
 import { parse as dateParse } from 'date-fns';
+import Heap from 'heap';
 
 import { INDRA_DB_BASE_URL, INDRA_ENGLISH_ASSEMBLER_URL, SEMANTIC_SEARCH_BASE_URL } from '../../../../config';
 import logger from '../../../logger';
@@ -12,6 +13,7 @@ import querystring from 'querystring';
 const INDRA_STATEMENTS_URL = INDRA_DB_BASE_URL + 'statements/from_agents';
 const MIN_SEMANTIC_SCORE = 0.47;
 const SORT_BY_DATE = false;
+const SEMANTIC_SEARCH_LIMIT = 30;
 
 const SUB_MODIFICATION_TYPES = ['Phosphorylation', 'Dephosphorylation', 'Dephosphorylation',
   'Deubiquitination', 'Methylation', 'Demethylation'];
@@ -91,14 +93,17 @@ const getDocuments = ( templates, queryArticle ) => {
       return [];
     }
 
-    const getSemanticScores = pubmeds => {
+    const getPmid = article => article.PubmedData.ArticleIdList.find( o => o.IdType == 'pubmed' ).id;
+    const getMedlineArticle = article => article.MedlineCitation.Article;
+
+    const getSemanticScores = articles => {
       if ( SORT_BY_DATE ) {
         let semanticScores = null;
-        return { semanticScores, pubmeds };
+        return { semanticScores, articles };
       }
 
       const getAbstract = article => {
-        let abstract = article.MedlineCitation.Article.Abstract;
+        let abstract = getMedlineArticle(article).Abstract;
         if ( _.isString( abstract ) ) {
           return abstract;
         }
@@ -107,14 +112,13 @@ const getDocuments = ( templates, queryArticle ) => {
         }
         return null;
       };
-      const getPmid = article => article.PubmedData.ArticleIdList.find( o => o.IdType == 'pubmed' ).id;
 
       let url = SEMANTIC_SEARCH_BASE_URL;
       let queryText = getAbstract( queryArticle );
       let queryUid = getPmid( queryArticle );
       let query = { uid: queryUid, text: queryText };
 
-      let documents = pubmeds.PubmedArticleSet.map( article => {
+      let documents = articles.map( article => {
         let text = getAbstract( article );
         let uid = getPmid( article );
 
@@ -133,17 +137,51 @@ const getDocuments = ( templates, queryArticle ) => {
         headers: { 'Content-Type': 'application/json' }
       })
       .then( res => res.json() )
-      .then( semanticScores => ( { pubmeds, semanticScores } ) );
+      .then( semanticScores => ( { articles, semanticScores } ) );
+    };
+
+    const getPubTime = article => {
+        let dateJs = article.Journal.JournalIssue.PubDate;
+        let { Day: day, Year: year, Month: month, MedlineDate: medlineDate } = dateJs;
+
+        if ( medlineDate ) {
+          return new Date( medlineDate );
+        }
+
+        if ( month != null && isNaN( month ) ) {
+            month = dateParse(month, 'MMM', new Date()).getMonth() + 1;
+        }
+
+        // Date class accepts the moth indices starting by 0
+        month = month - 1;
+
+        return new Date( year, month, day ).getTime();
+    };
+
+    const filterByDate = articles => {
+      // if the sort operation wil be based on the semantic search
+      // then filter the most current papers before sorting
+      if ( !SORT_BY_DATE && articles.length > SEMANTIC_SEARCH_LIMIT ) {
+        const cmp = ( a, b ) => {
+          const getDate = e => getPubTime( getMedlineArticle( e ) );
+          return getDate( a ) - getDate( b );
+        };
+
+        articles = Heap.nlargest( articles, SEMANTIC_SEARCH_LIMIT, cmp );
+      }
+
+      return articles;
     };
 
     return tryPromise( () => fetchPubmed({ uids: pmids }) )
+      .then( o => o.PubmedArticleSet )
+      .then( filterByDate )
       .then( getSemanticScores )
-      .then( ( { pubmeds, semanticScores } ) => {
+      .then( ( { articles, semanticScores } ) => {
         let semanticScoreById = _.groupBy( semanticScores, 'uid' );
-        let articles = pubmeds.PubmedArticleSet;
-
-        let arr = pmids.map( (pmid, i) => {
-          let pubmed = articles[i].MedlineCitation.Article;
+        let arr = articles.map( article => {
+          let pubmed = getMedlineArticle( article );
+          let pmid = getPmid( article );
           let elements = o[ pmid ];
           // prevent duplication of the same interactions in a document
           elements = _.uniqWith( elements, _.isEqual );
@@ -152,28 +190,10 @@ const getDocuments = ( templates, queryArticle ) => {
           return { elements, pmid, pubmed };
         } );
 
-        const getPubTime = doc => {
-            let dateJs = doc.pubmed.Journal.JournalIssue.PubDate;
-            let { Day: day, Year: year, Month: month, MedlineDate: medlineDate } = dateJs;
-
-            if ( medlineDate ) {
-              return new Date( medlineDate );
-            }
-
-            if ( month != null && isNaN( month ) ) {
-                month = dateParse(month, 'MMM', new Date()).getMonth() + 1;
-            }
-
-            // Date class accepts the moth indices starting by 0
-            month = month - 1;
-
-            return new Date( year, month, day ).getTime();
-        };
-
         const getSemanticScore = doc => _.get( semanticScoreById, [ doc.pmid, 0, 'score' ] );
 
         const getNegativeScore = ( doc ) => {
-          let fcn = SORT_BY_DATE ? getPubTime : getSemanticScore;
+          let fcn = SORT_BY_DATE ? () => getPubTime(doc.pubmed) : getSemanticScore;
           return -fcn( doc );
         };
 


### PR DESCRIPTION
Refs #742 

I filtered the N most current papers before running the semantic search and anything else as discussed in the issue.

I made the filtering when SORT_BY_DATE flag is unset which means that the sort must be based on the semantic search. I can add either of the followings as well:

- Filter the top N results when SORT_BY_DATE flag is set as well.
- Run the semantic search only for the most current N papers but still include the others as well in the resulting list. Probably sort the others by the date.

I used 30 as the value of N that would be subject to change.