### PR TITLE
Pubmed articles by paperId

### DIFF
--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -70,7 +70,12 @@ const getPubmedArticle = async paperId => {
       const PubmedArticle = _.head( PubmedArticleSet );
       const { title, pmid, doi } = getPubmedCitation( PubmedArticle );
       // Pubmed EFETCH returns lower-cased title, adds trailing period
-      const cleanTitle = raw => _.toLower( _.trim( raw , ' .') );
+      const santitize = raw => {
+        const trimmed = _.trim( raw , ' .');
+        const lower = _.toLower( trimmed );
+        const clean = lower.replace(/[\W_]+/g, ' ');
+        return clean;
+      };
 
       switch ( IdType ) {
         case ID_TYPE.DOI:
@@ -80,7 +85,7 @@ const getPubmedArticle = async paperId => {
           if( pmid === paperId ) hasMatch = true;
           break;
         case ID_TYPE.TITLE:
-          if( cleanTitle( title ).includes( cleanTitle( paperId ) ) ) hasMatch = true;
+          if( santitize( title ).includes( santitize( paperId ) ) ) hasMatch = true;
           break;
       }
 

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -69,6 +69,7 @@ const getPubmedArticle = async paperId => {
       let hasMatch = false;
       const PubmedArticle = _.head( PubmedArticleSet );
       const { title, pmid, doi } = getPubmedCitation( PubmedArticle );
+      // Pubmed EFETCH returns lower-cased title, adds trailing period
       const cleanTitle = raw => _.toLower( _.trim( raw , ' .') );
 
       switch ( IdType ) {

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -1,90 +1,55 @@
 import _ from 'lodash';
-import { URL } from 'url';
 import { fetchPubmed } from './fetchPubmed';
 import demoPubmedArticle from './demoPubmedArticle';
 import { searchPubmed } from './searchPubmed';
 import logger from '../../../../logger';
-import { ArticleIDError } from '../../../../../util/pubmed';
+import { ArticleIDError, getPubmedCitation } from '../../../../../util/pubmed';
 import {
-  PUBMED_LINK_BASE_URL,
   DEMO_ID
 } from '../../../../../config';
 
+const ID_TYPE = Object.freeze({
+  DOI: 'doi',
+  PMID: 'uid',
+  TITLE: 'title'
+});
+
+// 99.3% of CrossRef DOIs (https://www.crossref.org/blog/dois-and-matching-regular-expressions/)
+const doiRegex = /^10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i;
 const digitsRegex = /^[0-9.]+$/;
 
-/**
- * findPubmedId
- *
- * Try to extract out a PMID from the input, which can be:
- *   1. number (including period(s))
- *   2. PubMed url, such as an article path (/123345) or search (e.g. /?term=title)
- *   3. a text query (e.g. title)
- * Will throw an 'ArticleIDError' if 1 and 2 do not apply and a PubMed search does
- * not return a unique result. This function is necessary because it polyfills
- * capabilities in EUTILS that are through  the PubMed website.
- *
- * @param {string} paperId the description of an article
- * @returns {string} the candidate uid
- * @throws {ArticleIDError} if it cannot identify a non-emptu, unique record
- */
-const findPubmedId = async paperId => {
-
-  let id;
-  const getUniqueIdOrThrow = async query => {
-    const { searchHits, count } = await searchPubmed( query );
-    if( count === 1 ){
-      return _.first( searchHits );
-    } else {
-      throw new ArticleIDError( `Unrecognized paperId '${paperId}'`, paperId );
-    }
-  };
-  const isUidLike = digitsRegex.test( paperId );
-
-  if( isUidLike ){
-    // Case: a bunch of digits, periods
-    id = paperId;
-
+const getUniqueArticleOrThrow = async ( query, IdType ) => {
+  const queryOpts = IdType === ID_TYPE.TITLE ? { field: ID_TYPE.TITLE } : {};
+  const { searchHits, count } = await searchPubmed( query, queryOpts );
+  if( count === 1 ){
+    return _.first( searchHits );
   } else {
-    if ( !_.isString( paperId )  ) throw new ArticleIDError( `Missing paperId`, paperId );
-    const isPubMedUrlLike = paperId.startsWith( PUBMED_LINK_BASE_URL );
-
-    if( isPubMedUrlLike ) {
-      // Case: URL, look for path or exact search term
-      const pubmedUrl = new URL( PUBMED_LINK_BASE_URL );
-      const paperIdUrl = new URL( paperId );
-      const isSameHost = paperIdUrl.hostname === pubmedUrl.hostname;
-      const pathUidMatchResult = paperIdUrl.pathname.match( /^\/pubmed\/([0-9.]+)$/ );
-
-      if( isSameHost && !_.isNull( pathUidMatchResult ) ){
-        id = pathUidMatchResult[1];
-
-      } else {
-        const paperIdUrlSearchTerm = paperIdUrl.searchParams.get('term');
-
-        if( isSameHost && paperIdUrlSearchTerm ) {
-          id = await getUniqueIdOrThrow( paperIdUrlSearchTerm );
-        }
-      }
-
-    } else {
-      //Last bucket - do a search (title, doi, ...)
-      id = await getUniqueIdOrThrow( paperId );
-    }
+    throw new ArticleIDError( `Unrecognized paperId '${query}'`, query );
   }
+};
 
-  return id;
+const findPubmedId = async paperId => {
+  let IdType = ID_TYPE.TITLE;
+  const isUidLike = digitsRegex.test( paperId );
+  const isDoiLike = doiRegex.test( paperId );
+
+  if( isDoiLike ) {
+    IdType = ID_TYPE.DOI;
+  } else if ( isUidLike ){
+    IdType = ID_TYPE.PMID;
+  }
+  const foundId = await getUniqueArticleOrThrow( paperId, IdType );
+  return { IdType, foundId };
 };
 
 /**
  * getPubmedRecord
  *
- * Retrieve a single PubmedArticle. Shall interpret an input as either:
- *   - A number (with optional period)
- *   - A url
- *     - with an PubMed article path e.g. 'https://www.ncbi.nlm.nih.gov/pubmed/123456'
- *     - with an PubMed search query.g. 'https://www.ncbi.nlm.nih.gov/pubmed/?term=123456'
- *     - A search returning a unique PubMed ID
- *
+ * Retrieve a single PubmedArticle. Shall interpret an input as:
+ *   1. Digital Object Identifier (doi)
+ *   2. PubMed UID (pmid)
+ *   3. The exact article title
+ *   4. Keyword 'demo'
  * @param {string} paperId Contains or references a single PubMed uid (see above). If 'demo' return canned demo data.
  * @return {Object} The unique PubMedArticle (see [NLM DTD]{@link https://dtd.nlm.nih.gov/ncbi/pubmed/out/pubmed_190101.dtd} )
  */
@@ -94,16 +59,36 @@ const getPubmedArticle = async paperId => {
 
   } else {
     try {
-      const candidateId = await findPubmedId( paperId );
+      const { IdType, foundId } = await findPubmedId( paperId );
       const { PubmedArticleSet } = await fetchPubmed({
-        uids: [ candidateId ]
+        uids: [ foundId ]
       });
 
-      if( !_.isEmpty( PubmedArticleSet ) ){
+      if( _.isEmpty( PubmedArticleSet ) ) throw new ArticleIDError( `No PubMed record found '${paperId}'`, paperId );
+
+      let hasMatch = false;
+      const PubmedArticle = _.head( PubmedArticleSet );
+      const { title, pmid, doi } = getPubmedCitation( PubmedArticle );
+      const cleanTitle = raw => _.toLower( _.trim( raw , ' .') );
+
+      switch ( IdType ) {
+        case ID_TYPE.DOI:
+          if( doi === paperId ) hasMatch = true;
+          break;
+        case ID_TYPE.PMID:
+          if( pmid === paperId ) hasMatch = true;
+          break;
+        case ID_TYPE.TITLE:
+          if( cleanTitle( title ).includes( cleanTitle( paperId ) ) ) hasMatch = true;
+          break;
+      }
+
+      if( hasMatch ){
         return _.head( PubmedArticleSet );
       } else {
         throw new ArticleIDError( `No PubMed record found '${paperId}'`, paperId );
       }
+
     } catch ( e ) {
       // Error types to note: ArticleIDError, HTTPStatusError, FetchError
       logger.error( `Unable to retrieve a PubmedArticle for '${paperId}'` );

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -64,8 +64,6 @@ const getPubmedArticle = async paperId => {
         uids: [ foundId ]
       });
 
-      if( _.isEmpty( PubmedArticleSet ) ) throw new ArticleIDError( `No PubMed record found '${paperId}'`, paperId );
-
       let hasMatch = false;
       const PubmedArticle = _.head( PubmedArticleSet );
       const { title, pmid, doi } = getPubmedCitation( PubmedArticle );

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -35,8 +35,8 @@ const checkEsearchResult = json => {
   return json;
 };
 
-const eSearchPubmed = term => {
-  const params = _.assign( {}, DEFAULT_ESEARCH_PARAMS, { term } );
+const eSearchPubmed = ( term, opts ) => {
+  const params = _.assign( {}, DEFAULT_ESEARCH_PARAMS, { term }, opts );
   const url = EUTILS_SEARCH_URL + '?' + queryString.stringify( params );
   const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version}`;
   return fetch( url, {
@@ -56,12 +56,13 @@ const eSearchPubmed = term => {
  * Query the PubMed database for matching UIDs.
  *
  * @param { String } q The query term
+ * @param { Object } opts EUTILS ESEARCH options
  * @returns { Object } result The search results from PubMed
  * @returns { Array } result.searchHits A list of PMIDs
  * @returns { Number } result.count The number of searchHits containing PMIDs
  * @returns { String } result.query_key See {@link https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch|EUTILS docs }
  * @returns { String } result.webenv See {@link https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.ESearch|EUTILS docs }
  */
-const searchPubmed = q => eSearchPubmed( q );
+const searchPubmed = ( q, opts ) => eSearchPubmed( q, opts );
 
 export { searchPubmed, pubmedDataConverter };


### PR DESCRIPTION
- Search pubmed accepts optional configuration parameter, enabling search by `field: "title"`
- Pubmed 'finding' module now accepts:
  - 1. exact doi
  - 2. exact pmid
  - 3. title

Discriminating input: DOI regex provided by Crossref that hits 99.3%. To my knowledge, CrossRef is the primary registrar for research articles. PMIDs just look like plain number.

Double checking search results: Previously, if one search result came back it was assumed to be a match, and there were edge cases. Now, the single search result is checked against the input. The title check is a little more fragile, so I only check if input 'word' characters is contained in the title of the search hit.  

I was looking for more title test cases...

Refs #741 