### PR TITLE
Related papers loading & notice

### DIFF
--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -87,7 +87,7 @@ export class InfoPanel extends Component {
         // ]),
         h('div.editor-info-related-papers-section.editor-info-main-section', [
           h('div.editor-info-section-title', 'Recommended articles'),
-          h('div.editor-info-related-papers', [ h(RelatedPapers, { document, papers: document.relatedPapers() }) ])
+          h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
         ])
       ])
     ]);

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -518,7 +518,7 @@ class EntityInfo extends DataComponent {
         children.push( h('div.entity-info-reld-papers-title', `Recommended articles`) );
         
         children.push( h('div.entity-info-related-papers', [
-          h(RelatedPapers, { document, papers: s.element.relatedPapers() })
+          h(RelatedPapers, { document, source: s.element })
         ]) );
       }
     } else {

--- a/src/client/components/element-info/interaction-info.js
+++ b/src/client/components/element-info/interaction-info.js
@@ -239,7 +239,7 @@ class InteractionInfo extends DataComponent {
         summaryChildren.push( h('div.interaction-info-reld-papers-title', 'Recommended articles') );
         
         summaryChildren.push( h('div.interaction-info-related-papers', [
-          h(RelatedPapers, { document, papers: el.relatedPapers() })
+          h(RelatedPapers, { document, source: el })
         ]) );
       }
 

--- a/src/client/components/related-papers.js
+++ b/src/client/components/related-papers.js
@@ -2,15 +2,46 @@ import h from 'react-hyperscript';
 import { Component } from 'react';
 import { DOI_LINK_BASE_URL, PUBMED_LINK_BASE_URL } from '../../config';
 
+const MAX_PAPERS = 6;
+
 export class RelatedPapers extends Component {
   constructor(props){
     super(props);
+
+    this.state = {
+      papers: this.props.source.relatedPapers()
+    };
+  }
+
+  componentDidMount(){
+    this.onRefresh = () => {
+      this.setState({ papers: this.props.source.relatedPapers() });
+    };
+
+    this.props.source.on('relatedpapers', this.onRefresh);
+  }
+
+  componentWillUnmount(){
+    this.props.source.removeListener('relatedpapers', this.onRefresh);
   }
 
   render(){
-    let { papers } = this.props;
+    let { papers } = this.state;
 
-    if( !papers ) return null;
+    if( !papers ){
+      return h('div.related-papers.related-papers-empty', [
+        h('div.related-papers-empty-icon', [
+          h('i.icon.icon-spinner')
+        ]),
+        h('p.related-papers-empty-msg', [
+          `Biofactoid is looking for other interesting articles.`,
+          h('br'),
+          `They'll be ready for you in a moment.`
+        ])
+      ]);
+    }
+
+    papers = papers.slice(0, MAX_PAPERS);
 
     return h('div.related-papers', papers.map( paper => {
       const { pubmed: { title, authors: { abbreviation: author }, reference: journal, abstract, doi, pmid } } = paper;

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -91,6 +91,11 @@ class Document {
         this.emit('submit');
         this.emit('remotesubmit');
       }
+
+      if( changes.relatedPapers ){
+        this.emit('relatedpapers', changes.relatedPapers);
+        this.emit('remoterelatedpapers', changes.relatedPapers);
+      }
     });
 
     if( isServer ) this.syncher.on( 'create', () => this.rwMeta( 'createdDate', new Date() ) );
@@ -390,7 +395,7 @@ class Document {
   relatedPapers( papersData ){
     if( papersData ){
       let p = this.syncher.update({ 'relatedPapers': papersData });
-      this.emit( 'relatedPapers', papersData );
+      this.emit( 'relatedpapers', papersData );
       return p;
     }
     else if( !papersData ){

--- a/src/model/element/element.js
+++ b/src/model/element/element.js
@@ -56,6 +56,11 @@ class Element {
         this.emit( 'complete', changes.completed, old.completed );
         this.emit( 'remotecomplete', changes.completed, old.completed );
       }
+
+      if( changes.relatedPapers ){
+        this.emit('relatedpapers', changes.relatedPapers);
+        this.emit('remoterelatedpapers', changes.relatedPapers);
+      }
     });
   }
 
@@ -197,7 +202,7 @@ class Element {
   relatedPapers( papersData ){
     if( papersData ){
       let p = this.syncher.update({ 'relatedPapers': papersData });
-      this.emit( 'relatedPapers', papersData );
+      this.emit( 'relatedpapers', papersData );
       return p;
     }
     else if( !papersData ){

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -115,10 +115,15 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: inline-block;
 }
 
 .editor-title-info {
   font-size: var(--smallFontSize);
+
+  & div {
+    display: block;
+  }
 }
 
 .editor-task-list-active {

--- a/src/styles/related-papers.css
+++ b/src/styles/related-papers.css
@@ -55,8 +55,31 @@
 
 .related-paper-author {
   font-style: italic;
+  margin-bottom: 0.5em;
 }
 
 .related-paper-journal {
   font-style: italic;
+}
+
+.related-papers-empty {
+  display: block;
+  background: #f0f0f0;
+  border: 1px solid #ddd;
+  border-radius: 0.25em;
+}
+
+.related-papers-empty-icon {
+  font-size: 2em;
+  text-align: center;
+  margin: 0.5em 0;
+  opacity: 0.333;
+}
+
+.related-papers-empty-msg {
+  margin: 1em 0;
+  box-sizing: border-box;
+  padding: 0 1em;
+  color: #888;
+  text-align: center;
 }


### PR DESCRIPTION
- Adds a notice to the related papers section when the calculation is in progress.
- Automatically adds the related papers to the UI when the server sets them.
- Renames `relatedPaper` event to `relatedpaper`, to be consistent with all other events.
- Limits the number of shown related papers to a maximum of six.
- Misc. fix to article title underline in the editor.