### PR TITLE
Use Crossref for more reliable Pubmed searches

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -60,6 +60,8 @@ export const NCBI_EUTILS_API_KEY = env('NCBI_EUTILS_API_KEY', 'b99e10ebe0f90d815
 export const INDRA_DB_BASE_URL = env('INDRA_DB_BASE_URL', 'https://db.indra.bio/latest/');
 export const INDRA_ENGLISH_ASSEMBLER_URL = env('INDRA_ENGLISH_ASSEMBLER_URL', 'http://api.indra.bio:8000/assemblers/english');
 export const SEMANTIC_SEARCH_BASE_URL = env('SEMANTIC_SEARCH_BASE_URL', 'https://semanticsearch.baderlab.org/');
+export const CROSSREF_API_BASE_URL = env('CROSSREF_API_BASE_URL', 'https://api.crossref.org');
+export const PMC_ID_API_URL = env('PMC_ID_API_URL', 'https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/');
 
 // Links
 export const UNIPROT_LINK_BASE_URL = env('UNIPROT_LINK_BASE_URL', 'http://www.uniprot.org/uniprot/');

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -80,7 +80,7 @@ const crSearchPubmed = async ( term, IdType, opts ) => {
   // try PubMed ESEARCH
   const queryOpts = IdType === ID_TYPE.TITLE ? { field: ID_TYPE.TITLE } : {};
   const searchResponse = await eSearchPubmed( term, queryOpts );
-  if( searchResponse.count === -1 ){
+  if( searchResponse.count === 1 ){
     return searchResponse;
 
   } else {

--- a/src/server/routes/api/document/pubmed/searchPubmed.js
+++ b/src/server/routes/api/document/pubmed/searchPubmed.js
@@ -24,7 +24,7 @@ const DEFAULT_ESEARCH_PARAMS = {
 };
 
 const safeFetch = url => {
-  const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version}`;
+  const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version} (${BASE_URL};mailto:${EMAIL_FROM_ADDR})`;
   return fetch( url, {
     method: 'GET',
     headers: {


### PR DESCRIPTION
- Process:
  - Search CR, get the DOI for the paper.
  - Search PMC for DOI.  If we've got a hit, return
  - Otherwise, fall back on a PM search via the DOI.
- Crossref searches get transformed into the Pubmed search result format, so no other modules need to be changed.
- The existing `searchPubmed` module only has newly added functions.  Nothing has been removed.
- The hybrid approach seems to get a lot more hits.
- This PR is still a rough draft.  There are edge cases to consider, and the [request headers should be revised](https://github.com/CrossRef/rest-api-doc#etiquette).
- Ref. https://github.com/CrossRef/rest-api-doc

Ref. #763 #741

@jvwong, could you test this out and evaluate whether it's a feasible alternative?  There are probably also some robustness improvements you could make, based on your previous experience with Pubmed API searches.

