### PR TITLE
Submit success: Wrapping url and text

### DIFF
--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -182,9 +182,9 @@ class TaskView extends DataComponent {
               h('p', 'Your paper is now linked to many others and shared for everyone to explore.'),
               h( 'a.task-view-done-button', { href: publicUrl, target: '_blank', }, 'Explore' )
             ]),
-            !isNativeShareSupported() ? h('div.task-view-done-section-footer', [
+            h('div.task-view-done-section-footer', [
               h('p', `Explore link: ${publicUrl}`)
-            ]): null
+            ])
           ]),
           h('hr'),
           h('div.task-view-done-section', [

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -1,6 +1,9 @@
 .task-view {
-  width: 300px;
+  box-sizing: border-box;
   padding: 0.25em 0.33em;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  max-width: 25em;
 }
 
 .task-view-spinner {
@@ -18,7 +21,6 @@
 }
 
 .task-view-submit {
-  width: 100%;
   box-sizing: border-box;
 }
 
@@ -75,11 +77,10 @@
 }
 
 .task-view-done hr {
-  width: 80%;
+  width: 90%;
   border: 0;
   height: 0;
   border-top: 1px solid rgba(0, 0, 0, 0.1);
-  margin: 0.2em 0 0;
 }
 
 .task-view-done-button {


### PR DESCRIPTION
This one should do the trick with respect to wrapping long text in the submit success tooltip. Also fixed the horizontal divider.

I removed a bug where the explore link was only shown contingent on the share capability being present. Odd.

Refs #787