### PR TITLE
Omit chemicals while creating organisms dropdown component.

### DIFF
--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -429,7 +429,9 @@ class EntityInfo extends DataComponent {
 
       if( refineEditableGgp ){
         let isPerfectNameMatch = m => m.distance === 0;
-        let orgMatches = s.matches.filter(isPerfectNameMatch);
+        let isChemicalMatch = m => m.type == 'chemical';
+        let isOrgMatch = m => isPerfectNameMatch(m) && !isChemicalMatch(m);
+        let orgMatches = s.matches.filter(isOrgMatch);
         let orgToMatches = new Map();
         const selectedIndex = _.findIndex(orgMatches, match => match.id === m.id && match.namespace === m.namespace);
 


### PR DESCRIPTION
Refs #794.

If I did not misunderstand what is desired just eliminating the chemical matches must be enough. Here is the new dropdown for the example from #794 

<img width="553" alt="Screen Shot 2020-08-17 at 1 50 48 PM" src="https://user-images.githubusercontent.com/6534865/90443592-5c33cd80-e091-11ea-961b-e90c8b03a134.png">


