### PR TITLE
Fill related papers for doc with article info retrieval

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -251,13 +251,14 @@ const fillDocArticle = async doc => {
     const pubmedRecord = createPubmedArticle({ articleTitle: paperId });
     await doc.article( pubmedRecord );
     await doc.issues({ paperId: { error, message: error.message } });
+  } finally {
+    getRelPprsForDoc( doc );
   }
 };
 
 const fillDoc = async doc => {
   await fillDocCorrespondence( doc );
   await fillDocArticle( doc );
-  getRelPprsForDoc( doc );
   return doc;
 };
 


### PR DESCRIPTION
Combine article info retrieval with related papers for doc, allowing admin and the cron to refresh all Pubmed information.

Refs #801 
