### PR TITLE
Capture the Pubmed article type 

### DIFF
--- a/src/server/routes/api/document/pubmed/fetchPubmed.js
+++ b/src/server/routes/api/document/pubmed/fetchPubmed.js
@@ -180,6 +180,16 @@ const getJournal = Article => {
   };
 };
 
+const getPublicationType = Article => {
+  const PublicationTypeList = getElementByName( Article, 'PublicationTypeList' );
+  const PublicationType = getElementsByName( PublicationTypeList, 'PublicationType' );
+  return PublicationType.map( elt => {
+    const UI = getElementAttribute( elt, 'UI' );
+    const value = getElementText( elt );
+    return { UI, value };
+  });
+};
+
 const getArticle = MedlineCitation => {
   // <!ELEMENT	Article (Journal,ArticleTitle,((Pagination, ELocationID*) | ELocationID+),
   //                    Abstract?,AuthorList?, Language+, DataBankList?, GrantList?,
@@ -196,11 +206,18 @@ const getArticle = MedlineCitation => {
   const AuthorList =  getElementByName( Article, 'AuthorList' ) ? getAuthorList( Article ): null;
   const Journal = getJournal( Article );
 
+  // <!ELEMENT	PublicationType (#PCDATA) >
+  // <!ATTLIST	PublicationType
+  // 		    UI CDATA #REQUIRED >
+  // <!ELEMENT	PublicationTypeList (PublicationType+) >
+  const PublicationTypeList = getPublicationType( Article );
+
   return {
     Journal,
     ArticleTitle,
     Abstract,
-    AuthorList
+    AuthorList,
+    PublicationTypeList
   };
 };
 

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -150,6 +150,7 @@ const getArticleId = ( PubmedArticle, IdType ) => _.get( _.find( _.get( PubmedAr
  * @return {String} result.reference (<ISOAbbreviation> | <Title>) <Year>; <Volume>
  * @return {String} result.pmid
  * @return {String} result.doi
+ * @return {String} result.pubTypes
  */
 const getPubmedCitation = PubmedArticle => {
   const Article = _.get( PubmedArticle, ['MedlineCitation','Article'] ); //required
@@ -162,8 +163,9 @@ const getPubmedCitation = PubmedArticle => {
   const abstract = _.get( Article, 'Abstract', null );
   const pmid = getArticleId( PubmedArticle, 'pubmed' );
   const doi = getArticleId( PubmedArticle, 'doi' );
+  const pubTypes = _.get( Article, 'PublicationTypeList' ); //required
 
-  return { title, authors, reference, abstract, pmid, doi };
+  return { title, authors, reference, abstract, pmid, doi, pubTypes };
 };
 
 /**

--- a/test/pubmed/fetchPubmed.js
+++ b/test/pubmed/fetchPubmed.js
@@ -226,6 +226,22 @@ describe('fetchPubmed', function(){
 
             }); //AuthorList
 
+            describe( 'PublicationTypeList', () => {
+
+              let PublicationTypeList;
+              before( () => {
+                PublicationTypeList = _.get( Article, 'PublicationTypeList' );
+              });
+
+              it('Should be a list of UI/text objects', () => {
+                expect( PublicationTypeList ).to.be.an.instanceof(Array);
+                PublicationTypeList.forEach( PublicationType => {
+                  expect( PublicationType ).to.have.property('UI');
+                  expect( PublicationType ).to.have.property('value');
+                });
+              });
+            });
+
           }); //Article
 
           describe( 'ChemicalList', () => {


### PR DESCRIPTION
- Store article PublicationType information from EUTILS EFETCH
- Use this info to exclude search hits of type `Published Erratum` for an author's paper

Trade-off is authors won't be able to add an erratum 

Refs #848