### PR TITLE
More salient organism in entity grounding popover

### DIFF
--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -10,6 +10,7 @@ import assocDisp from './entity-assoc-display';
 import CancelablePromise from 'p-cancelable';
 import { isComplex, isGGP, ELEMENT_TYPE } from '../../../model/element/element-type';
 import RelatedPapers from '../related-papers';
+import Organism from '../../../model/organism';
 
 import {
   focusDomElement, makeClassList, initCache, SingleValueCache,
@@ -383,11 +384,10 @@ class EntityInfo extends DataComponent {
         nameChildren.push( matchName() );
       }
 
-      if( complete && m.name.toLowerCase() !== s.name.toLowerCase() ){
+      if( m.organism != null ){
         nameChildren.push(
-          h('br'),
-          h('span', '('),
-          matchName(),
+          h('span', ' ('),
+          Organism.fromId(m.organism).name(),
           h('span', ')')
         );
       }

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -9,6 +9,7 @@ import Cytoscape from 'cytoscape';
 import { TWITTER_ACCOUNT_NAME } from '../../config';
 import { getPubmedCitation } from '../../util/pubmed';
 import { isServer } from '../../util/';
+import Organism from '../organism';
 
 const DEFAULTS = Object.freeze({
   // data
@@ -321,6 +322,33 @@ class Document {
         return Promise.resolve();
       }
     }
+  }
+
+  commonOrganism(){
+    const orgs = this.organisms();
+    const counts = this.organismCounts();
+    const getCount = org => counts.get(org) || 0;
+    const sortedOrgs = _.sortBy(orgs, o => -getCount(o));
+
+    if( sortedOrgs.length === 0 ){ return null; }
+
+    return Organism.fromId(sortedOrgs[0]);
+  }
+
+  irregularOrganismEntities(){
+    const comOrg = this.commonOrganism();
+
+    const isIrreg = ent => {
+      const entOrg = ent.organism();
+
+      if( entOrg == null ){ return false; } // e.g. chemical
+
+      return !entOrg.same(comOrg);
+    };
+
+    if( comOrg == null ){ return []; } // no common org => no irreg ents
+
+    return this.entities().filter(isIrreg);
   }
 
   add( el ){

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -2,6 +2,7 @@ import Element from './element';
 import _ from 'lodash';
 import { tryPromise } from '../../util';
 import { ENTITY_TYPE, getNCBIEntityType } from './entity-type';
+import Organism from '../organism';
 
 const TYPE = 'entity';
 
@@ -153,6 +154,14 @@ class Entity extends Element {
     this.emit('localunassociate', oldDef);
 
     return update;
+  }
+
+  organism(){
+    const assoc = this.association();
+
+    if( !assoc ){ return null; } //  no org
+
+    return Organism.fromId(assoc.organism);
   }
 
   json(){

--- a/src/model/organism.js
+++ b/src/model/organism.js
@@ -42,6 +42,10 @@ class Organism {
     };
   }
 
+  same(other){
+    return this.id() === other.id();
+  }
+
   static fromName( name ){
     return organisms.find( org => nameMatches( org.name(), name ) ) || Organism.OTHER;
   }


### PR DESCRIPTION
- Make the organism name salient (at the top) in the grounding popover.
- Add `ent.organism()` shortcut function to get the `Organism` an `Entity` is grounded to (may be null for chemical).
- Add `doc.commonOrganism()` to get the most common `Organism` in a `Document` -- may be null if no NCBI groundings exist.
- Add `doc.irregularOrganismEntities()` to get an array of entities that are grounded to an organism other than the common one.

Refs. :

- Grounding: Entity organism preference / mixed organisms for genes #861
- Block users from submitting empty documents #860