### PR TITLE
Supplement the sitemap urls with PNG image URL and metadata

### DIFF
--- a/test/sitemap/docs2Sitemap.js
+++ b/test/sitemap/docs2Sitemap.js
@@ -33,9 +33,7 @@ describe('docs2Sitemap - Element: <urlset>', function(){
 
     before( () => {
       urls = etree.findall('./url');
-      docUrls = _.filter( urls, url =>{
-        url.findtext('./loc') !== `${BASE_URL}/`;
-      });
+      docUrls = _.filter( urls, url => url.findtext('./loc') !== `${BASE_URL}/` );
     });
 
     it('Should have the correct number of <url> children', () => {
@@ -67,6 +65,23 @@ describe('docs2Sitemap - Element: <urlset>', function(){
       });
       expect( hasBaseUrl ).to.be.true;
     }); // homepage
+
+    //https://support.google.com/webmasters/answer/178636?hl=en&ref_topic=2370565
+    it('Should have the correct <image:image>', () => {
+      docUrls.forEach( url => {
+        const imageLocText = url.findtext('./image:image/image:loc');
+        const hasDocLoc = docsDataJSON.some( docJSON => imageLocText && imageLocText.includes( docJSON.id ) );
+        expect( hasDocLoc ).to.be.true;
+
+        const imageTitleText = url.findtext('./image:image/image:title');
+        const hasDocTitle = docsDataJSON.some( docJSON => docJSON.citation.title === imageTitleText );
+        expect( hasDocTitle ).to.be.true;
+
+        const imageCaptionText = url.findtext('./image:image/image:caption');
+        const hasDocCaption = docsDataJSON.some( docJSON => docJSON.text === imageCaptionText );
+        expect( hasDocCaption ).to.be.true;
+      });
+    }); // image:image
 
   }); // url
 


### PR DESCRIPTION
Now you get something like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset
  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
  <url>
    <loc>http://localhost:3000/document/aa18ee18-a78f-4d46-a244-9a6dc97bb238</loc>
    <lastmod>2020-09-30T15:18:53.022Z</lastmod>
    <changefreq>weekly</changefreq>
    <priority>0.5</priority>
    <image:image>
      <image:loc>http://localhost:3000/api/document/aa18ee18-a78f-4d46-a244-9a6dc97bb238.png</image:loc>
      <image:title>The Protein Arginine Methyltransferase PRMT8 and Substrate G3BP1 Control Rac1-PAK1 Signaling and Actin Cytoskeleton for Dendritic Spine Maturation.</image:title>
      <image:caption>PRMT8 activates G3BP1 via methylation. PRMT8 inhibits Rac1. Rac1 activates PAK1. PAK1 activates LIMK via phosphorylation. LIMK inhibits Cofilin via phosphorylation. G3BP1 binds with eIF4E.</image:caption>
    </image:image>
  </url>
  <url>
    <loc>http://localhost:3000/document/f3ac5915-b26e-469f-935d-abc2efb0a0f7</loc>
    <lastmod>2020-10-01T00:48:34.942Z</lastmod>
    <changefreq>weekly</changefreq>
    <priority>0.5</priority>
    <image:image>
      <image:loc>http://localhost:3000/api/document/f3ac5915-b26e-469f-935d-abc2efb0a0f7.png</image:loc>
      <image:title>ROCK-mediated selective activation of PERK signalling causes fibroblast reprogramming and tumour progression through a CRELD2-dependent mechanism.</image:title>
      <image:caption>PERK activates Atf4. Atf4 activates the transcription/translation of Creld2. ROCK interacts with PERK.</image:caption>
    </image:image>
  </url>
...
</urlset>
```

See https://support.google.com/webmasters/answer/178636?hl=en&ref_topic=2370565
Refs #842 
