### PR TITLE
Additional info: Curator name

### DIFF
--- a/src/client/components/editor/submit.js
+++ b/src/client/components/editor/submit.js
@@ -19,7 +19,8 @@ export const Submit = props => {
   return h('div.editor-submit', [
     h(Popover, {
       tippy: {
-        html: h(TaskView, { document, bus, controller, emitter } )
+        html: h(TaskView, { document, bus, controller, emitter } ),
+        sticky: true
       }
     }, [
       h('button.editor-submit-button', {

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -119,8 +119,9 @@ class TextEditableComponent extends Component {
           'editing': editing,
           'placeholder': displayValue == this.placeholderText
         }),
-        autoFocus: true,
+        autofocus: false,
         value: displayValue,
+        // ref: c => this.focusInput( c ),
         onClick: this.handleEdit(),
         onChange: e => this.handleChange( e ),
         // onFocus: e => this.handleFocus( e ),

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -30,11 +30,11 @@ class TextEditableComponent extends Component {
   constructor( props ) {
     super( props );
     this.textInput = React.createRef();
-    this.placeholderText = props.placeholder || 'Click to edit';
+    this.placeholderText = props.placeholder || '';
     this.defaultValue = props.value || this.placeholderText;
     this.state = {
       editText: this.defaultValue,
-      savedText: this.defaultValue,
+      savedText: this.defaultValue
     };
   }
 
@@ -82,17 +82,18 @@ class TextEditableComponent extends Component {
 
   handleBlur () {
     const { editText } = this.state;
-    const isPlaceholderText = editText == this.placeholderText;
-    if( !editText ){
-      this.setState({ editText: this.placeholderText });
-    } else if ( !isPlaceholderText ) {
+    const isPlaceholderText = editText === this.placeholderText;
+
+    if ( !this.placeholderText || !isPlaceholderText ) {
       this.handleSubmit();
+    } else if( this.placeholderText && !editText ){
+      this.setState({ editText: this.placeholderText });
     }
   }
 
   handleFocus ( ) {
     const { editText } = this.state;
-    const isPlaceholderText = editText == this.placeholderText;
+    const isPlaceholderText = !!this.placeholderText && editText === this.placeholderText;
     if( isPlaceholderText ){
       this.setState({ editText: '' });
     }
@@ -391,9 +392,8 @@ class TaskView extends DataComponent {
             h('div.task-view-done-section-body', [
               h('p', 'Optional info'),
               h( TextEditableComponent, {
-                label: 'Name',
+                label: 'Name:',
                 value: _.get( provided, 'name' ),
-                placeholder: 'Click to edit',
                 autofocus: true,
                 cb: name => document.provided({ name })
               })

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -32,10 +32,12 @@ class TextEditableComponent extends Component {
     this.ENTER_KEY = 13;
     this.placeholderText = props.placeholder || 'Click to edit';
     this.defaultValue = props.value || this.placeholderText;
+    const defaultAutofocus = props.autofocus || false;
     this.state = {
       editText: this.defaultValue,
       savedText: this.defaultValue,
-      editing: false
+      editing: defaultAutofocus,
+      autofocus: defaultAutofocus
     };
   }
 
@@ -92,9 +94,9 @@ class TextEditableComponent extends Component {
     }
   }
 
-  // handleFocus ( e ) {
-  //   e.target.select();
-  // }
+  handleFocus ( e ) {
+    e.target.select();
+  }
 
   render() {
     const { label, className } = this.props;
@@ -119,9 +121,9 @@ class TextEditableComponent extends Component {
           'editing': editing,
           'placeholder': displayValue == this.placeholderText
         }),
-        autofocus: false,
+        autofocus: true,
         value: displayValue,
-        // ref: c => this.focusInput( c ),
+        ref: c => this.focusInput( c ),
         onClick: this.handleEdit(),
         onChange: e => this.handleChange( e ),
         // onFocus: e => this.handleFocus( e ),
@@ -401,6 +403,7 @@ class TaskView extends DataComponent {
                 label: 'Name',
                 value: _.get( provided, 'name' ),
                 placeholder: 'Click to edit',
+                autofocus: true,
                 cb: name => document.provided({ name })
               })
             ])

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -34,19 +34,19 @@ class TextEditableComponent extends Component {
     this.defaultValue = props.value || this.placeholderText;
     this.state = {
       editText: this.defaultValue,
-      savedText: this.defaultValue,
-      saved: !!props.value || false
+      submittedText: this.defaultValue,
+      submitted: !!props.value || false
     };
-    this.wait = 1000;
-    this.delayedSubmit = _.debounce( this.handleSubmit.bind( this ), this.wait );
+    this.wait = props.autosubmit || 0;
+    this.debounceSubmit = _.debounce( this.handleSubmit.bind( this ), this.wait );
   }
 
   handleChange ( e ) {
     this.setState({
-      saved: false,
+      submitted: false,
       editText: e.target.value
     });
-    this.delayedSubmit();
+    if( this.props.autosubmit ) this.debounceSubmit();
   }
 
   handleSubmit () {
@@ -55,8 +55,8 @@ class TextEditableComponent extends Component {
     const newValue = editText && editText.trim();
     return new Promise( resolve => {
       this.setState({
-        savedText: newValue,
-        saved: !!newValue
+        submittedText: newValue,
+        submitted: !!newValue
       }, resolve( newValue ) );
     })
     .then( cb )
@@ -64,9 +64,9 @@ class TextEditableComponent extends Component {
   }
 
   reset() {
-    const { savedText } = this.state;
+    const { submittedText } = this.state;
     this.setState({
-      editText: savedText
+      editText: submittedText
     });
   }
 
@@ -92,9 +92,11 @@ class TextEditableComponent extends Component {
     const { editText } = this.state;
     const isPlaceholderText = editText === this.placeholderText;
 
-    if ( !this.placeholderText || !isPlaceholderText ) {
+    if ( !isPlaceholderText || !this.placeholderText ) {
       this.handleSubmit();
-    } else if( this.placeholderText && !editText ){
+    }
+
+    if( this.placeholderText && !editText ){
       this.setState({ editText: this.placeholderText });
     }
   }
@@ -110,7 +112,7 @@ class TextEditableComponent extends Component {
 
   render() {
     const { label, className } = this.props;
-    const { editText, saved } = this.state;
+    const { editText, submitted } = this.state;
 
     return h('div.text-editable', className, [
       h('label', {
@@ -132,8 +134,8 @@ class TextEditableComponent extends Component {
         id: `text-editable-${label}`,
       }),
       h( 'i.material-icons', {
-        className: makeClassList({ 'show': saved })
-      }, 'check_circle' )
+        className: makeClassList({ 'show': submitted })
+      }, 'check_circle_outline' )
     ]);
   }
 }
@@ -406,6 +408,8 @@ class TaskView extends DataComponent {
                 label: 'Name:',
                 value: _.get( provided, 'name' ),
                 autofocus: true,
+                placeholder: '',
+                autosubmit: 1000,
                 cb: name => document.provided({ name })
               })
             ])
@@ -417,4 +421,4 @@ class TaskView extends DataComponent {
 }
 
 
-export { TaskView };
+export { TaskView, TextEditableComponent };

--- a/src/client/components/tasks.js
+++ b/src/client/components/tasks.js
@@ -34,12 +34,19 @@ class TextEditableComponent extends Component {
     this.defaultValue = props.value || this.placeholderText;
     this.state = {
       editText: this.defaultValue,
-      savedText: this.defaultValue
+      savedText: this.defaultValue,
+      saved: !!props.value || false
     };
+    this.wait = 1000;
+    this.delayedSubmit = _.debounce( this.handleSubmit.bind( this ), this.wait );
   }
 
   handleChange ( e ) {
-    this.setState({ editText: e.target.value });
+    this.setState({
+      saved: false,
+      editText: e.target.value
+    });
+    this.delayedSubmit();
   }
 
   handleSubmit () {
@@ -49,6 +56,7 @@ class TextEditableComponent extends Component {
     return new Promise( resolve => {
       this.setState({
         savedText: newValue,
+        saved: !!newValue
       }, resolve( newValue ) );
     })
     .then( cb )
@@ -102,7 +110,7 @@ class TextEditableComponent extends Component {
 
   render() {
     const { label, className } = this.props;
-    const { editText } = this.state;
+    const { editText, saved } = this.state;
 
     return h('div.text-editable', className, [
       h('label', {
@@ -122,7 +130,10 @@ class TextEditableComponent extends Component {
         onBlur: e => this.handleBlur( e ),
         onKeyDown: e => this.handleKeyDown( e ),
         id: `text-editable-${label}`,
-      })
+      }),
+      h( 'i.material-icons', {
+        className: makeClassList({ 'show': saved })
+      }, 'check_circle' )
     ]);
   }
 }

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -136,6 +136,10 @@
   height: 2em;
 }
 
+.text-editable input[type="text"] {
+  transition: none;
+}
+
 .text-editable input[type="text"]:focus {
   border: 2px solid var(--brandColor);
 }

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -136,15 +136,6 @@
   height: 2em;
 }
 
-.text-editable input[type="text"] {
-  border: none;
-}
-
-.text-editable input[type="text"]:hover {
-  transition: none;
-  border: 1px solid var(--widgetDisabledBorderColor);
-}
-
 .text-editable input[type="text"]:focus {
   border: 2px solid var(--brandColor);
 }
@@ -156,8 +147,4 @@
 .text-editable label {
   display: inline-block;
   margin: auto 0.5em;
-}
-
-.text-editable label::after {
-  content: ':';
 }

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -146,7 +146,7 @@
 }
 
 .text-editable input[type="text"].editing {
-  border: thin solid var(--brandColor);
+  border: 2px solid var(--brandColor);
 }
 
 .text-editable input[type="text"].placeholder {

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -148,3 +148,12 @@
   display: inline-block;
   margin: auto 0.5em;
 }
+
+.text-editable i {
+  visibility: hidden;
+}
+
+.text-editable i.show {
+  margin: auto 0.5em;
+  visibility: initial;
+}

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -145,7 +145,7 @@
   border: 1px solid var(--widgetDisabledBorderColor);
 }
 
-.text-editable input[type="text"].editing {
+.text-editable input[type="text"]:focus {
   border: 2px solid var(--brandColor);
 }
 

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -131,3 +131,33 @@
   }
 }
 
+.text-editable {
+  text-align: left;
+  height: 2em;
+}
+
+.text-editable input[type="text"] {
+  border: none;
+}
+
+.text-editable input[type="text"]:hover {
+  transition: none;
+  border: 1px solid var(--widgetDisabledBorderColor);
+}
+
+.text-editable input[type="text"].editing {
+  border: thin solid var(--brandColor);
+}
+
+.text-editable input[type="text"].placeholder {
+  color: var(--fadedColor);
+}
+
+.text-editable label {
+  display: inline-block;
+  margin: auto 0.5em;
+}
+
+.text-editable label::after {
+  content: ':';
+}


### PR DESCRIPTION
- made a `TextEditableComponent` that mimics the behaviour of the Google Doc title component.
  - props
    - `label`,  `placeholder`, `autofocus`
    - `cb`: callback to handle a 'saved' value
  - saving happens when you key 'Enter' or click off/blur
  - reset on key 'Escape'


- Issues
  - When the editor 'submit' is clicked the TaskView tippy covers the 'submit' button
  - Some jitter on hover over text box
  - Label and text input baseline aren't the same


Refs #729 


![ezgif com-video-to-gif](https://user-images.githubusercontent.com/4706307/97468324-86b8c700-191b-11eb-976d-b9de731bd9a1.gif)




  
