### PR TITLE
Provide author name parts and use in emails to ref'd paper authors

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -1239,7 +1239,7 @@ const emailRelatedPaperAuthors = async doc => {
   const sendEmail = async (paper, novelIntns) => {
     const contact = getContact(paper);
     const email = EMAIL_RELPPRS_CONTACT ? contact.email[0] : EMAIL_ADMIN_ADDR;
-    const name = contact.name;
+    const name = contact.ForeName;
 
     // prevent duplicate sending
     doc.relatedPapersNotified(true);

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -75,7 +75,8 @@ const getEmail = author => {
 const getContact = author => {
   const email = getEmail( author );
   const name = getAuthorName( author );
-  return { name, email };
+  const { ForeName, LastName } = getAuthorNameParts( author );
+  return { name, email, ForeName, LastName };
 };
 
 // Always show the last author

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -46,6 +46,22 @@ const getAbbrevAuthorName = author => {
   return name;
 };
 
+const getAuthorNameParts = author => {
+  let ForeName = null;
+  let LastName = null;
+  const collectiveName = _.get( author, 'CollectiveName' );
+  const isPerson = _.isNull( collectiveName );
+  if( isPerson ){
+    LastName = _.get( author, 'LastName' ); // required
+    ForeName = _.get( author, 'ForeName' ); // required
+    if( ForeName != null ){
+      // Only take the first token (could be 'name initial')
+      ForeName = ForeName.split(' ')[0];
+    }
+  }
+  return { ForeName, LastName };
+};
+
 const getEmail = author => {
   const AffiliationInfo = _.get( author, ['AffiliationInfo'] );
   let email = [];
@@ -78,8 +94,11 @@ const getContacts = AuthorList => AuthorList.map( getContact ).filter( contact =
 
 const getAuthorList = AuthorList => {
   return AuthorList.map( Author => {
+    const { ForeName, LastName } = getAuthorNameParts( Author );
     return {
       name: getAuthorName( Author ),
+      ForeName,
+      LastName,
       email: _.head( getEmail( Author ) ) || null,
       abbrevName: getAbbrevAuthorName( Author ),
       isCollectiveName: !_.isNull( _.get( Author, 'CollectiveName' ) )


### PR DESCRIPTION
Supply the `ForeName` and `LastName` (both possibly null) in the doc.citation.authors attribute. Use the `ForeName`  in the email to the referenced authors.

Refs https://github.com/PathwayCommons/factoid/issues/858#issuecomment-725607997