### PR TITLE
Expose the EMAIL_RELPPRS_CONTACT as a env variable in Docker.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       TWITTER_ACCOUNT_NAME:
       NCBI_EUTILS_API_KEY:
       NODE_OPTIONS:
+      EMAIL_RELPPRS_CONTACT:
   grounding:
     image: pathwaycommons/grounding-search:${GROUNDING_SEARCH_IMAGE_TAG:-latest}
     restart: on-failure


### PR DESCRIPTION
Primarily to give us flexibility in testing this. Don't want to flood authors with  emails in development if we switch to Docker.