### PR TITLE
Avoid edge arrow overlap with labels #908

### DIFF
--- a/src/util/cy.js
+++ b/src/util/cy.js
@@ -164,7 +164,9 @@ function makeBaseStylesheet(isStatic = false){
         'curve-style': 'bezier',
         'line-color': defaultColor,
         'target-arrow-color': defaultColor,
-        'source-arrow-color': defaultColor
+        'source-arrow-color': defaultColor,
+        'target-endpoint': 'outside-to-node-or-label',
+        'source-endpoint': 'outside-to-node-or-label'
       }
     },
     {
@@ -178,7 +180,8 @@ function makeBaseStylesheet(isStatic = false){
       selector: 'edge[sign="negative"]',
       style: {
         'source-arrow-shape': 'none',
-        'target-arrow-shape': 'tee'
+        'target-arrow-shape': 'tee',
+        'target-distance-from-node': 1
       }
     },
     {


### PR DESCRIPTION
Before:

![100129767-f4d7a780-2e4f-11eb-9d78-4af12ffb47b2](https://user-images.githubusercontent.com/989043/100889381-0e4aa600-3485-11eb-985e-fcf726aaeed8.png)

After:

<img width="452" alt="Screen Shot 2020-12-02 at 9 58 13 AM" src="https://user-images.githubusercontent.com/989043/100889400-14408700-3485-11eb-9c76-c99998272aa2.png">


Refs. : #908