### PR TITLE
Update paper metadata: Fail gently

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       NCBI_EUTILS_API_KEY:
       NODE_OPTIONS:
       EMAIL_RELPPRS_CONTACT:
+      CRON_SCHEDULE:
   grounding:
     image: pathwaycommons/grounding-search:${GROUNDING_SEARCH_IMAGE_TAG:-latest}
     restart: on-failure

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -2000,7 +2000,7 @@ const updateRelatedPapers = async doc => {
 };
 
 const getRelPprsForDoc = async doc => {
-  let papers = [];
+  let relatedPapers = [];
   let referencedPapers = [];
 
   try {
@@ -2008,36 +2008,40 @@ const getRelPprsForDoc = async doc => {
     const getUid = result => _.get( result, 'uid' );
     const { pmid } = doc.citation();
 
-    if( pmid ){
-      const elinkResponse = await eLink( { id: [pmid] } );
+    if( pmid == null ) throw new Error('Article pmid not available');
 
-      // For .relatedPapers
-      const documents = elink2UidList( elinkResponse );
-      let rankedDocs = await indra.semanticSearch({ query: pmid, documents });
-      const uids = _.take( rankedDocs, SEMANTIC_SEARCH_LIMIT ).map( getUid );
-      const relatedPapersResponse = await fetchPubmed({ uids });
-      papers = _.get( relatedPapersResponse, 'PubmedArticleSet', [] )
+    const elinkResponse = await eLink( { id: [pmid] } );
+
+    // For .relatedPapers
+    const documents = elink2UidList( elinkResponse );
+    let rankedDocs = await indra.semanticSearch({ query: pmid, documents });
+    const uids = _.take( rankedDocs, SEMANTIC_SEARCH_LIMIT ).map( getUid );
+    const relatedPapersResponse = await fetchPubmed({ uids });
+    relatedPapers = _.get( relatedPapersResponse, 'PubmedArticleSet', [] )
+      .map( getPubmedCitation )
+      .map( citation => ({ pmid: citation.pmid, pubmed: citation }) );
+    doc.relatedPapers( relatedPapers );
+
+    // For .referencedPapers
+    const referencedPaperUids = elink2UidList( elinkResponse, ['pubmed_pubmed_refs'], 100 );
+    if( referencedPaperUids.length ){
+      const referencedPapersResponse = await fetchPubmed({ uids: referencedPaperUids });
+      referencedPapers = _.get( referencedPapersResponse, 'PubmedArticleSet', [] )
         .map( getPubmedCitation )
         .map( citation => ({ pmid: citation.pmid, pubmed: citation }) );
-
-      // For .referencedPapers
-      const referencedPaperUids = elink2UidList( elinkResponse, ['pubmed_pubmed_refs'], 100 );
-      if( referencedPaperUids.length ){
-        const referencedPapersResponse = await fetchPubmed({ uids: referencedPaperUids });
-        referencedPapers = _.get( referencedPapersResponse, 'PubmedArticleSet', [] )
-          .map( getPubmedCitation )
-          .map( citation => ({ pmid: citation.pmid, pubmed: citation }) );
-      }
     }
 
-    doc.relatedPapers( papers );
     doc.referencedPapers( referencedPapers );
     logger.info(`Finished updating document-level related papers`);
     return doc;
 
   } catch ( err ){
-    logger.error(`Error getRelPprsForDoc: ${err.message}`);
-    doc.relatedPapers( papers );
+    logger.error(`Error getRelPprsForDoc: ${err}`);
+
+    // Only supply default when no previous retrieval
+    if( _.isNil( doc.relatedPapers() ) ) doc.relatedPapers( relatedPapers );
+    if( _.isNil( doc.referencedPapers() ) ) doc.referencedPapers( referencedPapers );
+
     return doc;
   }
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -317,11 +317,17 @@ const fillDocArticle = async doc => {
     await doc.article( pubmedRecord );
     await doc.issues({ paperId: null });
   } catch ( error ) {
+
     logger.error( `Error filling doc article` );
     logger.error( error );
-    const pubmedRecord = createPubmedArticle({ articleTitle: paperId });
-    await doc.article( pubmedRecord );
-    await doc.issues({ paperId: { error, message: error.message } });
+
+    // Only supply default when no previous retrieval (pmid is null)
+    const { pmid } = doc.citation();
+    if( pmid == null ){
+      const pubmedRecord = createPubmedArticle({ articleTitle: paperId });
+      await doc.article( pubmedRecord );
+      await doc.issues({ paperId: { error, message: error.message } });
+    }
   }
 };
 
@@ -1649,7 +1655,7 @@ http.post('/', function( req, res, next ){
     if ( email ) {
       return sendInviteNotification( doc ).then( () => doc );
     }
-    
+
     return doc;
   };
   const handleDocSource = doc => {


### PR DESCRIPTION
Two aspects that get set/refreshed are 1. article metadata (abstract, authors etc...) 2. related papers (document-level, which includes related papers and referenced papers; network-level). 

In this PR, refresh or update can only overwrite the existing information if there a. is no error and b. the previous saved result was null or undefined. Otherwise the previous information stays put.

The trade-off here, is that if you first entered a valid PMID and all the metadata got set, you can't overwrite the paper with a non-recognized PMID/title, although it gets stashed in the `provided.paperId` field. This is a weird case anyways.

Refs #914  