### PR TITLE
Post hoc titles etc

### DIFF
--- a/src/client/components/document-management.js
+++ b/src/client/components/document-management.js
@@ -175,7 +175,8 @@ class DocumentManagement extends DirtyComponent {
             apiKey,
             doneMsg: 'Request submitted.',
             bus: this.bus,
-            submitBtnText: 'Create my article profile'
+            submitBtnText: 'Create my article profile',
+            checkIncomplete: false
           }),
           onHidden: () => this.bus.emit( 'closecta' ),
           placement: 'top'

--- a/src/client/components/editor/credits.js
+++ b/src/client/components/editor/credits.js
@@ -1,0 +1,37 @@
+import h from 'react-hyperscript';
+import { Component } from 'react';
+import _ from 'lodash';
+
+export class Credits extends Component {
+  constructor(props){
+    super(props);
+  }
+
+  render(){
+    const { document } = this.props;
+    const authorName = _.get(document.provided(), ['name']);
+
+    if( document.editable() || !authorName ){
+      return null;
+    }
+
+    const profiles = document.authorProfiles() || [];
+    const isContributingAuthor = author => author.name === authorName;
+    const authorLink = _.get(profiles.find(isContributingAuthor), ['orcid']);
+
+    return h('div.editor-credits', [
+      `Created by `,
+      (authorLink ? 
+        h('a.plain-link', { href: authorLink, target: '_blank' }, authorName) 
+        :
+        h('span', authorName) 
+      ),
+      authorLink ? h('span', [
+        h('span', ' '),
+        h('i.icon.icon-orcid')
+      ]) : null
+    ]);
+  }
+}
+
+export default Credits;

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -27,6 +27,7 @@ import Help from './help';
 import InfoPanel from './info-panel';
 import ExploreShare from './explore-share';
 import * as cyDefs from './cy/defs';
+import Credits from './credits';
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;
@@ -527,7 +528,8 @@ class Editor extends DataComponent {
       h(UndoRemove, { controller, document, bus }),
       h('div.editor-graph#editor-graph'),
       h(Help, { controller, showHelp, document }),
-      h(InfoPanel, { controller, bus, document, history })
+      h(InfoPanel, { controller, bus, document, history }),
+      h(Credits, { controller, bus, document })
     ] : [];
 
     return h('div.editor', {

--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -5,6 +5,7 @@ import { DOI_LINK_BASE_URL, PUBMED_LINK_BASE_URL, GOOGLE_SCHOLAR_BASE_URL } from
 import { makeClassList } from '../../dom';
 import ElementInfo from '../element-info/element-info';
 import RelatedPapers from '../related-papers';
+import _ from 'lodash';
 
 export class InfoPanel extends Component {
   constructor(props){
@@ -68,14 +69,21 @@ export class InfoPanel extends Component {
 
     return h('div.editor-info-panel', [
       h('div.editor-info-title', title),
-      h('div.editor-info-authors', authorProfiles.map(a => {
+      h('div.editor-info-authors', _.flatten(authorProfiles.map((a, i) => {
         let orcidUri = a.orcid;
         if ( orcidUri ) {
-            return h('a.editor-info-author.plain-link', { target: '_blank', href: orcidUri }, a.name);
+          return [
+            h('a.editor-info-author.plain-link', { target: '_blank', href: orcidUri }, a.name),
+            h('i.icon.icon-orcid.editor-info-author-orcid'),
+            i !== authorProfiles.length - 1 ? h('span.editor-info-author-spacer', ', ') : null
+          ];
         }
 
-        return h('span.editor-info-author', a.name);
-      })),
+        return [
+          h('span.editor-info-author', a.name),
+          i !== authorProfiles.length - 1 ? h('span.editor-info-author-spacer', ', ') : null
+        ];
+      }))),
       h('div.editor-info-links', doi ? [
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }, reference),
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed'),

--- a/src/client/components/editor/submit.js
+++ b/src/client/components/editor/submit.js
@@ -14,10 +14,9 @@ export const Submit = props => {
     return null;
   }
 
-  // emitter.on('close', () => { console.log( 'close triggered'); });
-
   return h('div.editor-submit', [
     h(Popover, {
+      hide: hideNow => bus.on('closesubmit', hideNow),
       tippy: {
         html: h(TaskView, { document, bus, controller, emitter } ),
         sticky: true

--- a/src/client/components/editor/title.js
+++ b/src/client/components/editor/title.js
@@ -1,5 +1,6 @@
 import h from 'react-hyperscript';
 import { Component } from 'react';
+import _ from 'lodash';
 
 import Popover from '../popover/popover';
 import RequestForm from '../request-form';
@@ -33,25 +34,39 @@ class EditorTitle extends Component {
     const { document } = this.props;
     const { citation } = this.state;
     const { authors: { abbreviation }, title = 'Unnamed document', reference, doi } = citation;
+    const provided = document.provided() || {};
 
     if( !document.editable() ){
       return null;
     }
 
+    const otherMissingFields = !provided.authorName || !provided.authorEmail;
+
     const getTitleContent = () => {
        if ( title == null ) {
          return h( Popover, {
+           show: showTippy => {
+             this.bus.on('showedittitle', showTippy); // for submit validation: show me how
+           },
            tippy: {
              html: h( RequestForm, {
                doc: document,
                bus: this.bus,
-               submitBtnText: 'Okay'
+               submitBtnText: 'OK',
+               showDescription: false,
+               showTitle: false,
+               addClasses: '.editor-request-form-container',
+               formFields: {
+                 authorName: _.get(document.provided(), ['authorName']),
+                 authorEmail: _.get(document.provided(), ['authorEmail'])
+               }
              }),
+             onShown: () => this.bus.emit('opencta'),
              onHidden: () => this.bus.emit( 'closecta' ),
              placement: 'top'
            }
          }, [
-           h( 'span.plain-link.link-like', 'Set the article\'s title' )
+           h( 'span.plain-link.link-like', `Set your article's title` + (otherMissingFields ? ' etc.' : '') )
          ]);
        }
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -1843,7 +1843,10 @@ http.patch('/:id/:secret', function( req, res, next ){
           if( op === 'replace' && value === DOCUMENT_STATUS_FIELDS.PUBLIC ) await handleMakePublicRequest( doc );
           break;
         case 'article':
-          if( op === 'replace' ) await fillDocArticle( doc );
+          if( op === 'replace' ) {
+            await fillDocArticle( doc );
+            await fillDocAuthorProfiles( doc );
+          }
           break;
         case 'correspondence':
           if( op === 'replace' ){

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -348,6 +348,8 @@ button {
   width: 1em;
   height: 1em;
   background-size: contain;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
 }
 
 .icon-rot-15 {

--- a/src/styles/custom-icons.css
+++ b/src/styles/custom-icons.css
@@ -48,4 +48,8 @@
       background-image: url('./image/share-white.svg');
     }
   }
+
+  &.icon-orcid {
+    background-image: url('./image/orcid-icon.svg');
+  }
 }

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -341,6 +341,23 @@
   font-size: 3em;
 }
 
+.editor-credits {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 0.5em;
+  z-index: 1;
+  opacity: 0.7;
+
+  & .icon {
+    font-size: 0.8em;
+  }
+}
+
+.editor-request-form-container {
+  padding: 0.25em !important;
+}
+
 @media (min-width: 1000px) {
   .editor-info-panel {
     padding: 1em;

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -295,6 +295,7 @@
 
 .editor-info-authors {
   margin: 0.5em 0;
+  line-height: 1.4;
 }
 
 .editor-info-links {
@@ -302,7 +303,17 @@
   line-height: 1.4;
 }
 
-.editor-info-link, .editor-info-author {
+.editor-info-author-spacer {
+  margin-right: 0.333em;
+}
+
+.editor-info-author-orcid {
+  margin-left: 0.25em;
+  font-size: 0.8em;
+  opacity: 0.66;
+}
+
+.editor-info-link {
   display: inline-block;
   margin-right: 1em;
 }

--- a/src/styles/image/orcid-icon.svg
+++ b/src/styles/image/orcid-icon.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#000000;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/>
+<g>
+	<path class="st1" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/>
+	<path class="st1" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+	<path class="st1" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+</g>
+</svg>

--- a/src/styles/request-form.css
+++ b/src/styles/request-form.css
@@ -21,6 +21,7 @@
   font-size: 1.25em;
   text-align: center;
   color: #000;
+  margin-bottom: 0.4em;
 }
 
 .request-form-author {
@@ -35,8 +36,11 @@
 .request-form > input {
   display: block;
   width: 100%;
-  margin-top: 0.5em;
   box-sizing: border-box;
+
+  & + input {
+    margin-top: 0.5em;
+  }
 }
 
 .request-form-footer {
@@ -117,4 +121,8 @@
 
 .request-form-done-msg {
   text-align: center;
+}
+
+.request-form-provided {
+  display: none !important;
 }


### PR DESCRIPTION
For details, refer to the commits.  The main user-facing changes include:

(1) The name is another field on the landing page CTA:

<img width="305" alt="Screen Shot 2020-12-21 at 11 22 40" src="https://user-images.githubusercontent.com/989043/102798687-6fc4ad00-437f-11eb-8bea-5df57a7b7e35.png">

(2) There is a link to set the title in the editor:

<img width="784" alt="Screen Shot 2020-12-21 at 11 25 24" src="https://user-images.githubusercontent.com/989043/102798734-7ce19c00-437f-11eb-98b5-d6c4fcc132e2.png">

(3) The title is hooked into the validation:

<img width="781" alt="Screen Shot 2020-12-21 at 11 25 32" src="https://user-images.githubusercontent.com/989043/102798762-8a972180-437f-11eb-93aa-10b698f42a15.png">

(4) For use cases where the author name and email are pre-filled (e.g. email campaign #858), the user just needs to set the title:

<img width="780" alt="Screen Shot 2020-12-21 at 11 25 47" src="https://user-images.githubusercontent.com/989043/102798783-94b92000-437f-11eb-8c03-3de8203f71c1.png">

(5) When the title has been set, it looks like the normal editor title:

<img width="781" alt="Screen Shot 2020-12-21 at 11 25 55" src="https://user-images.githubusercontent.com/989043/102798870-b61a0c00-437f-11eb-85b5-4ef82e3484d5.png">

(6) The explore view has formatted author links to ORCID.  In the top-right corner, the contributing author is credited.

<img width="783" alt="Screen Shot 2020-12-21 at 11 26 14" src="https://user-images.githubusercontent.com/989043/102798912-c16d3780-437f-11eb-8952-e0dc960496ab.png">






Builds on Metin's PR, #913.

Ref. : 

- Post hoc specification of the paper in a factoid #901
- Novel interaction notification #858