### PR TITLE
Consider complex template transformation for invalid interaction templates as well.

### DIFF
--- a/src/model/element/interaction-type/binding.js
+++ b/src/model/element/interaction-type/binding.js
@@ -37,7 +37,7 @@ class Binding extends InteractionType {
 
   toBiopaxTemplate( transform, omitDbXref ){
     if ( !this.validatePpts() ){
-      return this.makeInvalidBiopaxTemplate( omitDbXref );
+      return this.makeInvalidBiopaxTemplate( transform, omitDbXref );
     }
 
     let participants = _.uniqBy(this.interaction.participants().map( transform ), p => p.id() );

--- a/src/model/element/interaction-type/interaction-type.js
+++ b/src/model/element/interaction-type/interaction-type.js
@@ -178,8 +178,9 @@ class InteractionType {
     return pptAssocsAllowed() && pptTypeAllowed();
   }
 
-  makeInvalidBiopaxTemplate( omitDbXref ){
+  makeInvalidBiopaxTemplate( transform, omitDbXref ){
     let participants = this.interaction.participants();
+    participants = _.uniqBy( participants.map( transform ), p => p.id() );
     let participantTemplates = participants.map( participant => participant.toBiopaxTemplate( omitDbXref ) );
 
     return {

--- a/src/model/element/interaction-type/interaction.js
+++ b/src/model/element/interaction-type/interaction.js
@@ -21,7 +21,7 @@ class Interaction extends InteractionType {
 
   toBiopaxTemplate( transform, omitDbXref ){
     if ( !this.validatePpts( transform ) ){
-      return this.makeInvalidBiopaxTemplate( omitDbXref );
+      return this.makeInvalidBiopaxTemplate( transform, omitDbXref );
     }
 
     // "Other" type; see 4A-E in "Factoid binary interaction types" doc.

--- a/src/model/element/interaction-type/modification.js
+++ b/src/model/element/interaction-type/modification.js
@@ -50,7 +50,7 @@ class Modification extends InteractionType {
 
   toBiopaxTemplate(transform, omitDbXref, effect){//effect is undefined in base Modification case (i.e., no phys. mod. feature)
     if ( !this.validatePpts( transform ) ){
-      return this.makeInvalidBiopaxTemplate( omitDbXref );
+      return this.makeInvalidBiopaxTemplate( transform, omitDbXref );
     }
 
     //src, tgt shouldn't be null at this point (barring bug)

--- a/src/model/element/interaction-type/transcription-translation.js
+++ b/src/model/element/interaction-type/transcription-translation.js
@@ -50,7 +50,7 @@ class TranscriptionTranslation extends InteractionType {
 
   toBiopaxTemplate( transform, omitDbXref ){
     if ( !this.validatePpts() ){
-      return this.makeInvalidBiopaxTemplate( omitDbXref );
+      return this.makeInvalidBiopaxTemplate( transform, omitDbXref );
     }
 
     //src, tgt shouldn't be null at this point (barring bug)


### PR DESCRIPTION
Refs https://github.com/PathwayCommons/factoid-converters/issues/17

The case in the issue was an example of invalid biopax template. In which case we were using a standard template for biopax conversion of related interaction. Looks like we were missing the transformation we make for complex components for this specific case. I fixed it.