### PR TITLE
Docker: Nginx and Zenodo support

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,6 +1,12 @@
 # Environment variables for Docker Compose services
 NCBI_EUTILS_API_KEY=
 
+# proxy
+NGINX_IMAGE_TAG=1.19
+PROXY_PORT=
+NGINX_PORT=80
+NGINX_HOST=
+
 # webapp
 BASE_URL=https://biofactoid.org
 FACTOID_IMAGE_TAG=latest
@@ -22,6 +28,9 @@ APPSIGNAL_APP_ENV=
 # grounding
 GROUNDING_SEARCH_IMAGE_TAG=latest
 GROUNDING_PORT=3011
+ZENODO_ACCESS_TOKEN=
+ZENODO_BASE_URL=
+ZENODO_BUCKET_ID=
 
 # db
 RETHINKDB_IMAGE_TAG=latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,22 @@
 version: "3.8"
 services:
+  proxy:
+    image: nginx:${NGINX_IMAGE_TAG:-latest}
+    restart: on-failure
+    container_name: proxy_container
+    depends_on:
+      - webapp
+    ports:
+      - "${PROXY_PORT:-80}:${NGINX_PORT:-80}"
+    volumes:
+      - ./templates:/etc/nginx/templates
+      - appdata:/var/www/app:ro
+    environment:
+      NGINX_PORT: "80"
+      NGINX_HOST:
+      NGINX_PROXY_SERVER: "webapp:3000"
+      STATIC_ROOT: /var/www/app/build
+      IMAGE_ROOT: /var/www/app/src/styles
   webapp:
     image: pathwaycommons/factoid:${FACTOID_IMAGE_TAG:-latest}
     restart: on-failure
@@ -10,6 +27,8 @@ services:
       - converter
     ports:
       - "${FACTOID_PORT:-3000}:3000"
+    volumes:
+      - appdata:/home/appuser/app
     environment:
       BASE_URL:
       GROUNDING_SEARCH_BASE_URL: "http://grounding:3000"
@@ -41,6 +60,9 @@ services:
     environment:
       ELASTICSEARCH_HOST: "index:9200"
       NCBI_EUTILS_API_KEY:
+      ZENODO_ACCESS_TOKEN:
+      ZENODO_BASE_URL:
+      ZENODO_BUCKET_ID:
     command: ["./wait-for-elasticsearch.sh", "index:9200", "npm", "run", "boot"]
   index:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.7.2
@@ -64,6 +86,8 @@ services:
       - "${CONVERTER_PORT:-3082}:8080"
 
 volumes:
+  appdata:
+    name: appdata
   dbdata:
     name: dbdata
   indata:

--- a/docker/templates/default.conf.template
+++ b/docker/templates/default.conf.template
@@ -1,0 +1,34 @@
+upstream backend {
+    server ${NGINX_PROXY_SERVER};
+}
+
+server {
+  listen ${NGINX_PORT};
+  listen [::]:${NGINX_PORT};
+  server_name ${NGINX_HOST};
+  root /;
+
+  location ~* ^/([^/]*\.(js|css))$ {
+              root ${STATIC_ROOT};
+              expires 30d;
+  }
+
+  location /image/ {
+           root ${IMAGE_ROOT};
+           expires 30d;
+  }
+
+  location / {
+    proxy_pass http://backend;
+
+    proxy_set_header Host ${NGINX_HOST};
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+
+  }
+
+}


### PR DESCRIPTION
- Support for Nginx 
  - Serve factoid static assets via volume [cannot follow symlinks in Docker containers (i.e. factoid /public)]:  
    - /*.js|css gets served from `STATIC_ROOT` path
    - /image gets served from  `IMAGE_ROOT` path
    - all else goes to the NodeJS server
- Add Zenodo env variables

Refs #933 
