### PR TITLE
Docker: environment variables in client-side assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,6 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 # Note: NODE_ENV is development so that dev deps are installed
 RUN NODE_ENV=development npm install
 
-# Build project
-RUN npm run clean
-RUN npm run build
-
 # Expose port
 EXPOSE 3000
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
+npm run clean
+npm run build
 google-chrome-stable &
 cd /home/appuser/app && npm run start


### PR DESCRIPTION
Move the `npm build command` to the entrypoint.sh file, so that the app assets are built under the provided environment.

Refs #951 