### PR TITLE
Author attribution overlaps the share button 

### DIFF
--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -344,7 +344,7 @@
 .editor-credits {
   position: absolute;
   right: 0;
-  top: 0;
+  bottom: 50%;
   margin: 0.5em;
   z-index: 1;
   opacity: 0.7;


### PR DESCRIPTION
Moved to bottom

<img width="1151" alt="Screen Shot 2021-04-14 at 13 49 17" src="https://user-images.githubusercontent.com/989043/114755978-3a760d80-9d28-11eb-885b-3e584f280bf2.png">


Ref. : #958