### PR TITLE
Retain the data source's 'name' in grounding tooltip entry

### DIFF
--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -148,6 +148,21 @@ class EntityInfo extends DataComponent {
       delete match.typeOfGene; // n.b. the model overrides via this field
     }
 
+    if( s.name !== match.name ) {
+      // Add 'name' to shortSynonyms
+      let shortSyns = _.get( match, 'shortSynonyms', [] );
+      let newShortSyns = _.uniq( _.concat( match.name, shortSyns ) );
+      _.set( match, 'shortSynonyms', newShortSyns );
+    }
+
+    const assoc = el.association();
+    if( assoc ) {
+      // Drop 'name' from shortSynonyms
+      let shortSyns = _.get( assoc, 'shortSynonyms', [] );
+      let newShortSyns = _.without( shortSyns, assoc.name );
+      _.set( assoc, 'shortSynonyms', newShortSyns );
+    }
+
     el.associate( match );
     el.complete();
 
@@ -371,16 +386,6 @@ class EntityInfo extends DataComponent {
       assoc = s.element.association();
     } else {
       assoc = null;
-    }
-
-    // Add association 'name' as a (short) synonym, if different than input
-    if( assoc ) {
-      const { name: assocName } = assoc;
-      if( assocName !== s.name ){
-        const shortSynonyms = _.get( assoc, 'shortSynonyms', [] );
-        const updatedSynonyms = _.uniq( _.concat( assocName, shortSynonyms ) );
-        _.set( assoc, 'shortSynonyms', updatedSynonyms );
-      }
     }
 
     let targetFromAssoc = (m, complete = false, showRefinement = false) => {

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -148,16 +148,18 @@ class EntityInfo extends DataComponent {
       delete match.typeOfGene; // n.b. the model overrides via this field
     }
 
-    if( s.name !== match.name ) {
-      // Add 'name' to shortSynonyms
-      let shortSyns = _.get( match, 'shortSynonyms', [] );
-      let newShortSyns = _.uniq( _.concat( match.name, shortSyns ) );
+    // If label is different from match 'name', add latter to shortSynonyms
+    const label = s.name;
+    let matchShortSyns = _.get( match, 'shortSynonyms', [] );
+    let inputNotMatchName = label !== match.name;
+    if ( inputNotMatchName ) {
+      let newShortSyns = _.uniq( _.concat( match.name, matchShortSyns ) );
       _.set( match, 'shortSynonyms', newShortSyns );
     }
 
+    // Remove the match 'name' from the current association, if exists
     const assoc = el.association();
     if( assoc ) {
-      // Drop 'name' from shortSynonyms
       let shortSyns = _.get( assoc, 'shortSynonyms', [] );
       let newShortSyns = _.without( shortSyns, assoc.name );
       _.set( assoc, 'shortSynonyms', newShortSyns );

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -149,9 +149,8 @@ class EntityInfo extends DataComponent {
     }
 
     // If label is different from match 'name', add latter to shortSynonyms
-    const label = s.name;
     let matchShortSyns = _.get( match, 'shortSynonyms', [] );
-    let inputNotMatchName = label !== match.name;
+    let inputNotMatchName = _.toLower( s.name ) !== _.toLower( match.name );
     if ( inputNotMatchName ) {
       let newShortSyns = _.uniq( _.concat( match.name, matchShortSyns ) );
       _.set( match, 'shortSynonyms', newShortSyns );

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -373,6 +373,16 @@ class EntityInfo extends DataComponent {
       assoc = null;
     }
 
+    // Add association 'name' as a (short) synonym, if different than input
+    if( assoc ) {
+      const { name: assocName } = assoc;
+      if( assocName !== s.name ){
+        const shortSynonyms = _.get( assoc, 'shortSynonyms', [] );
+        const updatedSynonyms = _.uniq( _.concat( assocName, shortSynonyms ) );
+        _.set( assoc, 'shortSynonyms', updatedSynonyms );
+      }
+    }
+
     let targetFromAssoc = (m, complete = false, showRefinement = false) => {
       let highlight = !complete;
       let searchStr = highlight ? s.name : null;


### PR DESCRIPTION
If the user label is different than the search hit selected, stash the data provider 'name' (e.g. Official, ChEBI) in the synonyms list.

For example, below, the name 'Carotol' is kept as a synonym.

<img width="350" alt="image" src="https://user-images.githubusercontent.com/4706307/117843559-ea1d9d00-b24c-11eb-9425-6baa8879c02d.png">


Refs #969 