### PR TITLE
Article search should exclude retractions from the hits

### DIFF
--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -15,7 +15,8 @@ const ID_TYPE = Object.freeze({
 });
 
 const pubTypeToExclude = [
-  { UI: 'D016425', value: 'Published Erratum' }
+  { UI: 'D016425', value: 'Published Erratum' },
+  { UI: 'D016440', value: 'Retraction of Publication' }
 ];
 
 const paperId2Type = paperId => {


### PR DESCRIPTION
When a user inputs a paper title, match against PubMed search hits for the original article, rather than those that can be closely related, specifically retractions of that paper.  

Refs https://github.com/PathwayCommons/factoid/issues/848#issuecomment-853340442
