### PR TITLE
Close unsubmitted editor warning

### DIFF
--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -254,7 +254,7 @@ class Editor extends DataComponent {
 
     window.addEventListener('beforeunload', (event) => {
       const isDevMode = NODE_ENV != 'production';
-      const shouldWarnUser = !this.data.document.submitted() || isDevMode; // dev mode blacklisted so livereload works (for productivity)
+      const shouldWarnUser = !this.data.document.submitted() && !isDevMode; // dev mode blacklisted so livereload works (for productivity)
 
       if (shouldWarnUser) {
         event.preventDefault();

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -6,7 +6,7 @@ import io from 'socket.io-client';
 import _ from 'lodash';
 import Mousetrap from 'mousetrap';
 
-import { DEMO_ID, DEMO_SECRET, DEMO_AUTHOR_EMAIL } from '../../../config';
+import { DEMO_ID, DEMO_SECRET, DEMO_AUTHOR_EMAIL, NODE_ENV } from '../../../config';
 
 import { makeClassList } from '../../dom';
 import { getId, defer, tryPromise } from '../../../util';
@@ -144,7 +144,7 @@ class Editor extends DataComponent {
         this.done( isDone );
       }
     });
-
+    
     let bus = new EventEmitter();
 
     bus.on('drawtoggle', (toggle, type) => this.toggleDrawMode(toggle, type));
@@ -251,6 +251,17 @@ class Editor extends DataComponent {
       } )
       .catch( (err) => logger.error('An error occurred livening the doc', err) )
     ;
+
+    window.addEventListener('beforeunload', (event) => {
+      const isDevMode = NODE_ENV != 'production';
+      const shouldWarnUser = !this.data.document.submitted() || isDevMode; // dev mode blacklisted so livereload works (for productivity)
+
+      if (shouldWarnUser) {
+        event.preventDefault();
+        
+        return event.returnValue = 'Your article summary has not been submitted.  Are you sure you would like to quit?';
+      }
+    }, { capture: true });
   }
 
   done( done ){


### PR DESCRIPTION
- A warning dialog is shown when exiting the editor tab with an not-yet-submitted document.
- The warning message is generic and set by the browser.  We can't set the message, as browsers have deprecated this feature.  The dialog is frequently used by scams.

<img width="372" alt="Screen Shot 2021-07-12 at 14 39 19" src="https://user-images.githubusercontent.com/989043/125340545-9436a580-e320-11eb-9899-1a26e52050db.png">


Ref. : Editor: Warning when attempting to close tab on unsubmitted network #992