### PR TITLE
Document-level context via caption

### DIFF
--- a/src/client/components/editor/caption.js
+++ b/src/client/components/editor/caption.js
@@ -1,0 +1,38 @@
+import h from 'react-hyperscript';
+import { Component } from 'react';
+import _ from 'lodash';
+import TextareaAutosize from 'react-autosize-textarea';
+import { makeClassList } from '../../dom';
+
+export class Caption extends Component {
+  constructor(props){
+    super(props);
+
+    this.state = ({ caption: props.document.caption() });
+  }
+
+  render(){
+    const { document } = this.props;
+
+    return h('div.editor-caption', [
+      document.editable() ? 
+        h(TextareaAutosize, {
+          className: makeClassList({
+            'editor-caption-textarea': true
+          }),
+          value: this.state.caption,
+          placeholder: `Figure caption (e.g. A phosphorylates B in breast cancer)`,
+          onChange: event => {
+            const val = event.target.value;
+
+            this.setState({ caption: val });
+
+            document.caption(val);
+          }
+        }) :
+        h('div.editor-caption-text', document.caption())
+    ]);
+  }
+}
+
+export default Caption;

--- a/src/client/components/editor/caption.js
+++ b/src/client/components/editor/caption.js
@@ -1,6 +1,6 @@
 import h from 'react-hyperscript';
 import { Component } from 'react';
-import _ from 'lodash';
+// import _ from 'lodash';
 import TextareaAutosize from 'react-autosize-textarea';
 import { makeClassList } from '../../dom';
 
@@ -15,13 +15,13 @@ export class Caption extends Component {
     const { document } = this.props;
 
     return h('div.editor-caption', [
-      document.editable() ? 
+      document.editable() ?
         h(TextareaAutosize, {
           className: makeClassList({
             'editor-caption-textarea': true
           }),
           value: this.state.caption,
-          placeholder: `Figure caption (e.g. A phosphorylates B in breast cancer)`,
+          placeholder: `List terms that identify the context (e.g. T cell, cancer, genome stability)`,
           onChange: event => {
             const val = event.target.value;
 

--- a/src/client/components/editor/caption.js
+++ b/src/client/components/editor/caption.js
@@ -21,7 +21,7 @@ export class Caption extends Component {
             'editor-caption-textarea': true
           }),
           value: this.state.caption,
-          placeholder: `List terms that identify the context (e.g. T cell, cancer, genome stability)`,
+          placeholder: `List terms that describe the context (e.g. T cell, cancer, genome stability)`,
           onChange: event => {
             const val = event.target.value;
 

--- a/src/client/components/editor/credits.js
+++ b/src/client/components/editor/credits.js
@@ -20,7 +20,7 @@ export class Credits extends Component {
     const authorLink = _.get(profiles.find(isContributingAuthor), ['orcid']);
 
     return h('div.editor-credits', [
-      `Created by `,
+      `Article summary created by `,
       (authorLink ? 
         h('a.plain-link', { href: authorLink, target: '_blank' }, authorName) 
         :

--- a/src/client/components/editor/index.js
+++ b/src/client/components/editor/index.js
@@ -27,7 +27,7 @@ import Help from './help';
 import InfoPanel from './info-panel';
 import ExploreShare from './explore-share';
 import * as cyDefs from './cy/defs';
-import Credits from './credits';
+import Caption from './caption';
 
 const RM_DEBOUNCE_TIME = 500;
 const RM_AVAIL_DURATION = 5000;
@@ -553,7 +553,7 @@ class Editor extends DataComponent {
       h('div.editor-graph#editor-graph'),
       h(Help, { controller, showHelp, document }),
       h(InfoPanel, { controller, bus, document, history }),
-      h(Credits, { controller, bus, document })
+      h(Caption, { controller, bus, document })
     ] : [];
 
     return h('div.editor', {

--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -6,6 +6,7 @@ import { makeClassList } from '../../dom';
 import ElementInfo from '../element-info/element-info';
 import RelatedPapers from '../related-papers';
 import _ from 'lodash';
+import Credits from './credits';
 
 export class InfoPanel extends Component {
   constructor(props){
@@ -84,6 +85,7 @@ export class InfoPanel extends Component {
           i !== authorProfiles.length - 1 ? h('span.editor-info-author-spacer', ', ') : null
         ];
       }))),
+      h(Credits, { controller, bus, document }),
       h('div.editor-info-links', [
         h( doi ? 'a.editor-info-link.plain-link': 'div.editor-info-link', doi ? { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }: {}, reference),
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed'),

--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -18,7 +18,7 @@ const DEFAULTS = Object.freeze({
   verified: false
 });
 
-const METADATA_FIELDS = ['provided', 'article', 'correspondence', 'createdDate', 'lastEditedDate', 'status', 'verified', 'authorProfiles' ];
+const METADATA_FIELDS = ['provided', 'article', 'correspondence', 'createdDate', 'lastEditedDate', 'status', 'verified', 'authorProfiles', 'caption' ];
 const READONLY_METADATA_FIELDS = _.difference( METADATA_FIELDS, ['provided', 'correspondence'] );
 const DOCUMENT_STATUS_FIELDS = Object.freeze({
   INITIATED: 'initiated',
@@ -197,6 +197,10 @@ class Document {
     } else {
       return this.syncher.get(field);
     }
+  }
+
+  caption(newVal) {
+    return this.rwMeta('caption', newVal);
   }
 
   provided(newVal){

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -342,13 +342,6 @@
 }
 
 .editor-credits {
-  position: absolute;
-  right: 0;
-  bottom: 50%;
-  margin: 0.5em;
-  z-index: 1;
-  opacity: 0.7;
-
   & .icon {
     font-size: 0.8em;
   }
@@ -356,6 +349,36 @@
 
 .editor-request-form-container {
   padding: 0.25em !important;
+}
+
+.editor-caption {
+  position: absolute;
+  z-index: 9999;
+  bottom: 4em;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.editor-read-only .editor-caption {
+  bottom: 50vh;
+  margin: 0.5em;
+  text-align: center;
+  margin-bottom: 1em;
+  pointer-events: none;
+}
+
+.editor-caption-textarea {
+  flex-grow: 1;
+  margin: 0 5em;
+  text-align: center;
+  resize: none !important;
+
+  &:not(:focus, :hover) {
+    border-color: transparent;
+  }
 }
 
 @media (min-width: 1000px) {


### PR DESCRIPTION
- Changes to existing components were kept to a minimum in order to minimise risk.
- The user provides context via free-form text entry into a figure caption text box.
- Article summary credits (contributing author) moved to be alongside the title.
- New metadata field in the model: `caption`.
- Current placeholder text: 'Figure caption (e.g. A phosphorylates B in breast cancer)'.  This example may be improved.

Ref. : Context #506

-----

Default state (empty, placeholder text, not focussed):

<img width="927" alt="Screen Shot 2021-07-21 at 13 20 54" src="https://user-images.githubusercontent.com/989043/126532112-a23c2bc7-8618-455d-bd82-5b8d4821dcf9.png">

Editing state (with typed text, focussed):

<img width="927" alt="Screen Shot 2021-07-21 at 13 24 22" src="https://user-images.githubusercontent.com/989043/126532509-4fe7f338-8486-4ceb-83d7-ff5f9ebbd7a3.png">

Article summary:

<img width="927" alt="Screen Shot 2021-07-21 at 13 29 32" src="https://user-images.githubusercontent.com/989043/126533313-93826bc0-ee73-4f12-9ebc-50ab59234869.png">


Video demo:

https://user-images.githubusercontent.com/989043/126532243-217cea05-2994-4726-bf09-19b75a4f113d.mov

