### PR TITLE
Normalize document dates

### DIFF
--- a/src/model/document/document.js
+++ b/src/model/document/document.js
@@ -40,13 +40,12 @@ const unixTimeFromDate = date => {
   }
   return Math.floor( msSinceEpoch / MILLISECONDS_PER_SECOND );
 };
-const dateFromUnixTime = unixTime  => {
-  return new Date( unixTime * MILLISECONDS_PER_SECOND );
-};
 const getDateSafe = value => {
   let date = value;
-  if( typeof( date ) == 'number' ) {
-    date = dateFromUnixTime( date );
+  if( typeof( value ) == 'number' ) {
+    date = new Date( value * MILLISECONDS_PER_SECOND );
+  } else if( typeof( value ) == 'string' ) {
+    date = new Date( value );
   }
   return date;
 };

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -580,9 +580,14 @@ const generateSitemap = () => {
       let t = tables.docDb;
       let { table, conn, rethink: r } = t;
       let q = table;
+      const toTime = field => r.branch(
+        r.typeOf( r.row( field ) ).eq( 'STRING' ), r.ISO8601( r.row( field ) ),
+        r.typeOf( r.row( field ) ).eq( 'NUMBER' ), r.epochTime( r.row( field ) ),
+        r.row( field ) // 'PTYPE<TIME>'
+      );
 
       q = q.filter( r.row( 'status' ).eq( status ) );
-      q = q.orderBy( r.desc( 'createdDate' ) );
+      q = q.orderBy( r.desc( toTime( 'createdDate' ) ) );
       q = q.pluck( ['id', 'secret'] );
       return q.run( conn );
     })
@@ -1124,9 +1129,14 @@ http.get('/', function( req, res, next ){
       let { table, conn, rethink: r } = t;
       let q = table;
       let count;
+      const toTime = field => r.branch(
+        r.typeOf( r.row( field ) ).eq( 'STRING' ), r.ISO8601( r.row( field ) ),
+        r.typeOf( r.row( field ) ).eq( 'NUMBER' ), r.epochTime( r.row( field ) ),
+        r.row( field ) // 'PTYPE<TIME>'
+      );
 
       q = q.filter(r.row('secret').ne(DEMO_SECRET));
-      q = q.orderBy(r.desc('createdDate'));
+      q = q.orderBy(r.desc( toTime( 'createdDate' ) ));
 
       if( ids ){ // doc id must be in specified id list
         let exprs = ids.map(id => r.row('id').eq(id));


### PR DESCRIPTION
- Document model
  - set dates as UNIX time (seconds since epoch) 
  - get dates as JS Date objects in getters and via .json() method
- other
  - provide `toTime` patch that always returns a rethinkdb `PTYPE<TIME>` object (backwards compatibility)

The downside here is that if you use the rethinkdb admin console, you'll get a grab bag of data types in the `lastEditedDate` field, so its harder to sort.

Refs #1000