### PR TITLE
Fallback for errors in related paper retrieval

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -2324,7 +2324,7 @@ const updateRelatedPapers = async doc => {
 const getRelPprsForDoc = async doc => {
   let relatedPapers = [];
   let referencedPapers = [];
-  const noRelatedPapers = _.isNil( doc.relatedPapers() ) || _.isEmpty( doc.relatedPapers() );
+  const noRelatedPapers = _.isEmpty( doc.relatedPapers() );
 
   try {
     logger.info(`Updating document-level related papers for doc ${doc.id()}`);
@@ -2398,6 +2398,7 @@ const getRelatedPapersForNetwork = async doc => {
     const toTemplate = el => el.toSearchTemplate();
 
     const getRelPprsForEl = async el => {
+      const hasRelatedPapers = !_.isEmpty( el.relatedPapers() );
       const template = toTemplate(el);
 
       const templates = {
@@ -2415,7 +2416,9 @@ const getRelatedPapersForNetwork = async doc => {
         }
 
       } catch ( err ) {
+        // Handle searchDocuments failures
         logger.error(`Failed searchDocuments for  ${el.id()}`);
+        if( hasRelatedPapers ) indraRes = el.relatedPapers();
       }
 
       el.relatedPapers( indraRes );

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -2397,13 +2397,17 @@ const getRelatedPapersForNetwork = async doc => {
         entities: el.isEntity() ? [ template ] : []
       };
 
-      let indraRes = await indra.searchDocuments({ templates, doc });
-      indraRes = indraRes || [];
-
-      if ( el.isInteraction() ) {
-        if ( indraRes.length == 0 ) {
-          el.setNovel( true );
+      let indraRes = [];
+      try {
+        indraRes = await indra.searchDocuments({ templates, doc });
+        if ( el.isInteraction() ) {
+          if ( indraRes.length == 0 ) {
+            el.setNovel( true );
+          }
         }
+
+      } catch ( err ) {
+        logger.error(`Failed searchDocuments for  ${el.id()}`);
       }
 
       el.relatedPapers( indraRes );

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -2336,8 +2336,20 @@ const getRelPprsForDoc = async doc => {
 
     // For .relatedPapers
     const documents = elink2UidList( elinkResponse );
-    let rankedDocs = await indra.semanticSearch({ query: pmid, documents });
-    const uids = _.take( rankedDocs, SEMANTIC_SEARCH_LIMIT ).map( getUid );
+    let uids;
+    try {
+      let rankedDocs = await indra.semanticSearch({ query: pmid, documents });
+      uids = rankedDocs.map( getUid );
+
+    } catch ( err ) {
+      logger.error(`Bypassing semantic search for document ${doc.id()}`);
+      uids = documents;
+
+    } finally {
+      uids = _.take( uids, SEMANTIC_SEARCH_LIMIT );
+
+    }
+
     const relatedPapersResponse = await fetchPubmed({ uids });
     relatedPapers = _.get( relatedPapersResponse, 'PubmedArticleSet', [] )
       .map( getPubmedCitation )


### PR DESCRIPTION
This update stems from observations that Explorer views are showing no related papers, making it appear 'broken'. 

It appears that calls to INDRA or semantic search are failing, in a manner that is intermittent. The problem is that there are no fall backs, that is, either everything works or the whole thing fails.

Here, I simply use the document level papers retrieved from PubMed (which is typically robust) to back fill the related papers in the case that any problems occur.

Refs:
https://github.com/PathwayCommons/factoid/pull/988#issuecomment-988064837
#937
https://github.com/PathwayCommons/semantic-search/issues/98 