### PR TITLE
Read the mod rather than creation time for bulk data file download 

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -628,7 +628,7 @@ http.get('/zip', function( req, res, next ){
       const DAY_TO_MS = 86400000;
 
       let now = Date.now();
-      let fileDate = fs.statSync(filePath).birthtimeMs;
+      let fileDate = fs.statSync(filePath).mtimeMs;
 
       if ( now - fileDate < DAY_TO_MS ) {
         recreate = false;


### PR DESCRIPTION
Check the factoid data dump file modification time (millisec) rather than creation time when deciding whether to recreate.

Refs #1032 
