### PR TITLE
Create and use a Document index

### DIFF
--- a/src/server/db.js
+++ b/src/server/db.js
@@ -86,7 +86,26 @@ let db = {
         table: table
       };
     } );
+  },
+
+  guaranteeIndex: function( tableName, secondaryKey ){
+    let t, c, r;
+    return this.accessTable( tableName )
+      .then( ({ table, conn, rethink }) => {
+        t = table;
+        c = conn;
+        r = rethink;
+      })
+      .then( () => {
+        return r.branch(
+           t.indexList().contains( secondaryKey ).not(),
+           t.indexCreate( secondaryKey ),
+           null
+        ).run( c );
+      })
+      .then( () => t.indexWait( secondaryKey ).run( c ) );
   }
+
 };
 
 export default db;

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -144,6 +144,8 @@ tryPromise( () => {
       .then( log('Accessed table "%s"', name) )
       .then( t => synch( t, name ) )
       .then( log('Set up synching for "%s"', name) )
+      .then( () => db.guaranteeIndex( 'document', 'createdDate' ) )
+      .then( log('Set up index for document') )
     ;
   };
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -580,14 +580,9 @@ const generateSitemap = () => {
       let t = tables.docDb;
       let { table, conn, rethink: r } = t;
       let q = table;
-      const toTime = field => r.branch(
-        r.typeOf( r.row( field ) ).eq( 'STRING' ), r.ISO8601( r.row( field ) ),
-        r.typeOf( r.row( field ) ).eq( 'NUMBER' ), r.epochTime( r.row( field ) ),
-        r.row( field ) // 'PTYPE<TIME>'
-      );
 
+      q = q.orderBy({ index: r.desc( 'createdDate' ) });
       q = q.filter( r.row( 'status' ).eq( status ) );
-      q = q.orderBy( r.desc( toTime( 'createdDate' ) ) );
       q = q.pluck( ['id', 'secret'] );
       return q.run( conn );
     })
@@ -1243,14 +1238,9 @@ http.get('/', function( req, res, next ){
       let { table, conn, rethink: r } = t;
       let q = table;
       let count;
-      const toTime = field => r.branch(
-        r.typeOf( r.row( field ) ).eq( 'STRING' ), r.ISO8601( r.row( field ) ),
-        r.typeOf( r.row( field ) ).eq( 'NUMBER' ), r.epochTime( r.row( field ) ),
-        r.row( field ) // 'PTYPE<TIME>'
-      );
 
+      q = q.orderBy({ index: r.desc('createdDate') });
       q = q.filter(r.row('secret').ne(DEMO_SECRET));
-      q = q.orderBy(r.desc( toTime( 'createdDate' ) ));
 
       if( ids ){ // doc id must be in specified id list
         let exprs = ids.map(id => r.row('id').eq(id));

--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -39,6 +39,8 @@ const docsToUpdate = async () => {
     r.row( field ) // 'PTYPE<TIME>'
   );
 
+  q = q.orderBy({ index: r.desc( 'createdDate' ) });
+
   // Filter: Exclude DEMO
   q = q.filter( r.row( 'secret' ).ne( DEMO_SECRET ) );
 
@@ -58,7 +60,6 @@ const docsToUpdate = async () => {
     );
   }
 
-  q = q.orderBy( r.desc( toTime('createdDate') ) );
   q = q.pluck([ 'id', 'secret' ]);
 
   const cursor =  await q.run( conn );


### PR DESCRIPTION
Enable an arbitrary index to be created. Create a Document `createdDate` index on server boot - Use the index for sorting on our web services and cron jobs.

Refs #1031