### PR TITLE
CRON: Document update tasks

### DIFF
--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -55,7 +55,7 @@ const docsToUpdate = async () => {
   if( !DOCUMENT_CRON_REFRESH_ENABLED ){
     q = q.filter(
       r.not(
-        r.row( 'article' )( 'PubmedData' )( 'ArticleIdList' ).contains( ArticleId => ArticleId('IdType').eq('pmid') )
+        r.row( 'article' )( 'PubmedData' )( 'ArticleIdList' ).contains( ArticleId => ArticleId('IdType').eq('pubmed') )
       )
     );
   }


### PR DESCRIPTION
Two changes to the cron job for document updates.

1. Skip updates to `relatedPapers`: Drop this rather heavy, long-running task (see https://github.com/PathwayCommons/factoid/issues/1024#issuecomment-1058277251). It's not completely clear that updates to these make any tangible difference (e.g. the most recent papers of interest).  

2. Filtering docs to update: Strips out those documents without any `paperId`, that is, documents that were auto-created to notify referenced authors that their paper was cited by a Biofactoid document (viral email). 

In this way, documents will get fresh data for the submitted article, and those submitting a paper not in PubMed at the time will be checked as well. 

Some empirical analysis to follow up on (https://github.com/PathwayCommons/factoid/issues/1024#issuecomment-1058277251):

|Condition       |Size (MB)|Size (bytes)|Delta| Elapsed Time |
|----------------|---------|------------|-----|---------|
|Base            |104.76   |104759158   |     |     |
|CRON job (unstable)|246.22   |246224854   |135%|  ~24 hours |
|CRON job (this branch)|105.27   |105268838   |0.4%| ~1 minute |

Refs #1024 
