### PR TITLE
Ungrounded node bug

### DIFF
--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -600,9 +600,9 @@ class EntityInfo extends DataComponent {
       if( assoc == null ){
         const type = s.element.type();
         const name = s.name;
-        const entityNames = s.element.participants().map(ppt => ppt.name());
 
         if( isComplex(s.element.type()) ){
+          const entityNames = s.element.participants().map(ppt => ppt.name());
           children.push( h('div.entity-info-assoc', targetFromAssoc({ type, name, entityNames }, true )) );
           children.push( h('div.entity-info-related-papers', [
             h(RelatedPapers, { document, source: s.element })


### PR DESCRIPTION
For Explorer, extract the `entityNames` where its used (i.e. for complex).

Refs #1049
<img width="443" alt="Screen Shot 2022-03-23 at 4 49 39 PM" src="https://user-images.githubusercontent.com/4706307/159793208-8204eb57-8b77-45f5-b45a-14c5a584d838.png">

