### PR TITLE
Id mapping declares the new db prefix.

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -208,12 +208,13 @@ const mapToUniprotIds = docTemplate => {
       return Promise.resolve();
     }
 
+    const UNIPROT_DB_PREFIX = 'uniprot';
     const opts = {
       id: [
         id
       ],
       dbfrom: dbPrefix,
-      dbto: 'uniprot'
+      dbto: UNIPROT_DB_PREFIX
     };
 
     return fetch( GROUNDING_SEARCH_BASE_URL + '/map', {
@@ -229,6 +230,7 @@ const mapToUniprotIds = docTemplate => {
       if ( dbXref ) {
         xref.id = dbXref.id;
         xref.db = dbXref.db;
+        xref.dbPrefix = opts.dbto;
       }
     } );
   };


### PR DESCRIPTION
Conversion of a pathway to BioPAX / template accepts an `idMapping`, which, in practice, maps the entity xref from `ncbigene` to `uniprot`. This PR updates the new `dbPrefix` for the mapping.

Refs #1073