### PR TITLE
Reply to Tweet with paper link

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -53,7 +53,8 @@ import { BASE_URL,
   BULK_DOWNLOADS_PATH,
   BIOPAX_DOWNLOADS_PATH,
   BIOPAX_IDMAP_DOWNLOADS_PATH,
-  ORCID_PUBLIC_API_BASE_URL
+  ORCID_PUBLIC_API_BASE_URL,
+  DOI_LINK_BASE_URL
  } from '../../../../config';
 
 import { ENTITY_TYPE } from '../../../../model/element/entity-type';
@@ -1460,6 +1461,19 @@ const tweetDoc = ( doc, text ) => {
       .then( tweet =>  doc.setTweetMetadata( tweet ) );
 };
 
+// reply to document tweet with article link
+const tweetArticleReply = async doc => {
+  const { doi } = doc.citation();
+  if( !doi || !doc.hasTweet() ) return;
+
+  const { id_str: in_reply_to_status_id } = doc.tweetMetadata();
+  const url = `${DOI_LINK_BASE_URL}${doi}`;
+  const status = `Read the paper: ${url}`;
+
+  await twitterClient.post( 'statuses/update', { status, in_reply_to_status_id } );
+  return doc;
+};
+
 const tryTweetingDoc = async ( doc, text ) => {
 
   const shouldTweet = doc => {
@@ -1473,6 +1487,7 @@ const tryTweetingDoc = async ( doc, text ) => {
     try {
       if( !text ) text = truncateString( doc.toText(), MAX_TWEET_LENGTH );
       await tweetDoc( doc, text );
+      await tweetArticleReply( doc );
     } catch ( e ) {
       logger.error( `Error attempting to Tweet: ${JSON.stringify(e)}` ); //swallow
     }


### PR DESCRIPTION
On successful Tweet, reply to that status with a link to the paper. This is cleaner than jamming it all in one tweet.

Sample result below:

<img width="500" alt="Screen Shot 2022-09-01 at 3 04 48 PM" src="https://user-images.githubusercontent.com/4706307/187993519-1fe215cf-a4ea-4051-bbe4-0b0f3e4e5159.png">



Refs #1041 