### PR TITLE
Iss1146: Neo4j Handling Complexes

### DIFF
--- a/neo4j-test/add-nodes-edges.js
+++ b/neo4j-test/add-nodes-edges.js
@@ -33,8 +33,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'ncbigene:5597',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -45,8 +45,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(edge.properties.type).to.equal('phosphorylation');
     expect(edge.properties.sourceId).to.equal('ncbigene:5597');
     expect(edge.properties.targetId).to.equal('ncbigene:207');
-    expect(edge.properties.sourceComplex).to.equal('n/a');
-    expect(edge.properties.targetComplex).to.equal('n/a');
+    expect(edge.properties.sourceComplex).to.equal('');
+    expect(edge.properties.targetComplex).to.equal('');
     expect(edge.properties.component).to.deep.equal([]);
     expect(edge.properties.xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(edge.properties.doi).to.equal('10.1126/sciadv.abi6439');
@@ -72,8 +72,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'ncbigene:5597',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -84,8 +84,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'ncbigene:5597',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -95,8 +95,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'nc7',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '3444',
@@ -107,8 +107,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(edge.properties.type).to.equal('phosphorylation');
     expect(edge.properties.sourceId).to.equal('ncbigene:5597');
     expect(edge.properties.targetId).to.equal('ncbigene:207');
-    expect(edge.properties.sourceComplex).to.equal('n/a');
-    expect(edge.properties.targetComplex).to.equal('n/a');
+    expect(edge.properties.sourceComplex).to.equal('');
+    expect(edge.properties.targetComplex).to.equal('');
     expect(edge.properties.component).to.deep.equal([]);
     expect(edge.properties.xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(edge.properties.doi).to.equal('10.1126/sciadv.abi6439');
@@ -124,8 +124,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'ncbigene:5597',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -137,8 +137,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(mapk6Relationships[0].type).to.equal('phosphorylation');
     expect(mapk6Relationships[0].sourceId).to.equal('ncbigene:5597');
     expect(mapk6Relationships[0].targetId).to.equal('ncbigene:207');
-    expect(mapk6Relationships[0].sourceComplex).to.equal('n/a');
-    expect(mapk6Relationships[0].targetComplex).to.equal('n/a');
+    expect(mapk6Relationships[0].sourceComplex).to.equal('');
+    expect(mapk6Relationships[0].targetComplex).to.equal('');
     expect(mapk6Relationships[0].component).to.deep.equal([]);
     expect(mapk6Relationships[0].xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(mapk6Relationships[0].doi).to.equal('10.1126/sciadv.abi6439');
@@ -160,8 +160,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'ncbigene:5597',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -173,8 +173,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(aktRelationships[0].type).to.equal('phosphorylation');
     expect(aktRelationships[0].sourceId).to.equal('ncbigene:5597');
     expect(aktRelationships[0].targetId).to.equal('ncbigene:207');
-    expect(aktRelationships[0].sourceComplex).to.equal('n/a');
-    expect(aktRelationships[0].targetComplex).to.equal('n/a');
+    expect(aktRelationships[0].sourceComplex).to.equal('');
+    expect(aktRelationships[0].targetComplex).to.equal('');
     expect(aktRelationships[0].component).to.deep.equal([]);
     expect(aktRelationships[0].xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(aktRelationships[0].doi).to.equal('10.1126/sciadv.abi6439');
@@ -202,8 +202,8 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       [],
       'ncbigene:5597',
       'ncbigene:207',
-      'N/A',
-      'N/A',
+      '',
+      '',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',

--- a/neo4j-test/add-nodes-edges.js
+++ b/neo4j-test/add-nodes-edges.js
@@ -32,6 +32,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'phosphorylation',
       'ncbigene:5597',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -42,6 +43,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(edge.properties.type).equal('phosphorylation');
     expect(edge.properties.sourceId).equal('ncbigene:5597');
     expect(edge.properties.targetId).equal('ncbigene:207');
+    expect(edge.properties.participantTypes).equal('noncomplex-to-noncomplex');
     expect(edge.properties.xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(edge.properties.doi).equal('10.1126/sciadv.abi6439');
     expect(edge.properties.pmid).equal('34767444');
@@ -65,6 +67,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'phosphorylation',
       'ncbigene:5597',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -74,6 +77,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'phosphorylation',
       'ncbigene:5597',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -82,6 +86,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'This is a dummy type',
       'nc7',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '3444',
@@ -92,6 +97,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(edge.properties.type).equal('phosphorylation');
     expect(edge.properties.sourceId).equal('ncbigene:5597');
     expect(edge.properties.targetId).equal('ncbigene:207');
+    expect(edge.properties.participantTypes).equal('noncomplex-to-noncomplex');
     expect(edge.properties.xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(edge.properties.doi).equal('10.1126/sciadv.abi6439');
     expect(edge.properties.pmid).equal('34767444');
@@ -105,6 +111,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'phosphorylation',
       'ncbigene:5597',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -113,10 +120,10 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     let mapk6Relationships = await getInteractions('ncbigene:5597');
 
     expect(mapk6Relationships.length).equal(1);
-    //expect(mapk6Relationships[0].type).equal('INTERACTION');
     expect(mapk6Relationships[0].type).equal('phosphorylation');
     expect(mapk6Relationships[0].sourceId).equal('ncbigene:5597');
     expect(mapk6Relationships[0].targetId).equal('ncbigene:207');
+    expect(mapk6Relationships[0].participantTypes).equal('noncomplex-to-noncomplex');
     expect(mapk6Relationships[0].xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(mapk6Relationships[0].doi).equal('10.1126/sciadv.abi6439');
     expect(mapk6Relationships[0].pmid).equal('34767444');
@@ -125,7 +132,6 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     let mapk6NeighbouringNodes = await getNeighbouringNodes('ncbigene:5597');
 
     expect(mapk6NeighbouringNodes.length).equal(1);
-    //expect(mapk6NeighbouringNodes[0].labels[0]).equal('Gene');
     expect(mapk6NeighbouringNodes[0].id).equal('ncbigene:207');
     expect(mapk6NeighbouringNodes[0].name).equal('AKT');
   });
@@ -137,6 +143,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'phosphorylation',
       'ncbigene:5597',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -145,10 +152,10 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     let aktRelationships = await getInteractions('ncbigene:207');
 
     expect(aktRelationships.length).equal(1);
-    //expect(aktRelationships[0].type).equal('INTERACTION');
     expect(aktRelationships[0].type).equal('phosphorylation');
     expect(aktRelationships[0].sourceId).equal('ncbigene:5597');
     expect(aktRelationships[0].targetId).equal('ncbigene:207');
+    expect(aktRelationships[0].participantTypes).equal('noncomplex-to-noncomplex');
     expect(aktRelationships[0].xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
     expect(aktRelationships[0].doi).equal('10.1126/sciadv.abi6439');
     expect(aktRelationships[0].pmid).equal('34767444');
@@ -157,7 +164,6 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     let aktNeighbouringNodes = await getNeighbouringNodes('ncbigene:207');
 
     expect(aktNeighbouringNodes.length).equal(1);
-    //expect(aktNeighbouringNodes[0].labels[0]).equal('Gene');
     expect(aktNeighbouringNodes[0].id).equal('ncbigene:5597');
     expect(aktNeighbouringNodes[0].name).equal('MAPK6');
   });
@@ -175,6 +181,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       'phosphorylation',
       'ncbigene:5597',
       'ncbigene:207',
+      'noncomplex-to-noncomplex',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',

--- a/neo4j-test/add-nodes-edges.js
+++ b/neo4j-test/add-nodes-edges.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
-import { addEdge, addNode, getInteractions, getNeighbouringNodes, searchByMoleculeId } from '../src/neo4j/neo4j-functions';
+import { addEdge, addNode, getInteractions, getNeighbouringNodes, neighbourhood } from '../src/neo4j/neo4j-functions';
 import { deleteAllNodesAndEdges, getGeneName, getNumNodes, getNumEdges, getEdge } from '../src/neo4j/test-functions.js';
 
 describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
@@ -189,7 +189,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
   });
 
   it('Search for a molecule in an empty database yields null', async function () {
-    expect(await searchByMoleculeId('ncbigene:207')).to.be.null;
+    expect(await neighbourhood('ncbigene:207')).to.be.null;
     expect(await getInteractions('ncbigene:207')).to.be.null;
     expect(await getNeighbouringNodes('ncbigene:207')).to.be.null;
   });
@@ -209,7 +209,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
       '34767444',
       'MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
 
-    expect(await searchByMoleculeId('ncbigene:217')).to.be.null;
+    expect(await neighbourhood('ncbigene:217')).to.be.null;
     expect(await getInteractions('ncbigene:217')).to.be.null;
     expect(await getNeighbouringNodes('ncbigene:217')).to.be.null;
   });

--- a/neo4j-test/add-nodes-edges.js
+++ b/neo4j-test/add-nodes-edges.js
@@ -18,10 +18,10 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
   });
 
   it('Make one node', async function () {
-    expect(await getNumNodes()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
     await addNode('ncbigene:5597', 'MAPK6');
-    expect(await getGeneName('ncbigene:5597')).equal('MAPK6');
-    expect(await getNumNodes()).equal(1);
+    expect(await getGeneName('ncbigene:5597')).to.equal('MAPK6');
+    expect(await getNumNodes()).to.equal(1);
   });
 
   it('Make an edge between the two nodes', async function () {
@@ -30,34 +30,38 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'phosphorylation',
+      [],
       'ncbigene:5597',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
       'MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
-    expect(await getNumEdges()).equal(1);
+    expect(await getNumEdges()).to.equal(1);
     let edge = await getEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b');
-    expect(edge.type).equal('INTERACTION');
-    expect(edge.properties.type).equal('phosphorylation');
-    expect(edge.properties.sourceId).equal('ncbigene:5597');
-    expect(edge.properties.targetId).equal('ncbigene:207');
-    expect(edge.properties.participantTypes).equal('noncomplex-to-noncomplex');
-    expect(edge.properties.xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
-    expect(edge.properties.doi).equal('10.1126/sciadv.abi6439');
-    expect(edge.properties.pmid).equal('34767444');
-    expect(edge.properties.articleTitle).equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
+    expect(edge.type).to.equal('INTERACTION');
+    expect(edge.properties.type).to.equal('phosphorylation');
+    expect(edge.properties.sourceId).to.equal('ncbigene:5597');
+    expect(edge.properties.targetId).to.equal('ncbigene:207');
+    expect(edge.properties.sourceComplex).to.equal('n/a');
+    expect(edge.properties.targetComplex).to.equal('n/a');
+    expect(edge.properties.component).to.deep.equal([]);
+    expect(edge.properties.xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
+    expect(edge.properties.doi).to.equal('10.1126/sciadv.abi6439');
+    expect(edge.properties.pmid).to.equal('34767444');
+    expect(edge.properties.articleTitle).to.equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
   });
 
   it('Making a duplicate node fails', async function () {
     await addNode('ncbigene:207', 'AKT');
     await addNode('ncbigene:5597', 'MAPK6');
-    expect(await getNumNodes()).equal(2);
+    expect(await getNumNodes()).to.equal(2);
     await addNode('ncbigene:5597', 'MAPK6');
     await addNode('ncbigene:5597', 'This is a dummy name');
-    expect(await getNumNodes()).equal(2);
-    expect(await getGeneName('ncbigene:5597')).equal('MAPK6');
+    expect(await getNumNodes()).to.equal(2);
+    expect(await getGeneName('ncbigene:5597')).to.equal('MAPK6');
   });
 
   it('Making a duplicate edge fails', async function () {
@@ -65,9 +69,11 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'phosphorylation',
+      [],
       'ncbigene:5597',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -75,33 +81,39 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(await getNumEdges()).equal(1);
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'phosphorylation',
+      [],
       'ncbigene:5597',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
       'MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'This is a dummy type',
+      [],
       'nc7',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '3444',
       'MAPK6-AKT signaling ');
     expect(await getNumEdges()).equal(1);
     let edge = await getEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b');
-    expect(edge.type).equal('INTERACTION');
-    expect(edge.properties.type).equal('phosphorylation');
-    expect(edge.properties.sourceId).equal('ncbigene:5597');
-    expect(edge.properties.targetId).equal('ncbigene:207');
-    expect(edge.properties.participantTypes).equal('noncomplex-to-noncomplex');
-    expect(edge.properties.xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
-    expect(edge.properties.doi).equal('10.1126/sciadv.abi6439');
-    expect(edge.properties.pmid).equal('34767444');
-    expect(edge.properties.articleTitle).equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
+    expect(edge.type).to.equal('INTERACTION');
+    expect(edge.properties.type).to.equal('phosphorylation');
+    expect(edge.properties.sourceId).to.equal('ncbigene:5597');
+    expect(edge.properties.targetId).to.equal('ncbigene:207');
+    expect(edge.properties.sourceComplex).to.equal('n/a');
+    expect(edge.properties.targetComplex).to.equal('n/a');
+    expect(edge.properties.component).to.deep.equal([]);
+    expect(edge.properties.xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
+    expect(edge.properties.doi).to.equal('10.1126/sciadv.abi6439');
+    expect(edge.properties.pmid).to.equal('34767444');
+    expect(edge.properties.articleTitle).to.equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
   });
 
   it('Ensure searchGeneById works as expected for MAPK6', async function () {
@@ -109,9 +121,11 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'phosphorylation',
+      [],
       'ncbigene:5597',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -119,21 +133,23 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
 
     let mapk6Relationships = await getInteractions('ncbigene:5597');
 
-    expect(mapk6Relationships.length).equal(1);
-    expect(mapk6Relationships[0].type).equal('phosphorylation');
-    expect(mapk6Relationships[0].sourceId).equal('ncbigene:5597');
-    expect(mapk6Relationships[0].targetId).equal('ncbigene:207');
-    expect(mapk6Relationships[0].participantTypes).equal('noncomplex-to-noncomplex');
-    expect(mapk6Relationships[0].xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
-    expect(mapk6Relationships[0].doi).equal('10.1126/sciadv.abi6439');
-    expect(mapk6Relationships[0].pmid).equal('34767444');
-    expect(mapk6Relationships[0].articleTitle).equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
+    expect(mapk6Relationships.length).to.equal(1);
+    expect(mapk6Relationships[0].type).to.equal('phosphorylation');
+    expect(mapk6Relationships[0].sourceId).to.equal('ncbigene:5597');
+    expect(mapk6Relationships[0].targetId).to.equal('ncbigene:207');
+    expect(mapk6Relationships[0].sourceComplex).to.equal('n/a');
+    expect(mapk6Relationships[0].targetComplex).to.equal('n/a');
+    expect(mapk6Relationships[0].component).to.deep.equal([]);
+    expect(mapk6Relationships[0].xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
+    expect(mapk6Relationships[0].doi).to.equal('10.1126/sciadv.abi6439');
+    expect(mapk6Relationships[0].pmid).to.equal('34767444');
+    expect(mapk6Relationships[0].articleTitle).to.equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
 
     let mapk6NeighbouringNodes = await getNeighbouringNodes('ncbigene:5597');
 
-    expect(mapk6NeighbouringNodes.length).equal(1);
-    expect(mapk6NeighbouringNodes[0].id).equal('ncbigene:207');
-    expect(mapk6NeighbouringNodes[0].name).equal('AKT');
+    expect(mapk6NeighbouringNodes.length).to.equal(1);
+    expect(mapk6NeighbouringNodes[0].id).to.equal('ncbigene:207');
+    expect(mapk6NeighbouringNodes[0].name).to.equal('AKT');
   });
 
   it('Ensure searchGeneById works as expected for AKT', async function () {
@@ -141,9 +157,11 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'phosphorylation',
+      [],
       'ncbigene:5597',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',
@@ -151,21 +169,23 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
 
     let aktRelationships = await getInteractions('ncbigene:207');
 
-    expect(aktRelationships.length).equal(1);
-    expect(aktRelationships[0].type).equal('phosphorylation');
-    expect(aktRelationships[0].sourceId).equal('ncbigene:5597');
-    expect(aktRelationships[0].targetId).equal('ncbigene:207');
-    expect(aktRelationships[0].participantTypes).equal('noncomplex-to-noncomplex');
-    expect(aktRelationships[0].xref).equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
-    expect(aktRelationships[0].doi).equal('10.1126/sciadv.abi6439');
-    expect(aktRelationships[0].pmid).equal('34767444');
-    expect(aktRelationships[0].articleTitle).equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
+    expect(aktRelationships.length).to.equal(1);
+    expect(aktRelationships[0].type).to.equal('phosphorylation');
+    expect(aktRelationships[0].sourceId).to.equal('ncbigene:5597');
+    expect(aktRelationships[0].targetId).to.equal('ncbigene:207');
+    expect(aktRelationships[0].sourceComplex).to.equal('n/a');
+    expect(aktRelationships[0].targetComplex).to.equal('n/a');
+    expect(aktRelationships[0].component).to.deep.equal([]);
+    expect(aktRelationships[0].xref).to.equal('a896d611-affe-4b45-a5e1-9bc560ffceab');
+    expect(aktRelationships[0].doi).to.equal('10.1126/sciadv.abi6439');
+    expect(aktRelationships[0].pmid).to.equal('34767444');
+    expect(aktRelationships[0].articleTitle).to.equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
 
     let aktNeighbouringNodes = await getNeighbouringNodes('ncbigene:207');
 
-    expect(aktNeighbouringNodes.length).equal(1);
-    expect(aktNeighbouringNodes[0].id).equal('ncbigene:5597');
-    expect(aktNeighbouringNodes[0].name).equal('MAPK6');
+    expect(aktNeighbouringNodes.length).to.equal(1);
+    expect(aktNeighbouringNodes[0].id).to.equal('ncbigene:5597');
+    expect(aktNeighbouringNodes[0].name).to.equal('MAPK6');
   });
 
   it('Search for a molecule in an empty database yields null', async function () {
@@ -179,9 +199,11 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
       'phosphorylation',
+      [],
       'ncbigene:5597',
       'ncbigene:207',
-      'noncomplex-to-noncomplex',
+      'N/A',
+      'N/A',
       'a896d611-affe-4b45-a5e1-9bc560ffceab',
       '10.1126/sciadv.abi6439',
       '34767444',

--- a/neo4j-test/doc-tests.js
+++ b/neo4j-test/doc-tests.js
@@ -87,8 +87,8 @@ describe('03. Tests for Documents', function () {
       }
       expect(edge.type).to.equal('INTERACTION');
       expect(edge.properties.component).to.deep.equal([]);
-      expect(edge.properties.sourceComplex).to.equal('n/a');
-      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.sourceComplex).to.equal('');
+      expect(edge.properties.targetComplex).to.equal('');
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.doi).to.equal(myDoc.citation().doi);
@@ -134,8 +134,8 @@ describe('03. Tests for Documents', function () {
       }
       expect(edge.type).to.equal('INTERACTION');
       expect(edge.properties.component).to.deep.equal([]);
-      expect(edge.properties.sourceComplex).to.equal('n/a');
-      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.sourceComplex).to.equal('');
+      expect(edge.properties.targetComplex).to.equal('');
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.doi).to.equal(myDoc.citation().doi);
       expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
@@ -180,8 +180,8 @@ describe('03. Tests for Documents', function () {
       }
       expect(edge.type).to.equal('INTERACTION');
       expect(edge.properties.component).to.deep.equal([]);
-      expect(edge.properties.sourceComplex).to.equal('n/a');
-      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.sourceComplex).to.equal('');
+      expect(edge.properties.targetComplex).to.equal('');
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.doi).to.equal(myDoc.citation().doi);
       expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
@@ -226,8 +226,8 @@ describe('03. Tests for Documents', function () {
       }
       expect(edge.type).to.equal('INTERACTION');
       expect(edge.properties.component).to.deep.equal([]);
-      expect(edge.properties.sourceComplex).to.equal('n/a');
-      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.sourceComplex).to.equal('');
+      expect(edge.properties.targetComplex).to.equal('');
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.doi).to.equal(myDoc.citation().doi);
       expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
@@ -272,8 +272,8 @@ describe('03. Tests for Documents', function () {
       }
       expect(edge.type).to.equal('INTERACTION');
       expect(edge.properties.component).to.deep.equal([]);
-      expect(edge.properties.sourceComplex).to.equal('n/a');
-      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.sourceComplex).to.equal('');
+      expect(edge.properties.targetComplex).to.equal('');
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.doi).to.equal(myDoc.citation().doi);
       expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
@@ -318,8 +318,8 @@ describe('03. Tests for Documents', function () {
       }
       expect(edge.type).to.equal('INTERACTION');
       expect(edge.properties.component).to.deep.equal([]);
-      expect(edge.properties.sourceComplex).to.equal('n/a');
-      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.sourceComplex).to.equal('');
+      expect(edge.properties.targetComplex).to.equal('');
       expect(edge.properties.xref).to.equal(myDoc.id());
       expect(edge.properties.doi).to.equal(myDoc.citation().doi);
       expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);

--- a/neo4j-test/doc-tests.js
+++ b/neo4j-test/doc-tests.js
@@ -20,7 +20,7 @@ let testDb;
 const dbName = 'factoid-neo4j-test';
 const dbTables = ['document', 'element']; // Match fixture (JSON) keys
 
-describe('Tests for Documents', function () {
+describe('03. Tests for Documents', function () {
 
   before('Create a Neo4j driver instance and connect to server. Connect to RDB', async function () {
     await initDriver();
@@ -61,35 +61,39 @@ describe('Tests for Documents', function () {
 
     let myDoc = fixtureDocs[0];
 
-    expect(await getNumNodes()).equal(0);
-    expect(await getNumEdges()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
+    expect(await getNumEdges()).to.equal(0);
     await addDocumentToNeo4j(myDoc);
 
     let arrNodes = myDoc.elements().filter(ele => ele.isEntity());
     let arrEdges = myDoc.elements().filter(ele => !(ele.isEntity()));
 
-    expect(await getNumNodes()).equal(2);
+    expect(await getNumNodes()).to.equal(2);
     for (const n of arrNodes) {
       let id = `${n.association().dbPrefix}:${n.association().id}`;
-      expect(await getGeneName(id)).equal(`${n.association().name}`);
+      expect(await getGeneName(id)).to.equal(`${n.association().name}`);
     }
 
-    expect(await getNumEdges()).equal(1);
+    expect(await getNumEdges()).to.equal(1);
     for (const e of arrEdges) {
       let edge = await getEdge(e.id());
-      expect(edge.properties.type).equal(e.type());
+      expect(edge.properties.type).to.equal(e.type());
       if (e.association().getSource()) {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
       } else {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
       }
-      expect(edge.type).equal('INTERACTION');
-      expect(edge.properties.xref).equal(myDoc.id());
-      expect(edge.properties.doi).equal(myDoc.citation().doi);
-      expect(edge.properties.pmid).equal(myDoc.citation().pmid);
-      expect(edge.properties.articleTitle).equal(myDoc.citation().title);
+      expect(edge.type).to.equal('INTERACTION');
+      expect(edge.properties.component).to.deep.equal([]);
+      expect(edge.properties.sourceComplex).to.equal('n/a');
+      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.doi).to.equal(myDoc.citation().doi);
+      expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
+      expect(edge.properties.articleTitle).to.equal(myDoc.citation().title);
     }
   });
 
@@ -104,35 +108,38 @@ describe('Tests for Documents', function () {
 
     let myDoc = fixtureDocs[0];
 
-    expect(await getNumNodes()).equal(0);
-    expect(await getNumEdges()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
+    expect(await getNumEdges()).to.equal(0);
     await addDocumentToNeo4j(myDoc);
 
     let arrNodes = myDoc.elements().filter(ele => ele.isEntity());
     let arrEdges = myDoc.elements().filter(ele => !(ele.isEntity()));
 
-    expect(await getNumNodes()).equal(2);
+    expect(await getNumNodes()).to.equal(2);
     for (const n of arrNodes) {
       let id = `${n.association().dbPrefix}:${n.association().id}`;
-      expect(await getGeneName(id)).equal(`${n.association().name}`);
+      expect(await getGeneName(id)).to.equal(`${n.association().name}`);
     }
 
-    expect(await getNumEdges()).equal(1);
+    expect(await getNumEdges()).to.equal(1);
     for (const e of arrEdges) {
       let edge = await getEdge(e.id());
-      expect(edge.properties.type).equal(e.type());
+      expect(edge.properties.type).to.equal(e.type());
       if (e.association().getSource()) {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
       } else {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
       }
-      expect(edge.type).equal('INTERACTION');
-      expect(edge.properties.xref).equal(myDoc.id());
-      expect(edge.properties.doi).equal(myDoc.citation().doi);
-      expect(edge.properties.pmid).equal(myDoc.citation().pmid);
-      expect(edge.properties.articleTitle).equal(myDoc.citation().title);
+      expect(edge.type).to.equal('INTERACTION');
+      expect(edge.properties.component).to.deep.equal([]);
+      expect(edge.properties.sourceComplex).to.equal('n/a');
+      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.doi).to.equal(myDoc.citation().doi);
+      expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
+      expect(edge.properties.articleTitle).to.equal(myDoc.citation().title);
     }
   });
 
@@ -147,35 +154,38 @@ describe('Tests for Documents', function () {
 
     let myDoc = fixtureDocs[0];
 
-    expect(await getNumNodes()).equal(0);
-    expect(await getNumEdges()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
+    expect(await getNumEdges()).to.equal(0);
     await addDocumentToNeo4j(myDoc);
 
     let arrNodes = myDoc.elements().filter(ele => ele.isEntity());
     let arrEdges = myDoc.elements().filter(ele => !(ele.isEntity()));
 
-    expect(await getNumNodes()).equal(3);
+    expect(await getNumNodes()).to.equal(3);
     for (const n of arrNodes) {
       let id = `${n.association().dbPrefix}:${n.association().id}`;
-      expect(await getGeneName(id)).equal(`${n.association().name}`);
+      expect(await getGeneName(id)).to.equal(`${n.association().name}`);
     }
 
-    expect(await getNumEdges()).equal(2);
+    expect(await getNumEdges()).to.equal(2);
     for (const e of arrEdges) {
       let edge = await getEdge(e.id());
-      expect(edge.properties.type).equal(e.type());
+      expect(edge.properties.type).to.equal(e.type());
       if (e.association().getSource()) {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
       } else {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
       }
-      expect(edge.type).equal('INTERACTION');
-      expect(edge.properties.xref).equal(myDoc.id());
-      expect(edge.properties.doi).equal(myDoc.citation().doi);
-      expect(edge.properties.pmid).equal(myDoc.citation().pmid);
-      expect(edge.properties.articleTitle).equal(myDoc.citation().title);
+      expect(edge.type).to.equal('INTERACTION');
+      expect(edge.properties.component).to.deep.equal([]);
+      expect(edge.properties.sourceComplex).to.equal('n/a');
+      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.doi).to.equal(myDoc.citation().doi);
+      expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
+      expect(edge.properties.articleTitle).to.equal(myDoc.citation().title);
     }
   });
 
@@ -190,35 +200,38 @@ describe('Tests for Documents', function () {
 
     let myDoc = fixtureDocs[0];
 
-    expect(await getNumNodes()).equal(0);
-    expect(await getNumEdges()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
+    expect(await getNumEdges()).to.equal(0);
     await addDocumentToNeo4j(myDoc);
 
     let arrNodes = myDoc.elements().filter(ele => ele.isEntity());
     let arrEdges = myDoc.elements().filter(ele => !(ele.isEntity()));
 
-    expect(await getNumNodes()).equal(2);
+    expect(await getNumNodes()).to.equal(2);
     for (const n of arrNodes) {
       let id = `${n.association().dbPrefix}:${n.association().id}`;
-      expect(await getGeneName(id)).equal(`${n.association().name}`);
+      expect(await getGeneName(id)).to.equal(`${n.association().name}`);
     }
 
-    expect(await getNumEdges()).equal(2);
+    expect(await getNumEdges()).to.equal(2);
     for (const e of arrEdges) {
       let edge = await getEdge(e.id());
-      expect(edge.properties.type).equal(e.type());
+      expect(edge.properties.type).to.equal(e.type());
       if (e.association().getSource()) {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
       } else {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
       }
-      expect(edge.type).equal('INTERACTION');
-      expect(edge.properties.xref).equal(myDoc.id());
-      expect(edge.properties.doi).equal(myDoc.citation().doi);
-      expect(edge.properties.pmid).equal(myDoc.citation().pmid);
-      expect(edge.properties.articleTitle).equal(myDoc.citation().title);
+      expect(edge.type).to.equal('INTERACTION');
+      expect(edge.properties.component).to.deep.equal([]);
+      expect(edge.properties.sourceComplex).to.equal('n/a');
+      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.doi).to.equal(myDoc.citation().doi);
+      expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
+      expect(edge.properties.articleTitle).to.equal(myDoc.citation().title);
     }
   });
 
@@ -233,35 +246,38 @@ describe('Tests for Documents', function () {
 
     let myDoc = fixtureDocs[0];
 
-    expect(await getNumNodes()).equal(0);
-    expect(await getNumEdges()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
+    expect(await getNumEdges()).to.equal(0);
     await addDocumentToNeo4j(myDoc);
 
     let arrNodes = myDoc.elements().filter(ele => ele.isEntity());
     let arrEdges = myDoc.elements().filter(ele => !(ele.isEntity()));
 
-    expect(await getNumNodes()).equal(4);
+    expect(await getNumNodes()).to.equal(4);
     for (const n of arrNodes) {
       let id = `${n.association().dbPrefix}:${n.association().id}`;
-      expect(await getGeneName(id)).equal(`${n.association().name}`);
+      expect(await getGeneName(id)).to.equal(`${n.association().name}`);
     }
 
-    expect(await getNumEdges()).equal(4);
+    expect(await getNumEdges()).to.equal(4);
     for (const e of arrEdges) {
       let edge = await getEdge(e.id());
-      expect(edge.properties.type).equal(e.type());
+      expect(edge.properties.type).to.equal(e.type());
       if (e.association().getSource()) {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
       } else {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
       }
-      expect(edge.type).equal('INTERACTION');
-      expect(edge.properties.xref).equal(myDoc.id());
-      expect(edge.properties.doi).equal(myDoc.citation().doi);
-      expect(edge.properties.pmid).equal(myDoc.citation().pmid);
-      expect(edge.properties.articleTitle).equal(myDoc.citation().title);
+      expect(edge.type).to.equal('INTERACTION');
+      expect(edge.properties.component).to.deep.equal([]);
+      expect(edge.properties.sourceComplex).to.equal('n/a');
+      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.doi).to.equal(myDoc.citation().doi);
+      expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
+      expect(edge.properties.articleTitle).to.equal(myDoc.citation().title);
     }
   });
 
@@ -276,8 +292,8 @@ describe('Tests for Documents', function () {
 
     let myDoc = fixtureDocs[0];
 
-    expect(await getNumNodes()).equal(0);
-    expect(await getNumEdges()).equal(0);
+    expect(await getNumNodes()).to.equal(0);
+    expect(await getNumEdges()).to.equal(0);
     await addDocumentToNeo4j(myDoc);
 
     let arrNodes = myDoc.elements().filter(ele => ele.isEntity());
@@ -286,25 +302,28 @@ describe('Tests for Documents', function () {
     expect(await getNumNodes()).equal(5);
     for (const n of arrNodes) {
       let id = `${n.association().dbPrefix}:${n.association().id}`;
-      expect(await getGeneName(id)).equal(`${n.association().name}`);
+      expect(await getGeneName(id)).to.equal(`${n.association().name}`);
     }
 
-    expect(await getNumEdges()).equal(5);
+    expect(await getNumEdges()).to.equal(5);
     for (const e of arrEdges) {
       let edge = await getEdge(e.id());
-      expect(edge.properties.type).equal(e.type());
+      expect(edge.properties.type).to.equal(e.type());
       if (e.association().getSource()) {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.association().getSource().id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.association().getTarget().id()));
       } else {
-        expect(edge.properties.sourceId).equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
-        expect(edge.properties.targetId).equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
+        expect(edge.properties.sourceId).to.equal(convertUUIDtoId(myDoc, e.elements()[0].id()));
+        expect(edge.properties.targetId).to.equal(convertUUIDtoId(myDoc, e.elements()[1].id()));
       }
-      expect(edge.type).equal('INTERACTION');
-      expect(edge.properties.xref).equal(myDoc.id());
-      expect(edge.properties.doi).equal(myDoc.citation().doi);
-      expect(edge.properties.pmid).equal(myDoc.citation().pmid);
-      expect(edge.properties.articleTitle).equal(myDoc.citation().title);
+      expect(edge.type).to.equal('INTERACTION');
+      expect(edge.properties.component).to.deep.equal([]);
+      expect(edge.properties.sourceComplex).to.equal('n/a');
+      expect(edge.properties.targetComplex).to.equal('n/a');
+      expect(edge.properties.xref).to.equal(myDoc.id());
+      expect(edge.properties.doi).to.equal(myDoc.citation().doi);
+      expect(edge.properties.pmid).to.equal(myDoc.citation().pmid);
+      expect(edge.properties.articleTitle).to.equal(myDoc.citation().title);
     }
   });
 

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { loadDoc } from '../src/server/routes/api/document/index.js';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
-import { searchByMoleculeId, getInteractions, getNeighbouringNodes } from '../src/neo4j/neo4j-functions.js';
+import { neighbourhood, getInteractions, getNeighbouringNodes } from '../src/neo4j/neo4j-functions.js';
 import { addDocumentToNeo4j } from '../src/neo4j/neo4j-document.js';
 import { deleteAllNodesAndEdges } from '../src/neo4j/test-functions.js';
 
@@ -21,7 +21,7 @@ let testDb;
 const dbName = 'factoid-neo4j-test';
 const dbTables = ['document', 'element'];
 
-describe('04. Tests for searchByMoleculeId', function () {
+describe('04. Tests for search functions', function () {
 
   before('Create a Neo4j driver instance and connect to server. Connect to RDB', async function () {
     await initDriver();
@@ -65,14 +65,14 @@ describe('04. Tests for searchByMoleculeId', function () {
 
   it('Search for MAPK6', async function () {
     let mapk6 = 'ncbigene:5597';
-    expect(await searchByMoleculeId(mapk6)).to.be.null;
+    expect(await neighbourhood(mapk6)).to.be.null;
     expect(await getInteractions(mapk6)).to.be.null;
     expect(await getNeighbouringNodes(mapk6)).to.be.null;
   });
 
   it('Search for KANK1', async function () {
     let kank1 = 'ncbigene:23189';
-    expect(await searchByMoleculeId(kank1)).to.not.be.null;
+    expect(await neighbourhood(kank1)).to.not.be.null;
     let edges = await getInteractions(kank1);
     expect(edges.length).equal(3);
     expect(_.find(edges, { id: 'd7b2a15d-43bf-4494-815b-a77e08cea59c', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
@@ -88,7 +88,7 @@ describe('04. Tests for searchByMoleculeId', function () {
 
   it('Search for TLN1', async function () {
     let tln1 = 'ncbigene:7094';
-    expect(await searchByMoleculeId(tln1)).to.not.be.null;
+    expect(await neighbourhood(tln1)).to.not.be.null;
     let edges = await getInteractions(tln1);
     expect(edges.length).equal(6);
     expect(_.find(edges, { id: '028e7366-9779-4466-96ea-18a45bfe3f38', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
@@ -109,7 +109,7 @@ describe('04. Tests for searchByMoleculeId', function () {
 
   it('Search for TLNRD1', async function () {
     let tlnrd1 = 'ncbigene:59274';
-    expect(await searchByMoleculeId(tlnrd1)).to.not.be.null;
+    expect(await neighbourhood(tlnrd1)).to.not.be.null;
     let edges = await getInteractions(tlnrd1);
     expect(edges.length).equal(5);
     expect(_.find(edges, { id: 'd5d9fbcc-a1d9-4026-b1d3-d4a97faff36b', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;

--- a/src/neo4j/index.js
+++ b/src/neo4j/index.js
@@ -1,2 +1,2 @@
 export { addDocumentToNeo4j } from './neo4j-document';
-export { addNode, addEdge, searchByMoleculeId } from './neo4j-functions';
+export { addNode, addEdge, neighbourhood } from './neo4j-functions';

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -148,6 +148,22 @@ export async function addDocumentToNeo4j(doc) {
         const sourceComplex = doc.get(sourceUUId);
         const targetComplex = doc.get(targetUUId);
 
+        for (let i = 0; i < sourceComplex.elements().length - 1; i++) {
+          for (let j = 0; j < targetComplex.elements().length - 1; j++) {
+            const complexElementSourceUUId = sourceComplex.elements()[i].id();
+            const targetElementSourceUUId = targetComplex.elements()[i].id();
+            const edgeInfo = {
+              id: e.id(),
+              type: e.type(),
+              component: [],
+              sourceId: convertUUIDtoId(doc, complexElementSourceUUId),
+              targetId: convertUUIDtoId(doc, targetElementSourceUUId),
+              sourceComplex: sourceComplex.id(),
+              targetComplex: targetComplex.id()
+            };
+            arrEdges.push(edgeInfo);
+          }
+        }
       }
       arrEdges.push(edgeInfo);
     }

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -38,9 +38,9 @@ function complexEdgesMaker(i, doc, complex, arrOfEdges) {
 
   const component = makeComponent(complex, doc);
 
-  while (i < complex.elements().length - 2) {
+  for (let j = i; j < complex.elements().length - 1; j++) {
     const sourceUUId = complex.elements()[i].id();
-    const targetUUId = complex.elements()[i + 1].id();
+    const targetUUId = complex.elements()[j + 1].id();
     const edgeInfo = {
       id: complex.id(),
       type: complex.type(),

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -48,7 +48,7 @@ export async function addDocumentToNeo4j(doc) {
       // Untested
       const complex = e;
       const component = makeComponent(complex, doc);
-      for (let i = 0; i < complex.elements().length - 2; i++) {
+      for (let i = 0; i < complex.elements().length - 1; i++) {
         for (let j = i + 1; j < complex.elements().length - 1; j++) {
           const sourceUUId = complex.elements()[i].id();
           const targetUUId = complex.elements()[j].id();

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -23,40 +23,6 @@ function makeComponent(complex, doc) {
 }
 
 /**
- * This is a recursive function
- * @param { Int } i 
- * @param { Document } doc 
- * @param { Document element } complex 
- * @param { Array } arrOfEdges 
- * @returns an array with all the info for the edges needed to represent complex
- */
-function complexEdgesMaker(i, doc, complex, arrOfEdges) {
-  if (i == complex.elements().length - 1) {
-    return arrOfEdges;
-  }
-
-  const component = makeComponent(complex, doc);
-
-  for (let j = i + 1; j < complex.elements().length - 1; j++) {
-    const sourceUUId = complex.elements()[i].id();
-    const targetUUId = complex.elements()[j].id();
-    const edgeInfo = {
-      id: complex.id(),
-      type: complex.type(),
-      component: component,
-      sourceId: convertUUIDtoId(doc, sourceUUId),
-      targetId: convertUUIDtoId(doc, targetUUId),
-      sourceComplex: 'N/A',
-      targetComplex: 'N/A'
-    };
-    arrOfEdges.push(edgeInfo);
-  }
-  i++;
-  complexEdgesMaker(i, doc, complex, arrOfEdges);
-  return arrOfEdges;
-}
-
-/**
  * addDocumentToNeo4j takes a Document as a parameter and creates the associated nodes 
  * and edges in a Neo4j database
  * @param { Document } doc : a document model instance
@@ -80,8 +46,24 @@ export async function addDocumentToNeo4j(doc) {
     } else if (e.isEntity && e.isComplex()) {
       // TODO: Push on the edges that will represent this complex e in arrEdges
       // Untested
-      let complexEdges = complexEdgesMaker(0, doc, e, []);
-      arrEdges.push(...complexEdges);
+      const complex = e;
+      const component = makeComponent(complex, doc);
+      for (let i = 0; i < complex.elements.length - 2; i++) {
+        for (let j = i + 1; j < complex.elements().length - 1; j++) {
+          const sourceUUId = complex.elements()[i].id();
+          const targetUUId = complex.elements()[j].id();
+          const edgeInfo = {
+            id: complex.id(),
+            type: complex.type(),
+            component: component,
+            sourceId: convertUUIDtoId(doc, sourceUUId),
+            targetId: convertUUIDtoId(doc, targetUUId),
+            sourceComplex: 'N/A',
+            targetComplex: 'N/A'
+          };
+          arrEdges.push(edgeInfo);
+        }
+      }
     } else {
       let sourceUUId;
       let targetUUId;

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -112,14 +112,13 @@ export async function addDocumentToNeo4j(doc) {
       } else if (source.isComplex() && !target.isComplex()) {
         // sourceUUID is a complex and targetUUID is a noncomplex
         const sourceComplex = doc.get(sourceUUId);
-        const component = makeComponent(sourceComplex, doc);
 
-        for (let i = 0; i < e.elements().length - 1; i++) {
+        for (let i = 0; i < sourceComplex.elements().length - 1; i++) {
           const complexElementSourceUUId = sourceComplex.elements()[i].id();
           const edgeInfo = {
             id: e.id(),
             type: e.type(),
-            component: component,
+            component: [],
             sourceId: convertUUIDtoId(doc, complexElementSourceUUId),
             targetId: convertUUIDtoId(doc, targetUUId),
             sourceComplex: sourceComplex.id(),
@@ -130,14 +129,13 @@ export async function addDocumentToNeo4j(doc) {
       } else if (!source.isComplex() && target.isComplex()) {
         // sourceUUID is a noncomplex and targetUUID is a complex
         const targetComplex = doc.get(targetUUId);
-        const component = makeComponent(targetComplex, doc);
 
-        for (let i = 0; i < e.elements().length - 1; i++) {
+        for (let i = 0; i < targetComplex.elements().length - 1; i++) {
           const complexElementTargetUUId = targetComplex.elements()[i].id();
           const edgeInfo = {
             id: e.id(),
             type: e.type(),
-            component: component,
+            component: [],
             sourceId: convertUUIDtoId(doc, sourceUUId),
             targetId: convertUUIDtoId(doc, complexElementTargetUUId),
             sourceComplex: 'N/A',
@@ -147,6 +145,8 @@ export async function addDocumentToNeo4j(doc) {
         }
       } else {
         // TODO: sourceUUID is a complex and targetUUID is a complex
+        const sourceComplex = doc.get(sourceUUId);
+        const targetComplex = doc.get(targetUUId);
 
       }
       arrEdges.push(edgeInfo);

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -63,9 +63,11 @@ export async function addDocumentToNeo4j(doc) {
         edgeInfo = {
           id: e.id(),
           type: e.type(),
+          component: [],
           sourceId: convertUUIDtoId(doc, sourceUUId),
           targetId: convertUUIDtoId(doc, targetUUId),
-          participantTypes: 'noncomplex-to-noncomplex'
+          sourceComplex: 'N/A',
+          targetComplex: 'N/A'
         };
       } else if (source.isComplex() && !target.isComplex()) {
         // TODO: sourceUUID is a complex and targetUUID is a noncomplex
@@ -95,7 +97,7 @@ export async function addDocumentToNeo4j(doc) {
 
   // Step 3: Make all the edges
   for (const edge of arrEdges) {
-    await addEdge(edge.id, edge.type, edge.sourceId, edge.targetId, edge.participantTypes,
+    await addEdge(edge.id, edge.type, edge.component, edge.sourceId, edge.targetId, edge.sourceComplex, edge.targetComplex,
       docCitations.xref, docCitations.doi, docCitations.pmid, docCitations.articleTitle);
   }
 

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -54,7 +54,7 @@ export async function addDocumentToNeo4j(doc) {
           const targetUUId = complex.elements()[j].id();
           const edgeInfo = {
             id: complex.id(),
-            type: complex.type(),
+            type: 'binding',
             component: component,
             sourceId: convertUUIDtoId(doc, sourceUUId),
             targetId: convertUUIDtoId(doc, targetUUId),

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -48,7 +48,7 @@ export async function addDocumentToNeo4j(doc) {
       // Untested
       const complex = e;
       const component = makeComponent(complex, doc);
-      for (let i = 0; i < complex.elements.length - 2; i++) {
+      for (let i = 0; i < complex.elements().length - 2; i++) {
         for (let j = i + 1; j < complex.elements().length - 1; j++) {
           const sourceUUId = complex.elements()[i].id();
           const targetUUId = complex.elements()[j].id();

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -31,16 +31,15 @@ function makeComponent(complex, doc) {
  * @returns an array with all the info for the edges needed to represent complex
  */
 function complexEdgesMaker(i, doc, complex, arrOfEdges) {
-  const nextIndex = i + 1;
   if (i == complex.elements().length - 1) {
     return arrOfEdges;
   }
 
   const component = makeComponent(complex, doc);
 
-  for (let j = i; j < complex.elements().length - 2; j++) {
+  for (let j = i + 1; j < complex.elements().length - 1; j++) {
     const sourceUUId = complex.elements()[i].id();
-    const targetUUId = complex.elements()[j + 1].id();
+    const targetUUId = complex.elements()[j].id();
     const edgeInfo = {
       id: complex.id(),
       type: complex.type(),
@@ -52,8 +51,8 @@ function complexEdgesMaker(i, doc, complex, arrOfEdges) {
     };
     arrOfEdges.push(edgeInfo);
   }
-
-  complexEdgesMaker(nextIndex, doc, complex, arrOfEdges);
+  i++;
+  complexEdgesMaker(i, doc, complex, arrOfEdges);
   return arrOfEdges;
 }
 

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -59,6 +59,7 @@ export async function addDocumentToNeo4j(doc) {
 
       let edgeInfo;
       if (!source.isComplex() && !target.isComplex()) {
+        // TESTED
         edgeInfo = {
           id: e.id(),
           type: e.type(),

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -38,7 +38,7 @@ function complexEdgesMaker(i, doc, complex, arrOfEdges) {
 
   const component = makeComponent(complex, doc);
 
-  for (let j = i; j < complex.elements().length - 1; j++) {
+  for (let j = i; j < complex.elements().length - 2; j++) {
     const sourceUUId = complex.elements()[i].id();
     const targetUUId = complex.elements()[j + 1].id();
     const edgeInfo = {

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -58,8 +58,8 @@ export async function addDocumentToNeo4j(doc) {
             component: component,
             sourceId: convertUUIDtoId(doc, sourceUUId),
             targetId: convertUUIDtoId(doc, targetUUId),
-            sourceComplex: 'N/A',
-            targetComplex: 'N/A'
+            sourceComplex: '',
+            targetComplex: ''
           };
           arrEdges.push(edgeInfo);
         }
@@ -87,8 +87,8 @@ export async function addDocumentToNeo4j(doc) {
           component: [],
           sourceId: convertUUIDtoId(doc, sourceUUId),
           targetId: convertUUIDtoId(doc, targetUUId),
-          sourceComplex: 'N/A',
-          targetComplex: 'N/A'
+          sourceComplex: '',
+          targetComplex: ''
         };
       } else if (source.isComplex() && !target.isComplex()) {
         // sourceUUID is a complex and targetUUID is a noncomplex
@@ -103,7 +103,7 @@ export async function addDocumentToNeo4j(doc) {
             sourceId: convertUUIDtoId(doc, complexElementSourceUUId),
             targetId: convertUUIDtoId(doc, targetUUId),
             sourceComplex: sourceComplex.id(),
-            targetComplex: 'N/A'
+            targetComplex: ''
           };
           arrEdges.push(edgeInfo);
         }
@@ -119,7 +119,7 @@ export async function addDocumentToNeo4j(doc) {
             component: [],
             sourceId: convertUUIDtoId(doc, sourceUUId),
             targetId: convertUUIDtoId(doc, complexElementTargetUUId),
-            sourceComplex: 'N/A',
+            sourceComplex: '',
             targetComplex: targetComplex.id()
           };
           arrEdges.push(edgeInfo);

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -1,4 +1,4 @@
-import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery } from './query-strings';
+import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery, makeComplexEdgeQuery } from './query-strings';
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
 
@@ -65,8 +65,24 @@ export async function addEdge(id, type, sourceId, targetId, participantTypes, xr
 }
 
 export async function addComplexEdge(id, sourceId, targetId, allParticipants) {
-    // TO DO
-    
+    // NOT TESTED
+    const driver = getDriver();
+    let session;
+    try {
+        session = driver.session({ database: "neo4j" });
+        await session.executeWrite(tx => {
+            return tx.run(makeEdgeQuery, {
+                id: id.toLowerCase(),
+                sourceId: sourceId.toLowerCase(),
+                targetId: targetId.toLowerCase(),
+                allParticipants: allParticipants
+            });
+        });
+    } catch (error) {
+        throw error;
+    } finally {
+        await session.close();
+    }
     return;
 }
 

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -115,7 +115,7 @@ export async function addComplexEdge(sourceId, targetId, allParticipants) {
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
  * @returns An object with 2 fields: relationships (array) and neighbouring nodes (array) or null
  */
-export async function searchByMoleculeId(id) {
+export async function neighbourhood(id) {
     const driver = getDriver();
     let session;
     let record;
@@ -142,7 +142,7 @@ export async function searchByMoleculeId(id) {
  * @returns an array of nodes that are neighbours to the specified gene
  */
 export async function getNeighbouringNodes(id) {
-    let record = await searchByMoleculeId(id);
+    let record = await neighbourhood(id);
     if (record) {
         return _.uniqBy(record.map(row => {
             return row.get('m').properties;
@@ -156,7 +156,7 @@ export async function getNeighbouringNodes(id) {
  * @returns an array of relationships leading away from/leading to the specified gene
  */
 export async function getInteractions(id) {
-    let record = await searchByMoleculeId(id);
+    let record = await neighbourhood(id);
     if (record) {
         return _.uniqBy(record.map(row => {
             return row.get('r').properties;

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -1,4 +1,4 @@
-import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery, makeComplexEdgeQuery } from './query-strings';
+import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery } from './query-strings';
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
 
@@ -38,7 +38,7 @@ export async function addNode(id, name) {
  * @param { String } articleTitle 
  * @returns 
  */
-export async function addEdge(id, type, sourceId, targetId, participantTypes, xref, doi, pmid, articleTitle) {
+export async function addEdge(id, type, component, sourceId, targetId, sourceComplex, targetComplex, xref, doi, pmid, articleTitle) {
     const driver = getDriver();
     let session;
     try {
@@ -47,9 +47,11 @@ export async function addEdge(id, type, sourceId, targetId, participantTypes, xr
             return tx.run(makeEdgeQuery, {
                 id: id.toLowerCase(),
                 type: type,
+                component: component,
                 sourceId: sourceId.toLowerCase(),
                 targetId: targetId.toLowerCase(),
-                participantTypes: participantTypes.toLowerCase(),
+                sourceComplex: sourceComplex.toLowerCase(),
+                targetComplex: targetComplex.toLowerCase(),
                 xref: xref.toLowerCase(),
                 doi: doi,
                 pmid: pmid,

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -1,4 +1,4 @@
-import { giveConnectedInfoByGeneId, makeNodeQuery, makeRelationshipQuery } from './query-strings';
+import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery } from './query-strings';
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
 
@@ -31,23 +31,25 @@ export async function addNode(id, name) {
  * @param { String } type 
  * @param { String } sourceId in the form of "dbName:dbId", ex: "ncbigene:207"
  * @param { String } targetId in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { String } participantTypes 'noncomplex-to-noncomplex', 'complex-to-noncomplex', etc
  * @param { String } xref document UUID
  * @param { String } doi 
  * @param { String } pmid 
  * @param { String } articleTitle 
  * @returns 
  */
-export async function addEdge(id, type, sourceId, targetId, xref, doi, pmid, articleTitle) {
+export async function addEdge(id, type, sourceId, targetId, participantTypes, xref, doi, pmid, articleTitle) {
     const driver = getDriver();
     let session;
     try {
         session = driver.session({ database: "neo4j" });
         await session.executeWrite(tx => {
-            return tx.run(makeRelationshipQuery, {
+            return tx.run(makeEdgeQuery, {
                 id: id.toLowerCase(),
                 type: type,
                 sourceId: sourceId.toLowerCase(),
                 targetId: targetId.toLowerCase(),
+                participantTypes: participantTypes.toLowerCase(),
                 xref: xref.toLowerCase(),
                 doi: doi,
                 pmid: pmid,
@@ -59,6 +61,12 @@ export async function addEdge(id, type, sourceId, targetId, xref, doi, pmid, art
     } finally {
         await session.close();
     }
+    return;
+}
+
+export async function addComplexEdge(id, sourceId, targetId, allParticipants) {
+    // TO DO
+    
     return;
 }
 

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -64,8 +64,31 @@ export async function addEdge(id, type, sourceId, targetId, participantTypes, xr
     return;
 }
 
-export async function addComplexEdge(id, sourceId, targetId, allParticipants) {
+/**
+ * @param { Array } arrParticipants Array of strings (ids of entities) sorted in alphabetical order
+ * @returns id in the form of 'dbNameA:dbIdA-dbNameB:dbIdB' etc.
+ */
+function makeComplexId(arrParticipants) {
+    let id = '';
+    for (let i = 0; i < arrParticipants.length; i++) {
+        id = id + arrParticipants[i];
+        if (i < arrParticipants.length - 1) {
+            id = id + '-';
+        }
+    }
+    return id;
+}
+
+/**
+ * Makes exactly one Complex edge
+ * @param { String } sourceId in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { String } targetId in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { Array } allParticipants Array of strings (ids of entities) sorted in alphabetical order
+ * @returns 
+ */
+export async function addComplexEdge(sourceId, targetId, allParticipants) {
     // NOT TESTED
+    const id = makeComplexId(allParticipants);
     const driver = getDriver();
     let session;
     try {

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -7,9 +7,11 @@ export const makeEdgeQuery =
     MATCH (y:Molecule {id: $targetId})
     MERGE (x)-[r:INTERACTION {id: $id}]->(y)
     ON CREATE SET r.type = $type,
+    r.component = $component,
     r.sourceId = $sourceId,
     r.targetId = $targetId,
-    r.participantTypes = $participantTypes,
+    r.sourceComplex = $sourceComplex,
+    r.targetComplex = $targetComplex,
     r.xref = $xref,
     r.doi = $doi, 
     r.pmid = $pmid,

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -2,17 +2,24 @@ export const makeNodeQuery =
     `MERGE (n:Molecule {id: $id})
     ON CREATE SET n.name = $name`;
 
-export const makeRelationshipQuery =
+export const makeEdgeQuery =
     `MATCH (x:Molecule {id: $sourceId})
     MATCH (y:Molecule {id: $targetId})
     MERGE (x)-[r:INTERACTION {id: $id}]->(y)
     ON CREATE SET r.type = $type,
+    r.sourceId = $sourceId,
+    r.targetId = $targetId,
+    r.participantTypes = $participantTypes,
     r.xref = $xref,
     r.doi = $doi, 
     r.pmid = $pmid,
-    r.articleTitle = $articleTitle,
-    r.sourceId = $sourceId,
-    r.targetId = $targetId`;
+    r.articleTitle = $articleTitle`;
+
+export const makeComplexEdgeQuery = 
+    `MATCH (x:Molecule {id: $sourceId})
+    MATCH (y:Molecule {id: $targetId})
+    MERGE (x)-[r:COMPLEX {id: $id}]->(y)
+    ON CREATE SET r.allParticipants = $allParticipants`;
 
 export const giveConnectedInfoByGeneId =
     `MATCH (n:Molecule {id: $id})<-[r]-(m)


### PR DESCRIPTION
See #1146 for more detail

Making changes to code for handling Complexes via the "hairball" visualization

The following tasks (non-exhaustive) must be completed:

### OLD Plan:
- ~~Make a function similar to `addEdge()` that makes a COMPLEX edge rather than a regular INTERACTION edge. Call this `addComplexEdge()`. Should have fields for: `id`, `targetId`, `sourceId` and `allParticipants` (`allParticipants` is an array)~~
- ~~Make a Neo4j Cypher query string for `addComplexEdge()`~~
- ~~Update `addDocumentstoNeo4j()` to account for making complexes via `addComplexEdge()`~~
- ~~Add a `participantTypes` field to ALL interaction edges (can be `'noncomplex-to-noncomplex'`, `'complex-to-complex'`, `'noncomplex-to-complex'` or `'complex-to-noncomplex'`)~~
- ~~Update `addDocumentstoNeo4j()` to account for the `participantTypes` field so it can properly handle making INTERACTION edges in all 4 cases (see above)~~

### New Plan:

- [x] Add the following additional fields to edges: `component` (this is an array. [ ] by default), `targetComplex` (null by default), `sourceComplex` (null by default).
- [x] Handle making a complex (special considerations: `id` of the edges will be the factoid UUID for the complex, `type` will be "complex")
- [x] Handle making an interaction between a complex and a non-complex
- [x] Handle making an interaction between two complexes