### PR TITLE
Neo4j: Complex filter for neighbourhood()

### DIFF
--- a/neo4j-test/doc-tests-complex.js
+++ b/neo4j-test/doc-tests-complex.js
@@ -6,6 +6,7 @@ import { loadDoc } from '../src/server/routes/api/document/index.js';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
 import { addDocumentToNeo4j, convertUUIDtoId } from '../src/neo4j/neo4j-document.js';
 import { deleteAllNodesAndEdges, getGeneName, getNumNodes, getNumEdges, getEdge, getEdgeByIdAndEndpoints } from '../src/neo4j/test-functions.js';
+import { neighbourhoodWithoutComplexes } from '../src/neo4j/neo4j-functions.js';
 
 import complex1 from './document/complex_tests_1.json';
 import complex2 from './document/complex_tests_2.json';
@@ -91,6 +92,9 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge1.properties.doi).to.equal(myDoc.citation().doi);
     expect(edge1.properties.pmid).to.equal(myDoc.citation().pmid);
     expect(edge1.properties.articleTitle).to.equal(myDoc.citation().title);
+
+    expect(await neighbourhoodWithoutComplexes('ncbigene:22882')).to.be.null;
+    expect(await neighbourhoodWithoutComplexes('ncbigene:3091')).to.be.null;
   });
 
   it('Three nodes in one complex, edges between them', async function () {
@@ -340,6 +344,10 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(interactionEdge2.properties.component).to.deep.equal([]);
     expect(interactionEdge2.properties.sourceComplex).to.equal(complexId1);
     expect(interactionEdge2.properties.targetComplex).to.equal('');
+
+    expect(await neighbourhoodWithoutComplexes('ncbigene:11335')).to.be.null;
+    expect(await neighbourhoodWithoutComplexes('ncbigene:648791')).to.be.null;
+    expect(await neighbourhoodWithoutComplexes('ncbigene:8737')).to.be.null;
   });
 
   it('One complex interacting with another complex', async function () {

--- a/neo4j-test/doc-tests-complex.js
+++ b/neo4j-test/doc-tests-complex.js
@@ -256,6 +256,14 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge1.properties.component).to.deep.equal(['ncbigene:90550', 'ncbigene:27173']);
     expect(edge1.properties.sourceComplex).to.equal('');
     expect(edge1.properties.targetComplex).to.equal('');
+
+    const record = await neighbourhoodWithoutComplexes('ncbigene:27173');
+    const testNodes = record.map(row => row.get('m').properties);
+    expect(testNodes.length).to.equal(1);
+    expect(_.find(testNodes, { id: 'ncbigene:10059' })).to.be.not.undefined;
+    const testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(1);
+    expect(_.find(testEdges, { id: 'abce49de-663c-4a5b-8bc5-de1ec79a63d7' })).to.be.not.undefined;
   });
 
   it('Two complexes, 1 node from each interacting with a node from the other complex', async function () {
@@ -322,6 +330,23 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge2.properties.component).to.deep.equal(['ncbigene:57599', 'ncbigene:7398']);
     expect(edge2.properties.sourceComplex).to.equal('');
     expect(edge2.properties.targetComplex).to.equal('');
+
+    let record = await neighbourhoodWithoutComplexes('ncbigene:55215');
+    let testNodes = record.map(row => row.get('m').properties);
+    expect(testNodes.length).to.equal(1);
+    expect(_.find(testNodes, { id: 'ncbigene:57599' })).to.be.not.undefined;
+    let testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(1);
+    expect(_.find(testEdges, { id: 'b38116a2-5002-48b0-b156-32bcbff764a4' })).to.be.not.undefined;
+
+    record = await neighbourhoodWithoutComplexes('ncbigene:7398');
+    testNodes = record.map(row => row.get('m').properties);
+    expect(testNodes.length).to.equal(1);
+    expect(_.find(testNodes, { id: 'ncbigene:2177' })).to.be.not.undefined;
+    testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(1);
+    expect(_.find(testEdges, { id: '8ee9fb94-b3b8-4212-bddc-d46f1a079164' })).to.be.not.undefined;
+
   });
 
   it('One complex interacting with one non-complex', async function () {
@@ -498,5 +523,16 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(interactionEdge6.properties.component).to.deep.equal([]);
     expect(interactionEdge6.properties.sourceComplex).to.equal(complexId1);
     expect(interactionEdge6.properties.targetComplex).to.equal(complexId2);
+
+    expect(await neighbourhoodWithoutComplexes('ncbigene:9474')).to.be.null;
+
+    const record = await neighbourhoodWithoutComplexes('ncbigene:64112');
+    const testNodes = record.map(row => row.get('m').properties);
+    expect(testNodes.length).to.equal(1);
+    expect(_.find(testNodes, { id: 'ncbigene:84557' })).to.not.be.undefined;
+    const testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(1);
+    expect(_.find(testEdges, { id: '3b8e906f-d7ea-476b-a15c-4d383a603f22'})).to.not.be.undefined;
+
   });
 });

--- a/neo4j-test/doc-tests-complex.js
+++ b/neo4j-test/doc-tests-complex.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import rdbFix from 'rethinkdb-fixtures';
 import r from 'rethinkdb';
+import _ from 'lodash';
 
 import { loadDoc } from '../src/server/routes/api/document/index.js';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
@@ -167,6 +168,36 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge3.properties.component).to.deep.equal(['ncbigene:3303', 'ncbigene:7157', 'ncbigene:3326']);
     expect(edge3.properties.sourceComplex).to.equal('');
     expect(edge3.properties.targetComplex).to.equal('');
+
+    let record = await neighbourhoodWithoutComplexes('ncbigene:3303');
+    let testNodes = record.map(row => row.get('m').properties);
+    expect(testNodes.length).to.equal(2);
+    expect(_.find(testNodes, { id: 'ncbigene:7157' })).to.be.not.undefined;
+    expect(_.find(testNodes, { id: 'ncbigene:3326' })).to.be.not.undefined;
+    let testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(2);
+    expect(_.find(testEdges, { id: 'b6e4c90d-4870-4c64-8abf-b6e16b0738f7' })).to.be.not.undefined;
+    expect(_.find(testEdges, { id: '7ba76f35-faaa-4622-ae37-5aff0d802eed' })).to.be.not.undefined;
+
+    record = await neighbourhoodWithoutComplexes('ncbigene:7157');
+    testNodes = record.map(row => row.get('m').properties);
+    expect(_.find(testNodes, { id: 'ncbigene:3303' })).to.be.not.undefined;
+    expect(_.find(testNodes, { id: 'ncbigene:3326' })).to.be.not.undefined;
+    expect(testNodes.length).to.equal(2);
+    testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(2);
+    expect(_.find(testEdges, { id: 'b6e4c90d-4870-4c64-8abf-b6e16b0738f7' })).to.be.not.undefined;
+    expect(_.find(testEdges, { id: 'eb40318c-9a0e-45f6-a81e-21836fd9e9e3' })).to.be.not.undefined;
+
+    record = await neighbourhoodWithoutComplexes('ncbigene:3326');
+    testNodes = record.map(row => row.get('m').properties);
+    expect(testNodes.length).to.equal(2);
+    expect(_.find(testNodes, { id: 'ncbigene:7157' })).to.be.not.undefined;
+    expect(_.find(testNodes, { id: 'ncbigene:3303' })).to.be.not.undefined;
+    testEdges = record.map(row => row.get('r').properties);
+    expect(testEdges.length).to.equal(2);
+    expect(_.find(testEdges, { id: '7ba76f35-faaa-4622-ae37-5aff0d802eed' })).to.be.not.undefined;
+    expect(_.find(testEdges, { id: 'eb40318c-9a0e-45f6-a81e-21836fd9e9e3' })).to.be.not.undefined;
   });
 
   it('Two nodes in one complex, 1 node interacting with a non-complex', async function () {

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -1,4 +1,4 @@
-import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery } from './query-strings';
+import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery, giveConnectedInfoByGeneIdNoComplexes } from './query-strings';
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
 
@@ -67,21 +67,6 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
 }
 
 /**
- * @param { Array } arrParticipants Array of strings (ids of entities) sorted in alphabetical order
- * @returns id in the form of 'dbNameA:dbIdA-dbNameB:dbIdB' etc.
- */
-function makeComplexId(arrParticipants) {
-    let id = '';
-    for (let i = 0; i < arrParticipants.length; i++) {
-        id = id + arrParticipants[i];
-        if (i < arrParticipants.length - 1) {
-            id = id + '-';
-        }
-    }
-    return id;
-}
-
-/**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
  * @returns An object with 2 fields: relationships (array) and neighbouring nodes (array) or null
  */
@@ -133,4 +118,26 @@ export async function getInteractions(id) {
         }), edge => edge.id);
     }
     return null;
+}
+
+export async function neighbourhoodWithoutComplexes(id) {
+    const driver = getDriver();
+    let session;
+    let record;
+    try {
+        session = driver.session({ database: "neo4j" });
+        let result = await session.executeRead(tx => {
+            return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
+        });
+        if (result.records.length > 0) {
+            record = result.records;
+        } else {
+            record = null;
+        }
+    } catch (error) {
+        throw error;
+    } finally {
+        await session.close();
+    }
+    return record;
 }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -82,36 +82,6 @@ function makeComplexId(arrParticipants) {
 }
 
 /**
- * Makes exactly one Complex edge
- * @param { String } sourceId in the form of "dbName:dbId", ex: "ncbigene:207"
- * @param { String } targetId in the form of "dbName:dbId", ex: "ncbigene:207"
- * @param { Array } allParticipants Array of strings (ids of entities) sorted in alphabetical order
- * @returns 
- */
-export async function addComplexEdge(sourceId, targetId, allParticipants) {
-    // NOT TESTED
-    const id = makeComplexId(allParticipants);
-    const driver = getDriver();
-    let session;
-    try {
-        session = driver.session({ database: "neo4j" });
-        await session.executeWrite(tx => {
-            return tx.run(makeEdgeQuery, {
-                id: id.toLowerCase(),
-                sourceId: sourceId.toLowerCase(),
-                targetId: targetId.toLowerCase(),
-                allParticipants: allParticipants
-            });
-        });
-    } catch (error) {
-        throw error;
-    } finally {
-        await session.close();
-    }
-    return;
-}
-
-/**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
  * @returns An object with 2 fields: relationships (array) and neighbouring nodes (array) or null
  */

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -24,6 +24,15 @@ export const giveConnectedInfoByGeneId =
     MATCH (n:Molecule {id: $id})-[r]->(m)
     RETURN n, r, m`;
 
+export const giveConnectedInfoByGeneIdNoComplexes =
+    `MATCH (n:Molecule {id: $id})<-[r]-(m)
+    WHERE r.component = [] AND r.sourceComplex = '' AND r.targetComplex = ''
+    RETURN n, r, m
+    UNION
+    MATCH (n:Molecule {id: $id})-[r]->(m)
+    WHERE r.component = [] AND r.sourceComplex = '' AND r.targetComplex = ''
+    RETURN n, r, m`;
+
 export const returnGene =
     `MATCH (n {id: $id}) 
     RETURN n`;

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -17,12 +17,6 @@ export const makeEdgeQuery =
     r.pmid = $pmid,
     r.articleTitle = $articleTitle`;
 
-export const makeComplexEdgeQuery = 
-    `MATCH (x:Molecule {id: $sourceId})
-    MATCH (y:Molecule {id: $targetId})
-    MERGE (x)-[r:COMPLEX {id: $id}]->(y)
-    ON CREATE SET r.allParticipants = $allParticipants`;
-
 export const giveConnectedInfoByGeneId =
     `MATCH (n:Molecule {id: $id})<-[r]-(m)
     RETURN n, r, m

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -1,10 +1,10 @@
 export const makeNodeQuery =
-    `MERGE (n:Molecule {id: $id})
+    `MERGE (n:Entity {id: $id})
     ON CREATE SET n.name = $name`;
 
 export const makeEdgeQuery =
-    `MATCH (x:Molecule {id: $sourceId})
-    MATCH (y:Molecule {id: $targetId})
+    `MATCH (x:Entity {id: $sourceId})
+    MATCH (y:Entity {id: $targetId})
     MERGE (x)-[r:INTERACTION {id: $id}]->(y)
     ON CREATE SET r.type = $type,
     r.component = $component,
@@ -18,18 +18,18 @@ export const makeEdgeQuery =
     r.articleTitle = $articleTitle`;
 
 export const giveConnectedInfoByGeneId =
-    `MATCH (n:Molecule {id: $id})<-[r]-(m)
+    `MATCH (n:Entity {id: $id})<-[r]-(m)
     RETURN n, r, m
     UNION
-    MATCH (n:Molecule {id: $id})-[r]->(m)
+    MATCH (n:Entity {id: $id})-[r]->(m)
     RETURN n, r, m`;
 
 export const giveConnectedInfoByGeneIdNoComplexes =
-    `MATCH (n:Molecule {id: $id})<-[r]-(m)
+    `MATCH (n:Entity {id: $id})<-[r]-(m)
     WHERE r.component = [] AND r.sourceComplex = '' AND r.targetComplex = ''
     RETURN n, r, m
     UNION
-    MATCH (n:Molecule {id: $id})-[r]->(m)
+    MATCH (n:Entity {id: $id})-[r]->(m)
     WHERE r.component = [] AND r.sourceComplex = '' AND r.targetComplex = ''
     RETURN n, r, m`;
 


### PR DESCRIPTION
#1153 

### Currently:

We have one search function called `neighbourhood( id )` that takes the `id` of an entity (ex. 'ncbigene:207') as a parameter and returns `null` if the entity does not exist in the database, otherwise it will return an object with two fields:

- list of all edges connected to that entity
- list all entities that are connected to that entity via one edge

### Task:
Make a function like `neighbourhood`, except it has an extra parameter, `includeComplexes`. If `includeComplexes` is  true, return as usual. Otherwise, do NOT include: 
- edges that represent complexes
- neighbouring nodes that are only neighbours because they are apart of a complex
- interactions that would be returned because the node that is being searched is apart of a complex