### PR TITLE
Neo4j: Add get(id) function

### DIFF
--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -197,12 +197,44 @@ describe('04. Tests for search functions', function () {
 
   it('Search for Goult 4 document', async function () {
     const doc4Id = 'a48ccff1-e647-462d-89fd-fb323f3410f3';
+    const results = await get(doc4Id);
 
+    const nodes = _.uniqBy(results.map(row => {
+      return row.get('n').properties;
+    }), edge => edge.id);
+    expect(nodes.length).to.equal(4);
+    expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
+
+    const edges = _.uniqBy(results.map(row => {
+      return row.get('r').properties;
+    }), edge => edge.id);
+    expect(edges.length).to.equal(4);
+    expect(_.find(edges, { id: 'e56263d8-d5b6-4812-bc2f-8d905a66f0f9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
+    expect(_.find(edges, { id: '013b7e2a-7240-4668-b628-2653c60f47e9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
+    expect(_.find(edges, { id: '5a374667-a51d-4aa3-bf93-526fe203b04e', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
+    expect(_.find(edges, { id: '651326eb-3d90-40be-a8d7-2ece04e82226', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
   });
 
   it('Search for Goult 5 document', async function () {
     const doc5Id = '63008749-2c2b-4863-8e73-386c851feb6a';
+    const results = await get(doc5Id);
 
+    const nodes = _.uniqBy(results.map(row => {
+      return row.get('n').properties;
+    }), edge => edge.id);
+    expect(nodes.length).to.equal(2);
+    expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:983', name: 'CDK1' })).to.be.not.undefined;
+
+    const edges = _.uniqBy(results.map(row => {
+      return row.get('r').properties;
+    }), edge => edge.id);
+    expect(edges.length).to.equal(2);
+    expect(_.find(edges, { id: '3e7c85db-c2a3-4a1f-b96e-6d187c6ab93b', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
+    expect(_.find(edges, { id: 'e39d0a06-5b02-44e3-9c36-27cc1f9ac08c', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
   });
 
 });

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -152,12 +152,47 @@ describe('04. Tests for search functions', function () {
 
   it('Search for Goult 2 document', async function () {
     const doc2Id = 'de1b09bf-0104-4d9e-a862-a3bb91d6aade';
+    const results = await get(doc2Id);
 
+    const nodes = _.uniqBy(results.map(row => {
+      return row.get('n').properties;
+    }), edge => edge.id);
+    expect(nodes.length).to.equal(3);
+    expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:10395', name: 'DLC1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:5829', name: 'PXN' })).to.be.not.undefined;
+
+    const edges = _.uniqBy(results.map(row => {
+      return row.get('r').properties;
+    }), edge => edge.id);
+    expect(edges.length).to.equal(2);
+    expect(_.find(edges, { id: '028e7366-9779-4466-96ea-18a45bfe3f38', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
+    expect(_.find(edges, { id: '80a4d403-8bc1-4ddb-a4f9-5227e87ef6fa', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
   });
 
   it('Search for Goult 3 document', async function () {
     const doc3Id = '65781dc0-4605-4887-a6dd-d13ae63cd9ba';
+    const results = await get(doc3Id);
 
+    const nodes = _.uniqBy(results.map(row => {
+      return row.get('n').properties;
+    }), edge => edge.id);
+    expect(nodes.length).to.equal(5);
+    expect(_.find(nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
+
+    const edges = _.uniqBy(results.map(row => {
+      return row.get('r').properties;
+    }), edge => edge.id);
+    expect(edges.length).to.equal(5);
+    expect(_.find(edges, { id: 'd5d9fbcc-a1d9-4026-b1d3-d4a97faff36b', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(edges, { id: '13ab91d1-ee5f-46ca-a1ea-82ce72a938f4', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(edges, { id: 'd7b2a15d-43bf-4494-815b-a77e08cea59c', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(edges, { id: 'eec84ebe-eece-4143-b406-cd99cdbe2e43', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(edges, { id: 'e59c16c4-11e8-4755-8e2f-f88fe4a73b30', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
   });
 
   it('Search for Goult 4 document', async function () {

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { loadDoc } from '../src/server/routes/api/document/index.js';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
-import { neighbourhood, getInteractions, getNeighbouringNodes } from '../src/neo4j/neo4j-functions.js';
+import { neighbourhood, getInteractions, getNeighbouringNodes, get } from '../src/neo4j/neo4j-functions.js';
 import { addDocumentToNeo4j } from '../src/neo4j/neo4j-document.js';
 import { deleteAllNodesAndEdges } from '../src/neo4j/test-functions.js';
 
@@ -125,6 +125,49 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
+  });
+
+  it('Search for document that does not exist', async function () {
+    const nonDocId = 'a896d611-affe-4b45-a5e1-9bc560ffceab';
+    expect(await get(nonDocId)).to.be.null;
+  });
+
+  it('Search for Goult 1 document', async function () {
+    const doc1Id = 'df9348dc-2126-45ff-a379-138b5589bcc8';
+    const results = await get(doc1Id);
+
+    const nodes = _.uniqBy(results.map(row => {
+      return row.get('n').properties;
+    }), edge => edge.id);
+    expect(nodes.length).to.equal(2);
+    expect(_.find(nodes, { id: 'ncbigene:55612', name: 'FERMT1' })).to.be.not.undefined;
+    expect(_.find(nodes, { id: 'ncbigene:1956', name: 'EGFR' })).to.be.not.undefined;
+
+    const edges = _.uniqBy(results.map(row => {
+      return row.get('r').properties;
+    }), edge => edge.id);
+    expect(edges.length).to.equal(1);
+    expect(_.find(edges, { id: 'f4b557ff-2219-45a8-bffb-5b7691e6b6bd', doi: '10.1016/j.jid.2018.08.020' })).to.be.not.undefined;
+  });
+
+  it('Search for Goult 2 document', async function () {
+    const doc2Id = 'de1b09bf-0104-4d9e-a862-a3bb91d6aade';
+
+  });
+
+  it('Search for Goult 3 document', async function () {
+    const doc3Id = '65781dc0-4605-4887-a6dd-d13ae63cd9ba';
+
+  });
+
+  it('Search for Goult 4 document', async function () {
+    const doc4Id = 'a48ccff1-e647-462d-89fd-fb323f3410f3';
+
+  });
+
+  it('Search for Goult 5 document', async function () {
+    const doc5Id = '63008749-2c2b-4863-8e73-386c851feb6a';
+
   });
 
 });

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -21,8 +21,6 @@ export async function addNode(id, name) {
                 name: name
             });
         });
-    } catch (error) {
-        throw error;
     } finally {
         await session.close();
     }
@@ -61,8 +59,6 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
                 articleTitle: articleTitle
             });
         });
-    } catch (error) {
-        throw error;
     } finally {
         await session.close();
     }
@@ -88,8 +84,6 @@ export async function neighbourhood(id) {
         } else {
             record = null;
         }
-    } catch (error) {
-        throw error;
     } finally {
         await session.close();
     }
@@ -138,8 +132,6 @@ export async function neighbourhoodWithoutComplexes(id) {
         } else {
             record = null;
         }
-    } catch (error) {
-        throw error;
     } finally {
         await session.close();
     }
@@ -166,8 +158,6 @@ export async function get(id) { // UNTESTED
         } else {
             record = null;
         }
-    } catch (error) {
-        throw error;
     } finally {
         await session.close();
     }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -5,6 +5,8 @@ import {
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
 
+const dbName = 'neo4j';
+
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
  * @param { String } name 
@@ -14,7 +16,7 @@ export async function addNode(id, name) {
     const driver = getDriver();
     let session;
     try {
-        session = driver.session({ database: "neo4j" });
+        session = driver.session({ database: dbName });
         await session.executeWrite(tx => {
             return tx.run(makeNodeQuery, {
                 id: id.toLowerCase(),
@@ -43,7 +45,7 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
     const driver = getDriver();
     let session;
     try {
-        session = driver.session({ database: "neo4j" });
+        session = driver.session({ database: dbName });
         await session.executeWrite(tx => {
             return tx.run(makeEdgeQuery, {
                 id: id.toLowerCase(),
@@ -75,7 +77,7 @@ export async function neighbourhood(id) {
     let session;
     let record;
     try {
-        session = driver.session({ database: "neo4j" });
+        session = driver.session({ database: dbName });
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneId, { id: id });
         });
@@ -123,7 +125,7 @@ export async function neighbourhoodWithoutComplexes(id) {
     let session;
     let record;
     try {
-        session = driver.session({ database: "neo4j" });
+        session = driver.session({ database: dbName });
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
         });
@@ -149,7 +151,7 @@ export async function get(id) { // UNTESTED
     let session;
     let record;
     try {
-        session = driver.session({ database: "neo4j" });
+        session = driver.session({ database: dbName });
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoForDocument, { id: id });
         });

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -1,4 +1,7 @@
-import { giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery, giveConnectedInfoByGeneIdNoComplexes } from './query-strings';
+import {
+    giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery,
+    giveConnectedInfoByGeneIdNoComplexes, giveConnectedInfoForDocument
+} from './query-strings';
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
 
@@ -68,7 +71,8 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
 
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
- * @returns An object with 2 fields: relationships (array) and neighbouring nodes (array) or null
+ * @returns null if node not in database, array of objects with
+ * fields for the nodes and edges otherwise
  */
 export async function neighbourhood(id) {
     const driver = getDriver();
@@ -128,6 +132,34 @@ export async function neighbourhoodWithoutComplexes(id) {
         session = driver.session({ database: "neo4j" });
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
+        });
+        if (result.records.length > 0) {
+            record = result.records;
+        } else {
+            record = null;
+        }
+    } catch (error) {
+        throw error;
+    } finally {
+        await session.close();
+    }
+    return record;
+}
+
+/**
+ * Get the graph pertaining to a specific factoid document
+ * @param { String } id factoid UUID for document
+ * @returns null if document does not exist in database, array of objects with
+ * fields for the nodes and edges otherwise
+ */
+export async function get(id) { // UNTESTED
+    const driver = getDriver();
+    let session;
+    let record;
+    try {
+        session = driver.session({ database: "neo4j" });
+        let result = await session.executeRead(tx => {
+            return tx.run(giveConnectedInfoForDocument, { id: id });
         });
         if (result.records.length > 0) {
             record = result.records;

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -33,6 +33,13 @@ export const giveConnectedInfoByGeneIdNoComplexes =
     WHERE r.component = [] AND r.sourceComplex = '' AND r.targetComplex = ''
     RETURN n, r, m`;
 
+export const giveConnectedInfoForDocument =
+    `MATCH (n)<-[r {xref: $id}]-(m)
+    RETURN n, r, m
+    UNION
+    MATCH (n)-[r {xref: $id}]->(m)
+    RETURN n, r, m`;
+
 export const returnGene =
     `MATCH (n {id: $id}) 
     RETURN n`;


### PR DESCRIPTION
#1153 

### Goal: 
`get( id )` where uuid is the factoid document uuid. And this will return an object that contains two fields for the nodes/edges relevant to that document. In the Neo4j Browser (`localhost:7687`) this would show the desired graph in ball-and-stick form.

### Demo:

`get( 'a48ccff1-e647-462d-89fd-fb323f3410f3')` runs the following cypher query:
```
MATCH (n)<-[r {xref: 'a48ccff1-e647-462d-89fd-fb323f3410f3'}]-(m)
RETURN n, r, m
UNION
MATCH (n)-[r {xref: 'a48ccff1-e647-462d-89fd-fb323f3410f3'}]->(m)
RETURN n, r, m
```

And this is what it looks like in Neo4j Browser (if the document we're looking for is indeed in the Neo4j database)

![Screen Shot 2023-04-03 at 1 29 23 PM](https://user-images.githubusercontent.com/66929920/229583783-5f402c8a-0b4f-4669-a921-c0a157b152f9.png)

Verus the document in Biofactoid
![Screen Shot 2023-04-03 at 1 30 48 PM](https://user-images.githubusercontent.com/66929920/229584025-40999da6-2b22-43d0-8142-4330c7196089.png)

