### PR TITLE
Neo4j: Update the search functions

### DIFF
--- a/neo4j-test/doc-tests-complex.js
+++ b/neo4j-test/doc-tests-complex.js
@@ -7,7 +7,7 @@ import { loadDoc } from '../src/server/routes/api/document/index.js';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
 import { addDocumentToNeo4j, convertUUIDtoId } from '../src/neo4j/neo4j-document.js';
 import { deleteAllNodesAndEdges, getGeneName, getNumNodes, getNumEdges, getEdge, getEdgeByIdAndEndpoints } from '../src/neo4j/test-functions.js';
-import { neighbourhoodWithoutComplexes } from '../src/neo4j/neo4j-functions.js';
+import { neighbourhood } from '../src/neo4j/neo4j-functions.js';
 
 import complex1 from './document/complex_tests_1.json';
 import complex2 from './document/complex_tests_2.json';
@@ -94,8 +94,8 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge1.properties.pmid).to.equal(myDoc.citation().pmid);
     expect(edge1.properties.articleTitle).to.equal(myDoc.citation().title);
 
-    expect(await neighbourhoodWithoutComplexes('ncbigene:22882')).to.be.null;
-    expect(await neighbourhoodWithoutComplexes('ncbigene:3091')).to.be.null;
+    expect(await neighbourhood('ncbigene:22882', false)).to.be.null;
+    expect(await neighbourhood('ncbigene:3091', false)).to.be.null;
   });
 
   it('Three nodes in one complex, edges between them', async function () {
@@ -169,7 +169,7 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge3.properties.sourceComplex).to.equal('');
     expect(edge3.properties.targetComplex).to.equal('');
 
-    let record = await neighbourhoodWithoutComplexes('ncbigene:3303');
+    let record = await neighbourhood('ncbigene:3303', false);
     let testNodes = record.map(row => row.get('m').properties);
     expect(testNodes.length).to.equal(2);
     expect(_.find(testNodes, { id: 'ncbigene:7157' })).to.be.not.undefined;
@@ -179,7 +179,7 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(_.find(testEdges, { id: 'b6e4c90d-4870-4c64-8abf-b6e16b0738f7' })).to.be.not.undefined;
     expect(_.find(testEdges, { id: '7ba76f35-faaa-4622-ae37-5aff0d802eed' })).to.be.not.undefined;
 
-    record = await neighbourhoodWithoutComplexes('ncbigene:7157');
+    record = await neighbourhood('ncbigene:7157', false);
     testNodes = record.map(row => row.get('m').properties);
     expect(_.find(testNodes, { id: 'ncbigene:3303' })).to.be.not.undefined;
     expect(_.find(testNodes, { id: 'ncbigene:3326' })).to.be.not.undefined;
@@ -189,7 +189,7 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(_.find(testEdges, { id: 'b6e4c90d-4870-4c64-8abf-b6e16b0738f7' })).to.be.not.undefined;
     expect(_.find(testEdges, { id: 'eb40318c-9a0e-45f6-a81e-21836fd9e9e3' })).to.be.not.undefined;
 
-    record = await neighbourhoodWithoutComplexes('ncbigene:3326');
+    record = await neighbourhood('ncbigene:3326', false);
     testNodes = record.map(row => row.get('m').properties);
     expect(testNodes.length).to.equal(2);
     expect(_.find(testNodes, { id: 'ncbigene:7157' })).to.be.not.undefined;
@@ -257,7 +257,7 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge1.properties.sourceComplex).to.equal('');
     expect(edge1.properties.targetComplex).to.equal('');
 
-    const record = await neighbourhoodWithoutComplexes('ncbigene:27173');
+    const record = await neighbourhood('ncbigene:27173', false);
     const testNodes = record.map(row => row.get('m').properties);
     expect(testNodes.length).to.equal(1);
     expect(_.find(testNodes, { id: 'ncbigene:10059' })).to.be.not.undefined;
@@ -331,7 +331,7 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(edge2.properties.sourceComplex).to.equal('');
     expect(edge2.properties.targetComplex).to.equal('');
 
-    let record = await neighbourhoodWithoutComplexes('ncbigene:55215');
+    let record = await neighbourhood('ncbigene:55215', false);
     let testNodes = record.map(row => row.get('m').properties);
     expect(testNodes.length).to.equal(1);
     expect(_.find(testNodes, { id: 'ncbigene:57599' })).to.be.not.undefined;
@@ -339,7 +339,7 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(testEdges.length).to.equal(1);
     expect(_.find(testEdges, { id: 'b38116a2-5002-48b0-b156-32bcbff764a4' })).to.be.not.undefined;
 
-    record = await neighbourhoodWithoutComplexes('ncbigene:7398');
+    record = await neighbourhood('ncbigene:7398', false);
     testNodes = record.map(row => row.get('m').properties);
     expect(testNodes.length).to.equal(1);
     expect(_.find(testNodes, { id: 'ncbigene:2177' })).to.be.not.undefined;
@@ -401,9 +401,9 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(interactionEdge2.properties.sourceComplex).to.equal(complexId1);
     expect(interactionEdge2.properties.targetComplex).to.equal('');
 
-    expect(await neighbourhoodWithoutComplexes('ncbigene:11335')).to.be.null;
-    expect(await neighbourhoodWithoutComplexes('ncbigene:648791')).to.be.null;
-    expect(await neighbourhoodWithoutComplexes('ncbigene:8737')).to.be.null;
+    expect(await neighbourhood('ncbigene:11335', false)).to.be.null;
+    expect(await neighbourhood('ncbigene:648791', false)).to.be.null;
+    expect(await neighbourhood('ncbigene:8737', false)).to.be.null;
   });
 
   it('One complex interacting with another complex', async function () {
@@ -524,9 +524,9 @@ describe('05. Tests for Documents with Complexes', function () {
     expect(interactionEdge6.properties.sourceComplex).to.equal(complexId1);
     expect(interactionEdge6.properties.targetComplex).to.equal(complexId2);
 
-    expect(await neighbourhoodWithoutComplexes('ncbigene:9474')).to.be.null;
+    expect(await neighbourhood('ncbigene:9474', false)).to.be.null;
 
-    const record = await neighbourhoodWithoutComplexes('ncbigene:64112');
+    const record = await neighbourhood('ncbigene:64112', false);
     const testNodes = record.map(row => row.get('m').properties);
     expect(testNodes.length).to.equal(1);
     expect(_.find(testNodes, { id: 'ncbigene:84557' })).to.not.be.undefined;

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -179,16 +179,12 @@ describe('04. Tests for search functions', function () {
     const doc1Id = 'df9348dc-2126-45ff-a379-138b5589bcc8';
     const results = await get(doc1Id);
 
-    const nodes = _.uniqBy(results.map(row => {
-      return row.get('n').properties;
-    }), edge => edge.id);
+    const nodes = results.nodes;
     expect(nodes.length).to.equal(2);
     expect(_.find(nodes, { id: 'ncbigene:55612', name: 'FERMT1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:1956', name: 'EGFR' })).to.be.not.undefined;
 
-    const edges = _.uniqBy(results.map(row => {
-      return row.get('r').properties;
-    }), edge => edge.id);
+    const edges = results.edges;
     expect(edges.length).to.equal(1);
     expect(_.find(edges, { id: 'f4b557ff-2219-45a8-bffb-5b7691e6b6bd', doi: '10.1016/j.jid.2018.08.020' })).to.be.not.undefined;
   });
@@ -197,17 +193,13 @@ describe('04. Tests for search functions', function () {
     const doc2Id = 'de1b09bf-0104-4d9e-a862-a3bb91d6aade';
     const results = await get(doc2Id);
 
-    const nodes = _.uniqBy(results.map(row => {
-      return row.get('n').properties;
-    }), edge => edge.id);
+    const nodes = results.nodes;
     expect(nodes.length).to.equal(3);
     expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:10395', name: 'DLC1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:5829', name: 'PXN' })).to.be.not.undefined;
 
-    const edges = _.uniqBy(results.map(row => {
-      return row.get('r').properties;
-    }), edge => edge.id);
+    const edges = results.edges;
     expect(edges.length).to.equal(2);
     expect(_.find(edges, { id: '028e7366-9779-4466-96ea-18a45bfe3f38', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
     expect(_.find(edges, { id: '80a4d403-8bc1-4ddb-a4f9-5227e87ef6fa', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
@@ -217,9 +209,7 @@ describe('04. Tests for search functions', function () {
     const doc3Id = '65781dc0-4605-4887-a6dd-d13ae63cd9ba';
     const results = await get(doc3Id);
 
-    const nodes = _.uniqBy(results.map(row => {
-      return row.get('n').properties;
-    }), edge => edge.id);
+    const nodes = results.nodes;
     expect(nodes.length).to.equal(5);
     expect(_.find(nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
@@ -227,9 +217,7 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
 
-    const edges = _.uniqBy(results.map(row => {
-      return row.get('r').properties;
-    }), edge => edge.id);
+    const edges = results.edges;
     expect(edges.length).to.equal(5);
     expect(_.find(edges, { id: 'd5d9fbcc-a1d9-4026-b1d3-d4a97faff36b', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
     expect(_.find(edges, { id: '13ab91d1-ee5f-46ca-a1ea-82ce72a938f4', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
@@ -242,18 +230,14 @@ describe('04. Tests for search functions', function () {
     const doc4Id = 'a48ccff1-e647-462d-89fd-fb323f3410f3';
     const results = await get(doc4Id);
 
-    const nodes = _.uniqBy(results.map(row => {
-      return row.get('n').properties;
-    }), edge => edge.id);
+    const nodes = results.nodes;
     expect(nodes.length).to.equal(4);
     expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
 
-    const edges = _.uniqBy(results.map(row => {
-      return row.get('r').properties;
-    }), edge => edge.id);
+    const edges = results.edges;
     expect(edges.length).to.equal(4);
     expect(_.find(edges, { id: 'e56263d8-d5b6-4812-bc2f-8d905a66f0f9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
     expect(_.find(edges, { id: '013b7e2a-7240-4668-b628-2653c60f47e9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
@@ -265,16 +249,12 @@ describe('04. Tests for search functions', function () {
     const doc5Id = '63008749-2c2b-4863-8e73-386c851feb6a';
     const results = await get(doc5Id);
 
-    const nodes = _.uniqBy(results.map(row => {
-      return row.get('n').properties;
-    }), edge => edge.id);
+    const nodes = results.nodes;
     expect(nodes.length).to.equal(2);
     expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:983', name: 'CDK1' })).to.be.not.undefined;
 
-    const edges = _.uniqBy(results.map(row => {
-      return row.get('r').properties;
-    }), edge => edge.id);
+    const edges = results.edges;
     expect(edges.length).to.equal(2);
     expect(_.find(edges, { id: '3e7c85db-c2a3-4a1f-b96e-6d187c6ab93b', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
     expect(_.find(edges, { id: 'e39d0a06-5b02-44e3-9c36-27cc1f9ac08c', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -87,10 +87,10 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
 
     const record = await neighbourhoodReadable(kank1);
-    expect(record.neighbouringNodes.length).equal(3);
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
+    expect(record.nodes.length).equal(3);
+    expect(_.find(record.nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
 
     expect(record.edges.length).equal(3);
     expect(_.find(record.edges, { id: 'd7b2a15d-43bf-4494-815b-a77e08cea59c', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
@@ -127,12 +127,12 @@ describe('04. Tests for search functions', function () {
     expect(_.find(record.edges, { id: '3e7c85db-c2a3-4a1f-b96e-6d187c6ab93b', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
     expect(_.find(record.edges, { id: 'e39d0a06-5b02-44e3-9c36-27cc1f9ac08c', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
 
-    expect(record.neighbouringNodes.length).equal(5);
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:5829', name: 'PXN' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:983', name: 'CDK1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:10395', name: 'DLC1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
+    expect(record.nodes.length).equal(5);
+    expect(_.find(record.nodes, { id: 'ncbigene:5829', name: 'PXN' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:983', name: 'CDK1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:10395', name: 'DLC1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
   });
 
   it('Search for TLNRD1', async function () {
@@ -162,12 +162,12 @@ describe('04. Tests for search functions', function () {
     expect(_.find(record.edges, { id: 'eec84ebe-eece-4143-b406-cd99cdbe2e43', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
     expect(_.find(record.edges, { id: 'e59c16c4-11e8-4755-8e2f-f88fe4a73b30', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
 
-    expect(record.neighbouringNodes.length).equal(5);
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
-    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
+    expect(record.nodes.length).equal(5);
+    expect(_.find(record.nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
+    expect(_.find(record.nodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
   });
 
   it('Search for document that does not exist', async function () {

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -5,7 +5,7 @@ import _ from 'lodash';
 
 import { loadDoc } from '../src/server/routes/api/document/index.js';
 import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
-import { neighbourhood, getInteractions, getNeighbouringNodes, get } from '../src/neo4j/neo4j-functions.js';
+import { neighbourhood, neighbourhoodReadable, getInteractions, getNeighbouringNodes, get } from '../src/neo4j/neo4j-functions.js';
 import { addDocumentToNeo4j } from '../src/neo4j/neo4j-document.js';
 import { deleteAllNodesAndEdges } from '../src/neo4j/test-functions.js';
 
@@ -66,6 +66,7 @@ describe('04. Tests for search functions', function () {
   it('Search for MAPK6', async function () {
     let mapk6 = 'ncbigene:5597';
     expect(await neighbourhood(mapk6)).to.be.null;
+    expect(await neighbourhoodReadable(mapk6)).to.be.null;
     expect(await getInteractions(mapk6)).to.be.null;
     expect(await getNeighbouringNodes(mapk6)).to.be.null;
   });
@@ -84,6 +85,17 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
+
+    let record = await neighbourhoodReadable(kank1);
+    expect(record.neighbouringNodes.length).equal(3);
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
+
+    expect(record.edges.length).equal(3);
+    expect(_.find(record.edges, { id: 'd7b2a15d-43bf-4494-815b-a77e08cea59c', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: 'e56263d8-d5b6-4812-bc2f-8d905a66f0f9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: '5a374667-a51d-4aa3-bf93-526fe203b04e', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
   });
 
   it('Search for TLN1', async function () {
@@ -105,6 +117,22 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:10395', name: 'DLC1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
+
+    let record = await neighbourhoodReadable(tln1);
+    expect(record.edges.length).equal(6);
+    expect(_.find(record.edges, { id: '028e7366-9779-4466-96ea-18a45bfe3f38', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: '80a4d403-8bc1-4ddb-a4f9-5227e87ef6fa', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: 'e56263d8-d5b6-4812-bc2f-8d905a66f0f9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: '013b7e2a-7240-4668-b628-2653c60f47e9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: '3e7c85db-c2a3-4a1f-b96e-6d187c6ab93b', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: 'e39d0a06-5b02-44e3-9c36-27cc1f9ac08c', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
+
+    expect(record.neighbouringNodes.length).equal(5);
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:5829', name: 'PXN' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:983', name: 'CDK1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:10395', name: 'DLC1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
   });
 
   it('Search for TLNRD1', async function () {
@@ -125,6 +153,21 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
+
+    let record = await neighbourhoodReadable(tlnrd1);
+    expect(record.edges.length).equal(5);
+    expect(_.find(record.edges, { id: 'd5d9fbcc-a1d9-4026-b1d3-d4a97faff36b', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: '13ab91d1-ee5f-46ca-a1ea-82ce72a938f4', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: 'd7b2a15d-43bf-4494-815b-a77e08cea59c', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: 'eec84ebe-eece-4143-b406-cd99cdbe2e43', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+    expect(_.find(record.edges, { id: 'e59c16c4-11e8-4755-8e2f-f88fe4a73b30', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
+
+    expect(record.neighbouringNodes.length).equal(5);
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:60', name: 'ACTB' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
+    expect(_.find(record.neighbouringNodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
   });
 
   it('Search for document that does not exist', async function () {

--- a/neo4j-test/search-tests.js
+++ b/neo4j-test/search-tests.js
@@ -64,7 +64,7 @@ describe('04. Tests for search functions', function () {
   });
 
   it('Search for MAPK6', async function () {
-    let mapk6 = 'ncbigene:5597';
+    const mapk6 = 'ncbigene:5597';
     expect(await neighbourhood(mapk6)).to.be.null;
     expect(await neighbourhoodReadable(mapk6)).to.be.null;
     expect(await getInteractions(mapk6)).to.be.null;
@@ -72,21 +72,21 @@ describe('04. Tests for search functions', function () {
   });
 
   it('Search for KANK1', async function () {
-    let kank1 = 'ncbigene:23189';
+    const kank1 = 'ncbigene:23189';
     expect(await neighbourhood(kank1)).to.not.be.null;
-    let edges = await getInteractions(kank1);
+    const edges = await getInteractions(kank1);
     expect(edges.length).equal(3);
     expect(_.find(edges, { id: 'd7b2a15d-43bf-4494-815b-a77e08cea59c', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
     expect(_.find(edges, { id: 'e56263d8-d5b6-4812-bc2f-8d905a66f0f9', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
     expect(_.find(edges, { id: '5a374667-a51d-4aa3-bf93-526fe203b04e', doi: '10.7554/eLife.18124' })).to.be.not.undefined;
 
-    let nodes = await getNeighbouringNodes(kank1);
+    const nodes = await getNeighbouringNodes(kank1);
     expect(nodes.length).equal(3);
     expect(_.find(nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:83660', name: 'TLN2' })).to.be.not.undefined;
 
-    let record = await neighbourhoodReadable(kank1);
+    const record = await neighbourhoodReadable(kank1);
     expect(record.neighbouringNodes.length).equal(3);
     expect(_.find(record.neighbouringNodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
     expect(_.find(record.neighbouringNodes, { id: 'ncbigene:7094', name: 'TLN1' })).to.be.not.undefined;
@@ -99,9 +99,9 @@ describe('04. Tests for search functions', function () {
   });
 
   it('Search for TLN1', async function () {
-    let tln1 = 'ncbigene:7094';
+    const tln1 = 'ncbigene:7094';
     expect(await neighbourhood(tln1)).to.not.be.null;
-    let edges = await getInteractions(tln1);
+    const edges = await getInteractions(tln1);
     expect(edges.length).equal(6);
     expect(_.find(edges, { id: '028e7366-9779-4466-96ea-18a45bfe3f38', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
     expect(_.find(edges, { id: '80a4d403-8bc1-4ddb-a4f9-5227e87ef6fa', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
@@ -110,7 +110,7 @@ describe('04. Tests for search functions', function () {
     expect(_.find(edges, { id: '3e7c85db-c2a3-4a1f-b96e-6d187c6ab93b', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
     expect(_.find(edges, { id: 'e39d0a06-5b02-44e3-9c36-27cc1f9ac08c', doi: '10.1016/j.jbc.2021.100837' })).to.be.not.undefined;
 
-    let nodes = await getNeighbouringNodes(tln1);
+    const nodes = await getNeighbouringNodes(tln1);
     expect(nodes.length).equal(5);
     expect(_.find(nodes, { id: 'ncbigene:5829', name: 'PXN' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:983', name: 'CDK1' })).to.be.not.undefined;
@@ -118,7 +118,7 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:25959', name: 'KANK2' })).to.be.not.undefined;
 
-    let record = await neighbourhoodReadable(tln1);
+    const record = await neighbourhoodReadable(tln1);
     expect(record.edges.length).equal(6);
     expect(_.find(record.edges, { id: '028e7366-9779-4466-96ea-18a45bfe3f38', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
     expect(_.find(record.edges, { id: '80a4d403-8bc1-4ddb-a4f9-5227e87ef6fa', doi: '10.1016/j.str.2016.04.016' })).to.be.not.undefined;
@@ -136,9 +136,9 @@ describe('04. Tests for search functions', function () {
   });
 
   it('Search for TLNRD1', async function () {
-    let tlnrd1 = 'ncbigene:59274';
+    const tlnrd1 = 'ncbigene:59274';
     expect(await neighbourhood(tlnrd1)).to.not.be.null;
-    let edges = await getInteractions(tlnrd1);
+    const edges = await getInteractions(tlnrd1);
     expect(edges.length).equal(5);
     expect(_.find(edges, { id: 'd5d9fbcc-a1d9-4026-b1d3-d4a97faff36b', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
     expect(_.find(edges, { id: '13ab91d1-ee5f-46ca-a1ea-82ce72a938f4', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
@@ -146,7 +146,7 @@ describe('04. Tests for search functions', function () {
     expect(_.find(edges, { id: 'eec84ebe-eece-4143-b406-cd99cdbe2e43', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
     expect(_.find(edges, { id: 'e59c16c4-11e8-4755-8e2f-f88fe4a73b30', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
 
-    let nodes = await getNeighbouringNodes(tlnrd1);
+    const nodes = await getNeighbouringNodes(tlnrd1);
     expect(nodes.length).equal(5);
     expect(_.find(nodes, { id: 'ncbigene:59274', name: 'TLNRD1' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:23189', name: 'KANK1' })).to.be.not.undefined;
@@ -154,7 +154,7 @@ describe('04. Tests for search functions', function () {
     expect(_.find(nodes, { id: 'ncbigene:54518', name: 'APBB1IP' })).to.be.not.undefined;
     expect(_.find(nodes, { id: 'ncbigene:65059', name: 'RAPH1' })).to.be.not.undefined;
 
-    let record = await neighbourhoodReadable(tlnrd1);
+    const record = await neighbourhoodReadable(tlnrd1);
     expect(record.edges.length).equal(5);
     expect(_.find(record.edges, { id: 'd5d9fbcc-a1d9-4026-b1d3-d4a97faff36b', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;
     expect(_.find(record.edges, { id: '13ab91d1-ee5f-46ca-a1ea-82ce72a938f4', doi: '10.1083/jcb.202005214' })).to.be.not.undefined;

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -72,14 +72,18 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
  * @returns null if node not in database, array of objects with
  * fields for the nodes and edges otherwise
  */
-export async function neighbourhood(id) {
+export async function neighbourhood(id, withComplexes = true) {
     const driver = getDriver();
     let session;
     let record;
     try {
         session = driver.session({ database: dbName });
         let result = await session.executeRead(tx => {
-            return tx.run(giveConnectedInfoByGeneId, { id: id });
+            if (withComplexes) {
+                return tx.run(giveConnectedInfoByGeneId, { id: id });
+            } else {
+                return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
+            }
         });
         if (result.records.length > 0) {
             record = result.records;
@@ -146,7 +150,7 @@ export async function neighbourhoodWithoutComplexes(id) {
  * @returns null if document does not exist in database, array of objects with
  * fields for the nodes and edges otherwise
  */
-export async function get(id) { // UNTESTED
+export async function get(id) {
     const driver = getDriver();
     let session;
     let record;

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -147,8 +147,8 @@ export async function neighbourhoodReadable(id, withComplexes = true) {
 /**
  * Get the graph pertaining to a specific factoid document
  * @param { String } id factoid UUID for document
- * @returns null if document does not exist in database, array of objects with
- * fields for the nodes and edges otherwise
+ * @returns null if document does not exist in database, object with 2 fields (one for nodes and one for
+ * edges) otherwise
  */
 export async function get(id) {
     const driver = getDriver();

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -137,7 +137,7 @@ export async function neighbourhoodReadable(id, withComplexes = true) {
     let record = await neighbourhood(id, withComplexes);
     if (record) {
         return {
-            neighbouringNodes: _.uniqBy(record.map(row => { return row.get('m').properties; }), edge => edge.id),
+            nodes: _.uniqBy(record.map(row => { return row.get('m').properties; }), edge => edge.id),
             edges: record.map(row => { return row.get('r').properties; })
         };
     }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -160,7 +160,12 @@ export async function get(id) {
             return tx.run(giveConnectedInfoForDocument, { id: id });
         });
         if (result.records.length > 0) {
-            record = result.records;
+            record = {
+                nodes: _.unionBy(result.records.map(row => { return row.get('n').properties; }),
+                    result.records.map(row => { return row.get('m').properties; }),
+                    node => node.id),
+                edges: result.records.map(row => { return row.get('r').properties; })
+            };
         } else {
             record = null;
         }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -120,15 +120,26 @@ export async function getNeighbouringNodes(id, withComplexes = true) {
 export async function getInteractions(id, withComplexes = true) {
     let record = await neighbourhood(id, withComplexes);
     if (record) {
-        if (withComplexes) {
-            return _.uniqBy(record.map(row => {
-                return row.get('r').properties;
-            }), edge => edge.id);
-        } else {
-            return record.map(row => {
-                return row.get('r').properties;
-            });
-        }
+        return record.map(row => {
+            return row.get('r').properties;
+        });
+    }
+    return null;
+}
+
+/**
+ * @param {*} id in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { Boolean } withComplexes default true to show complexes
+ * @returns null if id not found in database, object with 2 fields (one for neighbouring nodes and one for
+ * edges) otherwise
+ */
+export async function neighbourhoodReadable(id, withComplexes = true) {
+    let record = await neighbourhood(id, withComplexes);
+    if (record) {
+        return {
+            neighbouringNodes: _.uniqBy(record.map(row => { return row.get('m').properties; }), edge => edge.id),
+            edges: record.map(row => { return row.get('r').properties; })
+        };
     }
     return null;
 }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -99,28 +99,36 @@ export async function neighbourhood(id, withComplexes = true) {
 
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { Boolean } withComplexes default true to show complexes
  * @returns an array of nodes that are neighbours to the specified gene
  */
-export async function getNeighbouringNodes(id) {
-    let record = await neighbourhood(id);
+export async function getNeighbouringNodes(id, withComplexes = true) {
+    let record = await neighbourhood(id, withComplexes);
     if (record) {
         return _.uniqBy(record.map(row => {
             return row.get('m').properties;
-        }), node => node.id);
+        }), edge => edge.id);
     }
     return null;
 }
 
 /**
  * @param {*} id in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { Boolean } withComplexes default true to show complexes
  * @returns an array of relationships leading away from/leading to the specified gene
  */
-export async function getInteractions(id) {
-    let record = await neighbourhood(id);
+export async function getInteractions(id, withComplexes = true) {
+    let record = await neighbourhood(id, withComplexes);
     if (record) {
-        return _.uniqBy(record.map(row => {
-            return row.get('r').properties;
-        }), edge => edge.id);
+        if (withComplexes) {
+            return _.uniqBy(record.map(row => {
+                return row.get('r').properties;
+            }), edge => edge.id);
+        } else {
+            return record.map(row => {
+                return row.get('r').properties;
+            });
+        }
     }
     return null;
 }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -69,6 +69,7 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
 
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
+ * @param { Boolean } withComplexes default true to show complexes
  * @returns null if node not in database, array of objects with
  * fields for the nodes and edges otherwise
  */
@@ -122,26 +123,6 @@ export async function getInteractions(id) {
         }), edge => edge.id);
     }
     return null;
-}
-
-export async function neighbourhoodWithoutComplexes(id) {
-    const driver = getDriver();
-    let session;
-    let record;
-    try {
-        session = driver.session({ database: dbName });
-        let result = await session.executeRead(tx => {
-            return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
-        });
-        if (result.records.length > 0) {
-            record = result.records;
-        } else {
-            record = null;
-        }
-    } finally {
-        await session.close();
-    }
-    return record;
 }
 
 /**

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -34,10 +34,7 @@ export const giveConnectedInfoByGeneIdNoComplexes =
     RETURN n, r, m`;
 
 export const giveConnectedInfoForDocument =
-    `MATCH (n)<-[r {xref: $id}]-(m)
-    RETURN n, r, m
-    UNION
-    MATCH (n)-[r {xref: $id}]->(m)
+    `MATCH (n)-[r {xref: $id}]->(m)
     RETURN n, r, m`;
 
 export const returnGene =


### PR DESCRIPTION
#1163 

- [x] Merge `neighbourhood` and `neighbourhoodWithoutComplexes`
- [x] Make `neighbourhoodReadable`, a function that wraps around `neighbourhood` that returns data in a more user-friendly way (that is, return object with 2 fields: neighbouringNodes and edges)
- [x] Update `get` to return object with 2 fields: nodes and edges, instead of an array of objects that has three fields