### PR TITLE
neo4j driver refactoring

### DIFF
--- a/neo4j-test/fixtures.js
+++ b/neo4j-test/fixtures.js
@@ -123,6 +123,3 @@ async function writeData(data){
   await writeFile(OUT_FILE, formatJSON(data));
 }
 
-// Run this
-makeFixture().then( writeData );
-

--- a/src/config.js
+++ b/src/config.js
@@ -144,5 +144,5 @@ export const GTM_ID = env('GTM_ID', 'GTM-NV468LC');
 export const GRAPHDB_CONN = env('GRAPHDB_CONN', 'bolt://localhost:7687');
 export const GRAPHDB_USER = env('GRAPHDB_USER', undefined);
 export const GRAPHDB_PASS = env('GRAPHDB_PASS', undefined);
-export const GRAPHDB_DBNAME = env('GRAPHDB_DBNAME', 'factoid');
+export const GRAPHDB_DBNAME = env('GRAPHDB_DBNAME', 'neo4j');
 

--- a/src/neo4j/neo4j-driver.js
+++ b/src/neo4j/neo4j-driver.js
@@ -1,5 +1,6 @@
 import neo4j from 'neo4j-driver';
-import { GRAPHDB_CONN, GRAPHDB_USER, GRAPHDB_PASS } from '../config';
+import { GRAPHDB_CONN, GRAPHDB_USER, GRAPHDB_PASS, GRAPHDB_DBNAME } from '../config';
+const DEFAULT_SESSION_CONFIG = { database: GRAPHDB_DBNAME };
 
 let driver;
 
@@ -33,4 +34,15 @@ export function getDriver() {
  */
 export async function closeDriver() {
   return driver && driver.close();
+}
+
+/**
+ * Convenience function for accessing a session
+ *
+ * @param {object} sessionConfig additional configuration
+ * @returns A neo4j driver {@link https://neo4j.com/docs/api/javascript-driver/current/class/lib6/session.js~Session.html Session} instance
+ */
+export function guaranteeSession( sessionConfig = DEFAULT_SESSION_CONFIG ) {
+  if ( !driver ) initDriver();
+  return driver.session( sessionConfig );
 }

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -2,11 +2,8 @@ import {
     giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery,
     giveConnectedInfoByGeneIdNoComplexes, giveConnectedInfoForDocument
 } from './query-strings';
-import { getDriver } from './neo4j-driver';
+import { guaranteeSession } from './neo4j-driver';
 import _ from 'lodash';
-import { GRAPHDB_DBNAME } from '../config';
-
-const sessionConfig = { database: GRAPHDB_DBNAME };
 
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
@@ -14,10 +11,9 @@ const sessionConfig = { database: GRAPHDB_DBNAME };
  * @returns
  */
 export async function addNode(id, name) {
-    const driver = getDriver();
     let session;
     try {
-        session = driver.session(sessionConfig);
+        session = guaranteeSession();
         await session.executeWrite(tx => {
             return tx.run(makeNodeQuery, {
                 id: id.toLowerCase(),
@@ -43,10 +39,9 @@ export async function addNode(id, name) {
  * @returns
  */
 export async function addEdge(id, type, component, sourceId, targetId, sourceComplex, targetComplex, xref, doi, pmid, articleTitle) {
-    const driver = getDriver();
     let session;
     try {
-        session = driver.session(sessionConfig);
+        session = guaranteeSession();
         await session.executeWrite(tx => {
             return tx.run(makeEdgeQuery, {
                 id: id.toLowerCase(),
@@ -74,11 +69,10 @@ export async function addEdge(id, type, component, sourceId, targetId, sourceCom
  * fields for the nodes and edges otherwise
  */
 export async function neighbourhood(id) {
-    const driver = getDriver();
     let session;
     let record;
     try {
-        session = driver.session(sessionConfig);
+        session = guaranteeSession();
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneId, { id: id });
         });
@@ -122,11 +116,10 @@ export async function getInteractions(id) {
 }
 
 export async function neighbourhoodWithoutComplexes(id) {
-    const driver = getDriver();
     let session;
     let record;
     try {
-        session = driver.session(sessionConfig);
+        session = guaranteeSession();
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
         });
@@ -148,11 +141,10 @@ export async function neighbourhoodWithoutComplexes(id) {
  * fields for the nodes and edges otherwise
  */
 export async function get(id) { // UNTESTED
-    const driver = getDriver();
     let session;
     let record;
     try {
-        session = driver.session(sessionConfig);
+        session = guaranteeSession();
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoForDocument, { id: id });
         });

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -4,19 +4,20 @@ import {
 } from './query-strings';
 import { getDriver } from './neo4j-driver';
 import _ from 'lodash';
+import { GRAPHDB_DBNAME } from '../config';
 
-const dbName = 'neo4j';
+const sessionConfig = { database: GRAPHDB_DBNAME };
 
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"
- * @param { String } name 
- * @returns 
+ * @param { String } name
+ * @returns
  */
 export async function addNode(id, name) {
     const driver = getDriver();
     let session;
     try {
-        session = driver.session({ database: dbName });
+        session = driver.session(sessionConfig);
         await session.executeWrite(tx => {
             return tx.run(makeNodeQuery, {
                 id: id.toLowerCase(),
@@ -31,21 +32,21 @@ export async function addNode(id, name) {
 
 /**
  * @param { String } id interaction element's UUID (NOT document id)
- * @param { String } type 
+ * @param { String } type
  * @param { String } sourceId in the form of "dbName:dbId", ex: "ncbigene:207"
  * @param { String } targetId in the form of "dbName:dbId", ex: "ncbigene:207"
  * @param { String } participantTypes 'noncomplex-to-noncomplex', 'complex-to-noncomplex', etc
  * @param { String } xref document UUID
- * @param { String } doi 
- * @param { String } pmid 
- * @param { String } articleTitle 
- * @returns 
+ * @param { String } doi
+ * @param { String } pmid
+ * @param { String } articleTitle
+ * @returns
  */
 export async function addEdge(id, type, component, sourceId, targetId, sourceComplex, targetComplex, xref, doi, pmid, articleTitle) {
     const driver = getDriver();
     let session;
     try {
-        session = driver.session({ database: dbName });
+        session = driver.session(sessionConfig);
         await session.executeWrite(tx => {
             return tx.run(makeEdgeQuery, {
                 id: id.toLowerCase(),
@@ -77,7 +78,7 @@ export async function neighbourhood(id) {
     let session;
     let record;
     try {
-        session = driver.session({ database: dbName });
+        session = driver.session(sessionConfig);
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneId, { id: id });
         });
@@ -125,7 +126,7 @@ export async function neighbourhoodWithoutComplexes(id) {
     let session;
     let record;
     try {
-        session = driver.session({ database: dbName });
+        session = driver.session(sessionConfig);
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoByGeneIdNoComplexes, { id: id });
         });
@@ -151,7 +152,7 @@ export async function get(id) { // UNTESTED
     let session;
     let record;
     try {
-        session = driver.session({ database: dbName });
+        session = driver.session(sessionConfig);
         let result = await session.executeRead(tx => {
             return tx.run(giveConnectedInfoForDocument, { id: id });
         });

--- a/src/neo4j/test-functions.js
+++ b/src/neo4j/test-functions.js
@@ -1,6 +1,5 @@
 import { numNodes, numEdges, deleteAll, returnEdgeById, returnEdgeByIdAndEndpoints, returnGene } from './query-strings';
 import { guaranteeSession } from './neo4j-driver';
-import { GRAPHDB_DBNAME } from '../config';
 
 export async function getNode(id) {
   let session;

--- a/src/neo4j/test-functions.js
+++ b/src/neo4j/test-functions.js
@@ -1,15 +1,12 @@
 import { numNodes, numEdges, deleteAll, returnEdgeById, returnEdgeByIdAndEndpoints, returnGene } from './query-strings';
-import { getDriver } from './neo4j-driver';
+import { guaranteeSession } from './neo4j-driver';
 import { GRAPHDB_DBNAME } from '../config';
 
-const sessionConfig = { database: GRAPHDB_DBNAME };
-
 export async function getNode(id) {
-  const driver = getDriver();
   let session;
   let node;
   try {
-    session = driver.session(sessionConfig);
+    session = guaranteeSession();
     let result = await session.executeRead(tx => {
       return tx.run(returnGene, { id: id });
     });
@@ -35,11 +32,10 @@ export async function getGeneName(id) {
 }
 
 export async function getEdge(id) {
-  const driver = getDriver();
   let session;
   let edge;
   try {
-    session = driver.session(sessionConfig);
+    session = guaranteeSession();
     let result = await session.executeRead(tx => {
       return tx.run(returnEdgeById, { id: id });
     });
@@ -57,11 +53,10 @@ export async function getEdge(id) {
 }
 
 export async function getEdgeByIdAndEndpoints(sourceId, targetId, complexId) {
-  const driver = getDriver();
   let session;
   let edge;
   try {
-    session = driver.session(sessionConfig);
+    session = guaranteeSession();
     let result = await session.executeRead(tx => {
       return tx.run(returnEdgeByIdAndEndpoints,
         { sourceId: sourceId, targetId: targetId, complexId: complexId });
@@ -80,10 +75,9 @@ export async function getEdgeByIdAndEndpoints(sourceId, targetId, complexId) {
 }
 
 export async function deleteAllNodesAndEdges() {
-  const driver = getDriver();
   let session;
   try {
-    session = driver.session(sessionConfig);
+    session = guaranteeSession();
     await session.executeWrite(tx => {
       return tx.run(deleteAll);
     });
@@ -96,11 +90,10 @@ export async function deleteAllNodesAndEdges() {
 }
 
 export async function getNumNodes() {
-  const driver = getDriver();
   let session;
   let num;
   try {
-    session = driver.session(sessionConfig);
+    session = guaranteeSession();
     let result = await session.executeRead(tx => {
       return tx.run(numNodes);
     });
@@ -114,11 +107,10 @@ export async function getNumNodes() {
 }
 
 export async function getNumEdges() {
-  const driver = getDriver();
   let session;
   let num;
   try {
-    session = driver.session(sessionConfig);
+    session = guaranteeSession();
     let result = await session.executeRead(tx => {
       return tx.run(numEdges);
     });

--- a/src/neo4j/test-functions.js
+++ b/src/neo4j/test-functions.js
@@ -1,12 +1,15 @@
 import { numNodes, numEdges, deleteAll, returnEdgeById, returnEdgeByIdAndEndpoints, returnGene } from './query-strings';
 import { getDriver } from './neo4j-driver';
+import { GRAPHDB_DBNAME } from '../config';
+
+const sessionConfig = { database: GRAPHDB_DBNAME };
 
 export async function getNode(id) {
   const driver = getDriver();
   let session;
   let node;
   try {
-    session = driver.session({ database: "neo4j" });
+    session = driver.session(sessionConfig);
     let result = await session.executeRead(tx => {
       return tx.run(returnGene, { id: id });
     });
@@ -36,7 +39,7 @@ export async function getEdge(id) {
   let session;
   let edge;
   try {
-    session = driver.session({ database: 'neo4j' });
+    session = driver.session(sessionConfig);
     let result = await session.executeRead(tx => {
       return tx.run(returnEdgeById, { id: id });
     });
@@ -58,9 +61,9 @@ export async function getEdgeByIdAndEndpoints(sourceId, targetId, complexId) {
   let session;
   let edge;
   try {
-    session = driver.session({ database: 'neo4j' });
+    session = driver.session(sessionConfig);
     let result = await session.executeRead(tx => {
-      return tx.run(returnEdgeByIdAndEndpoints, 
+      return tx.run(returnEdgeByIdAndEndpoints,
         { sourceId: sourceId, targetId: targetId, complexId: complexId });
     });
     if (result.records.length > 0) {
@@ -80,7 +83,7 @@ export async function deleteAllNodesAndEdges() {
   const driver = getDriver();
   let session;
   try {
-    session = driver.session({ database: "neo4j" });
+    session = driver.session(sessionConfig);
     await session.executeWrite(tx => {
       return tx.run(deleteAll);
     });
@@ -97,7 +100,7 @@ export async function getNumNodes() {
   let session;
   let num;
   try {
-    session = driver.session({ database: "neo4j" });
+    session = driver.session(sessionConfig);
     let result = await session.executeRead(tx => {
       return tx.run(numNodes);
     });
@@ -115,7 +118,7 @@ export async function getNumEdges() {
   let session;
   let num;
   try {
-    session = driver.session({ database: "neo4j" });
+    session = driver.session(sessionConfig);
     let result = await session.executeRead(tx => {
       return tx.run(numEdges);
     });


### PR DESCRIPTION
A couple of observations and cosmetic changes:
  - `guaranteeSession` convenience func so you don't have to think about initializing, config etc
  -  The default community edition database is `neo4j`  so set that in config. You can't create one in the driver and I think the CE only lets you access one database anyways.