### PR TITLE
Submit documents to neo4j on public

### DIFF
--- a/neo4j-test/add-nodes-edges.js
+++ b/neo4j-test/add-nodes-edges.js
@@ -3,7 +3,7 @@ import { initDriver, closeDriver } from '../src/neo4j/neo4j-driver.js';
 import { addEdge, addNode, getInteractions, getNeighbouringNodes, neighbourhood } from '../src/neo4j/neo4j-functions';
 import { deleteAllNodesAndEdges, getGeneName, getNumNodes, getNumEdges, getEdge } from '../src/neo4j/test-functions.js';
 
-describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
+describe('02. Tests for addNode, addEdge and neighbourhood', function () {
 
   before('Should create a driver instance and connect to server', async function () {
     await initDriver();
@@ -116,7 +116,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(edge.properties.articleTitle).to.equal('MAPK6-AKT signaling promotes tumor growth and resistance to mTOR kinase blockade.');
   });
 
-  it('Ensure searchGeneById works as expected for MAPK6', async function () {
+  it('Ensure neighbourhood works as expected for MAPK6', async function () {
     await addNode('ncbigene:207', 'AKT');
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',
@@ -152,7 +152,7 @@ describe('02. Tests for addNode, addEdge and seachByGeneId', function () {
     expect(mapk6NeighbouringNodes[0].name).to.equal('AKT');
   });
 
-  it('Ensure searchGeneById works as expected for AKT', async function () {
+  it('Ensure neighbourhood works as expected for AKT', async function () {
     await addNode('ncbigene:207', 'AKT');
     await addNode('ncbigene:5597', 'MAPK6');
     await addEdge('01ef22cc-2a8e-46d4-9060-6bf1c273869b',

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -9,7 +9,7 @@ import { createConstraint, addNode, addEdge } from './neo4j-functions';
 export function convertUUIDtoId(doc, id) {
   let node = doc.get(id);
   if (node) {
-    return `${node.association().dbPrefix}:${node.association().id}`;
+    return `${node.association().dbPrefix.toLowerCase()}:${node.association().id}`;
   }
   return 'node not found';
 }

--- a/src/neo4j/neo4j-document.js
+++ b/src/neo4j/neo4j-document.js
@@ -1,4 +1,4 @@
-import { addNode, addEdge } from './neo4j-functions';
+import { createConstraint, addNode, addEdge } from './neo4j-functions';
 
 /**
  * @param { Document } doc : document model instance
@@ -29,6 +29,8 @@ function makeComponent(complex, doc) {
  * @returns 
  */
 export async function addDocumentToNeo4j(doc) {
+
+  await createConstraint();
 
   // Step 1: Sort each element in a document into one of two categories
   //              a. Node/Gene

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -1,9 +1,23 @@
 import {
-    giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery,
+    constraint, giveConnectedInfoByGeneId, makeNodeQuery, makeEdgeQuery,
     giveConnectedInfoByGeneIdNoComplexes, giveConnectedInfoForDocument
 } from './query-strings';
 import { guaranteeSession } from './neo4j-driver';
 import _ from 'lodash';
+
+
+export async function createConstraint() {
+    let session;
+    try {
+        session = guaranteeSession();
+        await session.executeWrite(tx => {
+            return tx.run(constraint);
+        });
+    } finally {
+        await session.close();
+    }
+    return;
+}
 
 /**
  * @param { String } id in the form of "dbName:dbId", ex: "ncbigene:207"

--- a/src/neo4j/neo4j-functions.js
+++ b/src/neo4j/neo4j-functions.js
@@ -5,7 +5,6 @@ import {
 import { guaranteeSession } from './neo4j-driver';
 import _ from 'lodash';
 
-
 export async function createConstraint() {
     let session;
     try {

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -1,5 +1,10 @@
+export const constraint = `CREATE CONSTRAINT FOR (x:Entity) REQUIRE x.id IS UNIQUE`;
+
 export const makeNodeQuery =
-    `MERGE (n:Entity {id: $id})
+    `MATCH (n:Entity {id: $id})
+    WITH collect(n) AS nodes
+    CALL apoc.lock.nodes(nodes)
+    MERGE (n:Entity {id: $id})
     ON CREATE SET n.name = $name`;
 
 export const makeEdgeQuery =

--- a/src/neo4j/query-strings.js
+++ b/src/neo4j/query-strings.js
@@ -1,4 +1,4 @@
-export const constraint = `CREATE CONSTRAINT FOR (x:Entity) REQUIRE x.id IS UNIQUE`;
+export const constraint = `CREATE CONSTRAINT IF NOT EXISTS FOR (x:Entity) REQUIRE x.id IS UNIQUE`;
 
 export const makeNodeQuery =
     `MATCH (n:Entity {id: $id})

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -150,7 +150,6 @@ tryPromise( () => {
       .then( () => db.guaranteeIndex( 'document', 'status' ) )
       .then( log('Set up index for document') )
       .then( setupGraphDbFeeds )
-      .then( log('Set up change graph db feeds') )
     ;
   };
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -21,6 +21,7 @@ import updateCron from './update-cron';
 import { Appsignal } from '@appsignal/nodejs';
 import { expressMiddleware as asExpressMiddleware, expressErrorHandler as asExpressErrorHandler } from '@appsignal/express';
 import { initExportTasks } from './routes/api/document/export';
+import setupGraphDbFeeds from './routes/api/document/graphdb';
 
 let app = express();
 let server = http.createServer(app);
@@ -148,6 +149,8 @@ tryPromise( () => {
       .then( () => db.guaranteeIndex( 'document', 'createdDate' ) )
       .then( () => db.guaranteeIndex( 'document', 'status' ) )
       .then( log('Set up index for document') )
+      .then( setupGraphDbFeeds )
+      .then( log('Set up change graph db feeds') )
     ;
   };
 

--- a/src/server/routes/api/document/graphdb.js
+++ b/src/server/routes/api/document/graphdb.js
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+
+import logger from '../../../logger';
+import { loadDoc, loadTables } from './index';
+import { initDriver } from '../../../../neo4j/neo4j-driver';
+import { addDocumentToNeo4j } from '../../../../neo4j';
+
+const handleDocChange = async (err, item) => {
+  const new_val = _.get( item, ['new_val'] );
+  const { id, secret } = _.pick( new_val, ['id', 'secret'] );
+
+  const { docDb, eleDb } = await loadTables();
+  const doc = await loadDoc({ docDb, eleDb, id, secret });
+  logger.debug( `doc id: ${doc.id()}` );
+  await addDocumentToNeo4j( doc );
+};
+
+// Configure Changefeeds for the document table
+const docChangefeeds = async () => {
+  const docOpts = {
+    includeTypes: true,
+  };
+
+  const { docDb } = await loadTables();
+  const { rethink: r, conn, table } = docDb;
+
+  // Database restore of doc with public status
+  const toPublicStatusFromNull = r.row( 'new_val' )( 'status' ).eq( 'public' )
+    .and( r.row( 'old_val' ).eq( null ) );
+  // Status changed to 'public'
+  const toPublicStatusFromOtherStatus = r.row( 'new_val' )( 'status' ).eq( 'public' )
+    .and( r.row( 'old_val' )( 'status' ).ne( 'public' ) );
+
+  const docFilter = toPublicStatusFromNull.or( toPublicStatusFromOtherStatus );
+
+  const cursor = await table.changes( docOpts )
+   .filter( docFilter )
+   .run( conn );
+
+  cursor.each( handleDocChange );
+};
+
+/**
+ * setupGraphDbFeeds
+ * Set up listeners for the specified Changefeeds
+ */
+const setupGraphDbFeeds = async () => {
+  initDriver();
+  await docChangefeeds();
+};
+
+export default setupGraphDbFeeds;


### PR DESCRIPTION
The addition of a document to the neo4j database. 
Here, Rethinkdb watches the `document` table and when document `status` gets set to `public` it calls the neo4j add documnent code.


---

@lindajiawenli Seeing weird issue: When I draw and submit a new document via the Biofactoid user interface, the nodes and edges in neo4j are duplicated.

<img width="500" alt="Screen Shot 2023-04-06 at 2 04 11 PM" src="https://user-images.githubusercontent.com/4706307/230459605-caa90177-2d99-4581-a3d5-a9ee0759d33c.png">

<img width="500" alt="Screen Shot 2023-04-06 at 1 58 35 PM" src="https://user-images.githubusercontent.com/4706307/230458564-a9d1c7bd-4971-49f8-98cc-d772d907aa58.png">

Q: If  I call `addDocumentToneo4j` twice with the same doc instance, would you expect the edges and nodes to be added once? In the tests it only adds them once.
