### PR TITLE
Neo4j: Investigate orphaned nodes

### DIFF
--- a/neo4j-test/document/orphaned_nodes_1.json
+++ b/neo4j-test/document/orphaned_nodes_1.json
@@ -1,0 +1,19519 @@
+{
+  "document": [
+    {
+      "_creationTimestamp": "2020-09-29T13:47:15.678Z",
+      "_newestOpId": "34378c7b-0b74-45d8-9710-0cd7d1b6602f",
+      "_ops": [],
+      "article": {
+        "MedlineCitation": {
+          "Article": {
+            "Abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "ArticleTitle": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits.",
+            "AuthorList": [
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Children's Health Research Institute, London, ON, Canada; Lawson Health Research Institute, London, ON, Canada; Department of Biochemistry, Western University, London, ON, Canada.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Renee J",
+                "Identifier": [],
+                "Initials": "RJ",
+                "LastName": "Tamming"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Department of Paediatrics, Western University, London, ON, Canada; PERFORM Centre, Concordia University, Montreal, QC, Canada.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Vanessa",
+                "Identifier": [],
+                "Initials": "V",
+                "LastName": "Dumeaux"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Children's Health Research Institute, London, ON, Canada; Lawson Health Research Institute, London, ON, Canada.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Yan",
+                "Identifier": [],
+                "Initials": "Y",
+                "LastName": "Jiang"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Children's Health Research Institute, London, ON, Canada; Department of Paediatrics, Western University, London, ON, Canada; Department of Anatomy & Cell Biology, Western University, London, ON, Canada.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Sarfraz",
+                "Identifier": [],
+                "Initials": "S",
+                "LastName": "Shafiq"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Children's Health Research Institute, London, ON, Canada; Lawson Health Research Institute, London, ON, Canada; Department of Anatomy & Cell Biology, Western University, London, ON, Canada.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Luana",
+                "Identifier": [],
+                "Initials": "L",
+                "LastName": "Langlois"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Mouse Imaging Centre, The Hospital for Sick Children, Toronto, ON, Canada.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Jacob",
+                "Identifier": [],
+                "Initials": "J",
+                "LastName": "Ellegood"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Mouse Imaging Centre, The Hospital for Sick Children, Toronto, ON, Canada; Wellcome Centre for Integrative Neuroimaging, The University of Oxford, Oxford, UK.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Lily R",
+                "Identifier": [],
+                "Initials": "LR",
+                "LastName": "Qiu"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Mouse Imaging Centre, The Hospital for Sick Children, Toronto, ON, Canada; Department of Medical Biophysics, The University of Toronto, Toronto, ON, Canada; Wellcome Centre for Integrative Neuroimaging, The University of Oxford, Oxford, UK.",
+                    "email": null
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Jason P",
+                "Identifier": [],
+                "Initials": "JP",
+                "LastName": "Lerch"
+              },
+              {
+                "AffiliationInfo": [
+                  {
+                    "Affiliation": "Children's Health Research Institute, London, ON, Canada; Lawson Health Research Institute, London, ON, Canada; Department of Paediatrics, Western University, London, ON, Canada; Department of Anatomy & Cell Biology, Western University, London, ON, Canada; Department of Oncology, Western University, London, ON, Canada. Electronic address: nberube@uwo.ca.",
+                    "email": [
+                      "nberube@uwo.ca"
+                    ]
+                  }
+                ],
+                "CollectiveName": null,
+                "ForeName": "Nathalie G",
+                "Identifier": [],
+                "Initials": "NG",
+                "LastName": "Bérubé"
+              }
+            ],
+            "Journal": {
+              "ISOAbbreviation": "Cell Rep",
+              "ISSN": {
+                "IssnType": "Electronic",
+                "value": "2211-1247"
+              },
+              "JournalIssue": {
+                "Issue": "13",
+                "PubDate": {
+                  "Day": "30",
+                  "Month": "Jun",
+                  "Year": "2020"
+                },
+                "Volume": "31"
+              },
+              "Title": "Cell reports"
+            },
+            "PublicationTypeList": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ]
+          },
+          "ChemicalList": [
+            {
+              "NameOfSubstance": {
+                "UI": "D006657",
+                "value": "Histones"
+              },
+              "RegistryNumber": "0"
+            },
+            {
+              "NameOfSubstance": {
+                "UI": "C551799",
+                "value": "MIRN137 microRNA, mouse"
+              },
+              "RegistryNumber": "0"
+            },
+            {
+              "NameOfSubstance": {
+                "UI": "D035683",
+                "value": "MicroRNAs"
+              },
+              "RegistryNumber": "0"
+            },
+            {
+              "NameOfSubstance": {
+                "UI": "D012333",
+                "value": "RNA, Messenger"
+              },
+              "RegistryNumber": "0"
+            },
+            {
+              "NameOfSubstance": {
+                "UI": "C490462",
+                "value": "Atrx protein, mouse"
+              },
+              "RegistryNumber": "EC 3.6.4.12"
+            },
+            {
+              "NameOfSubstance": {
+                "UI": "D000075924",
+                "value": "X-linked Nuclear Protein"
+              },
+              "RegistryNumber": "EC 3.6.4.12"
+            },
+            {
+              "NameOfSubstance": {
+                "UI": "D008239",
+                "value": "Lysine"
+              },
+              "RegistryNumber": "K3Z4F929H6"
+            }
+          ],
+          "InvestigatorList": [],
+          "KeywordList": [
+            "ATRX",
+            "H3K27me3",
+            "chromatin",
+            "hippocampus",
+            "intellectual disability",
+            "long-term spatial memory",
+            "miR-137",
+            "presynaptic vesicles",
+            "sex differences",
+            "synapse"
+          ],
+          "MeshheadingList": [
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D000818",
+                "value": "Animals"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D001483",
+                "value": "Base Sequence"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D056547",
+                "value": "CA1 Region, Hippocampal"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000473",
+                  "value": "pathology"
+                },
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000648",
+                  "value": "ultrastructure"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D003216",
+                "value": "Conditioning, Operant"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D003712",
+                "value": "Dendrites"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                },
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000648",
+                  "value": "ultrastructure"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D005260",
+                "value": "Female"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "Y",
+                "UI": "D017353",
+                "value": "Gene Deletion"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "Y",
+                "UI": "D005786",
+                "value": "Gene Expression Regulation"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D005838",
+                "value": "Genotype"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D006657",
+                "value": "Histones"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D008239",
+                "value": "Lysine"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D008279",
+                "value": "Magnetic Resonance Imaging"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D008297",
+                "value": "Male"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D008569",
+                "value": "Memory Disorders"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "Y",
+                  "UI": "Q000235",
+                  "value": "genetics"
+                },
+                {
+                  "MajorTopicYN": "Y",
+                  "UI": "Q000503",
+                  "value": "physiopathology"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D008810",
+                "value": "Mice, Inbred C57BL"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D018345",
+                "value": "Mice, Knockout"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D035683",
+                "value": "MicroRNAs"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "Y",
+                  "UI": "Q000235",
+                  "value": "genetics"
+                },
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D009474",
+                "value": "Neurons"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D009928",
+                "value": "Organ Specificity"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D012333",
+                "value": "RNA, Messenger"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000235",
+                  "value": "genetics"
+                },
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "Y",
+                "UI": "D012727",
+                "value": "Sex Characteristics"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "Y",
+                "UI": "D065853",
+                "value": "Spatial Learning"
+              },
+              "QualifierName": []
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D013569",
+                "value": "Synapses"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                },
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000648",
+                  "value": "ultrastructure"
+                }
+              ]
+            },
+            {
+              "DescriptorName": {
+                "MajorTopicYN": "N",
+                "UI": "D000075924",
+                "value": "X-linked Nuclear Protein"
+              },
+              "QualifierName": [
+                {
+                  "MajorTopicYN": "Y",
+                  "UI": "Q000172",
+                  "value": "deficiency"
+                },
+                {
+                  "MajorTopicYN": "N",
+                  "UI": "Q000378",
+                  "value": "metabolism"
+                }
+              ]
+            }
+          ]
+        },
+        "PubmedData": {
+          "ArticleIdList": [
+            {
+              "IdType": "pubmed",
+              "id": "32610139"
+            },
+            {
+              "IdType": "pmc",
+              "id": "PMC7326465"
+            },
+            {
+              "IdType": "doi",
+              "id": "10.1016/j.celrep.2020.107838"
+            },
+            {
+              "IdType": "pii",
+              "id": "S2211-1247(20)30819-6"
+            }
+          ],
+          "History": [
+            {
+              "PubMedPubDate": {
+                "Day": "18",
+                "Month": "4",
+                "Year": "2019"
+              },
+              "PubStatus": "received"
+            },
+            {
+              "PubMedPubDate": {
+                "Day": "13",
+                "Month": "4",
+                "Year": "2020"
+              },
+              "PubStatus": "revised"
+            },
+            {
+              "PubMedPubDate": {
+                "Day": "8",
+                "Month": "6",
+                "Year": "2020"
+              },
+              "PubStatus": "accepted"
+            },
+            {
+              "PubMedPubDate": {
+                "Day": "2",
+                "Month": "7",
+                "Year": "2020"
+              },
+              "PubStatus": "entrez"
+            },
+            {
+              "PubMedPubDate": {
+                "Day": "2",
+                "Month": "7",
+                "Year": "2020"
+              },
+              "PubStatus": "pubmed"
+            },
+            {
+              "PubMedPubDate": {
+                "Day": "29",
+                "Month": "4",
+                "Year": "2021"
+              },
+              "PubStatus": "medline"
+            }
+          ],
+          "ReferenceList": [
+            {
+              "Reference": [
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3297199"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "21373993"
+                    }
+                  ],
+                  "Citation": "Avants B.B., Tustison N.J., Wu J., Cook P.A., Gee J.C. An open source multivariate framework for n-tissue segmentation with evaluation on public data. Neuroinformatics. 2011;9:381–400."
+                },
+                {
+                  "ArticleIdList": null,
+                  "Citation": "Benjamini Y., Hochberg Y. Controlling the false discovery rate: a practical and powerful approach to multiple testing. J. R. Stat. Soc. B. 1995;57:289–300."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC544602"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "15668733"
+                    }
+                  ],
+                  "Citation": "Bérubé N.G., Mangelsdorf M., Jagla M., Vanderluit J., Garrick D., Gibbons R.J., Higgs D.R., Slack R.S., Picketts D.J. The chromatin-remodeling protein ATRX is critical for neuronal survival during corticogenesis. J. Clin. Invest. 2005;115:258–267."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "22537595"
+                    }
+                  ],
+                  "Citation": "Bian Y., Pan Z., Hou Z., Huang C., Li W., Zhao B. Learning, memory, and glial cell changes following recovery from chronic unpredictable stress. Brain Res. Bull. 2012;88:471–476."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4927759"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "27286292"
+                    }
+                  ],
+                  "Citation": "Bisht K., El Hajj H., Savage J.C., Sánchez M.G., Tremblay M.E. Correlative Light and Electron Microscopy to Study Microglial Interactions with β-Amyloid Plaques. J. Vis. Exp. 2016;(112):54060."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "18215625"
+                    }
+                  ],
+                  "Citation": "Brun V.H., Leutgeb S., Wu H.Q., Schwarcz R., Witter M.P., Moser E.I., Moser M.B. Impaired spatial representation in CA1 after lesion of direct input from entorhinal cortex. Neuron. 2008;57:290–302."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "11377840"
+                    }
+                  ],
+                  "Citation": "Bukalo O., Schachner M., Dityatev A. Modification of extracellular matrix by enzymatic removal of chondroitin sulfate and by lack of tenascin-R differentially affects several forms of synaptic plasticity in the hippocampus. Neuroscience. 2001;104:359–369."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2505319"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "18612068"
+                    }
+                  ],
+                  "Citation": "Bussey T.J., Padain T.L., Skillings E.A., Winters B.D., Morton A.J., Saksida L.M. The touchscreen cognitive testing method for rodents: how to get the best out of your rat. Learn. Mem. 2008;15:516–523."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3168710"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "21530550"
+                    }
+                  ],
+                  "Citation": "Bussey T.J., Holmes A., Lyon L., Mar A.C., McAllister K.A., Nithianantharajah J., Oomen C.A., Saksida L.M. New translational assays for preclinical modelling of cognition in schizophrenia: the touchscreen testing method for mice and rats. Neuropharmacology. 2012;62:1191–1203."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "8126267"
+                    }
+                  ],
+                  "Citation": "Collins D.L., Neelin P., Peters T.M., Evans A.C. Automatic 3D intersubject registration of MR volumetric data in standardized Talairach space. J. Comput. Assist. Tomogr. 1994;18:192–205."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "18778400"
+                    }
+                  ],
+                  "Citation": "de Castro B.M., Pereira G.S., Magalhães V., Rossato J.I., De Jaeger X., Martins-Silva C., Leles B., Lima P., Gomez M.V., Gainetdinov R.R. Reduced expression of the vesicular acetylcholine transporter causes learning deficits in mice. Genes Brain Behav. 2009;8:23–35."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "27335314"
+                    }
+                  ],
+                  "Citation": "de Guzman A.E., Wong M.D., Gleave J.A., Nieman B.J. Variations in post-perfusion immersion fixation and storage alter MRI measurements of mouse brain morphometry. Neuroimage. 2016;142:687–695."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5905159"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29665782"
+                    }
+                  ],
+                  "Citation": "de Sena Cortabitarte A., Berkel S., Cristian F.B., Fischer C., Rappold G.A. A direct regulatory link between microRNA-137 and SHANK2: implications for neuropsychiatric disorders. J. Neurodev. Disord. 2018;10:15."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "25687692"
+                    }
+                  ],
+                  "Citation": "Delotterie D.F., Mathis C., Cassel J.C., Rosenbrock H., Dorner-Ciossek C., Marti A. Touchscreen tasks in mice to demonstrate differences between hippocampal and striatal functions. Neurobiol. Learn. Mem. 2015;120:16–27."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "18502665"
+                    }
+                  ],
+                  "Citation": "Dorr A.E., Lerch J.P., Spring S., Kabani N., Henkelman R.M. High resolution three-dimensional brain atlas using an average magnetic resonance image of 40 adult C57Bl/6J mice. Neuroimage. 2008;42:60–69."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "27468717"
+                    }
+                  ],
+                  "Citation": "Du Y., Chen Y., Wang F., Gu L. miR-137 plays tumor suppressor roles in gastric cancer cell lines by targeting KLF12 and MYO1C. Tumour Biol. 2016;37:13557–13569."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "21666677"
+                    }
+                  ],
+                  "Citation": "Eustermann S., Yang J.C., Law M.J., Amos R., Chapman L.M., Jelinska C., Garrick D., Clynes D., Gibbons R.J., Rhodes D. Combinatorial readout of histone H3 modifications specifies localization of ATRX to heterochromatin. Nat. Struct. Mol. Biol. 2011;18:777–782."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5271921"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "25264773"
+                    }
+                  ],
+                  "Citation": "Ferreira T.A., Blackman A.V., Oyrer J., Jayabal S., Chung A.J., Watt A.J., Sjöström P.J., van Meyel D.J. Neuronal morphometry directly from bitmap images. Nat. Methods. 2014;11:982–984."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "19218885"
+                    }
+                  ],
+                  "Citation": "Fombonne E. Epidemiology of pervasive developmental disorders. Pediatr. Res. 2009;65:591–598."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4854010"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "27130160"
+                    }
+                  ],
+                  "Citation": "Friez M.J., Brooks S.S., Stevenson R.E., Field M., Basehore M.J., Adès L.C., Sebold C., McGee S., Saxon S., Skinner C. HUWE1 mutations in Juberg-Marsidi and Brooks syndromes: the results of an X-chromosome exome sequencing study. BMJ Open. 2016;6:e009537."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC1440874"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "16628246"
+                    }
+                  ],
+                  "Citation": "Garrick D., Sharpe J.A., Arkell R., Dobbie L., Smith A.J., Wood W.G., Higgs D.R., Gibbons R.J. Loss of Atrx affects trophoblast development and the pattern of X-inactivation in extraembryonic tissues. PLOS Genet. 2006;2:e58."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "11906227"
+                    }
+                  ],
+                  "Citation": "Genovese C.R., Lazar N.A., Nichols T. Thresholding of statistical maps in functional neuroimaging using the false discovery rate. Neuroimage. 2002;15:870–878."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC1682840"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "1415255"
+                    }
+                  ],
+                  "Citation": "Gibbons R.J., Suthers G.K., Wilkie A.O., Buckle V.J., Higgs D.R. X-linked alpha-thalassemia/mental retardation (ATR-X) syndrome: localization to Xq12-q21.31 by X inactivation and linkage analysis. Am. J. Hum. Genet. 1992;51:1136–1149."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "7697714"
+                    }
+                  ],
+                  "Citation": "Gibbons R.J., Picketts D.J., Villard L., Higgs D.R. Mutations in a putative global transcriptional regulator cause X-linked mental retardation with alpha-thalassemia (ATR-X syndrome) Cell. 1995;80:837–845."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "9326931"
+                    }
+                  ],
+                  "Citation": "Gibbons R.J., Bachoo S., Picketts D.J., Aftimos S., Asenbauer B., Bergoffen J., Berry S.A., Dahl N., Fryer A., Keppler K. Mutations in transcriptional regulator ATRX establish the functional significance of a PHD-like domain. Nat. Genet. 1997;17:146–148."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "18409179"
+                    }
+                  ],
+                  "Citation": "Gibbons R.J., Wada T., Fisher C.A., Malik N., Mitson M.J., Steensma D.P., Fryer A., Goudie D.R., Krantz I.D., Traeger-Synodinos J. Mutations in the chromatin-associated protein ATRX. Hum. Mutat. 2008;29:796–802."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2885838"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "20211137"
+                    }
+                  ],
+                  "Citation": "Goldberg A.D., Banaszynski L.A., Noh K.M., Lewis P.W., Elsaesser S.J., Stadler S., Dewell S., Law M., Guo X., Li X. Distinct factors control histone variant H3.3 localization at specific genomic regions. Cell. 2010;140:678–691."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4833192"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "26350204"
+                    }
+                  ],
+                  "Citation": "Grozeva D., Carss K., Spasic-Boskovic O., Tejada M.I., Gecz J., Shaw M., Corbett M., Haan E., Thompson E., Friend K., Italian X-linked Mental Retardation Project. UK10K Consortium. GOLD Consortium Targeted Next-Generation Sequencing Analysis of 1,000 Individuals with Intellectual Disability. Hum. Mutat. 2015;36:1197–1204."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "31713968"
+                    }
+                  ],
+                  "Citation": "Gugustea R., Tamming R.J., Martin-Kenny N., Bérubé N.G., Leung L.S. Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity. Hippocampus. 2020;30:565–581."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC6575840"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "1613552"
+                    }
+                  ],
+                  "Citation": "Harris K.M., Jensen F.E., Tsao B. Three-dimensional structure of dendritic spines and synapses in rat hippocampus (CA1) at postnatal day 15 and adult ages: implications for the maturation of synaptic physiology and long-term potentiation. J. Neurosci. 1992;12:2685–2705."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5961183"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29635364"
+                    }
+                  ],
+                  "Citation": "He E., Lozano M.A.G., Stringer S., Watanabe K., Sakamoto K., den Oudsten F., Koopmans F., Giamberardino S.N., Hammerschlag A., Cornelisse L.N. MIR137 schizophrenia-associated locus controls synaptic function by regulating synaptogenesis, synapse maturation and synaptic transmission. Hum. Mol. Genet. 2018;27:1879–1891."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4459681"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "26056561"
+                    }
+                  ],
+                  "Citation": "Hu V.W., Sarachana T., Sherrard R.M., Kocher K.M. Investigation of sex differences in the expression of RORA and its transcriptional targets in the brain as a potential contributor to the sex bias in autism. Mol. Autism. 2015;6:7."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3630486"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "23592037"
+                    }
+                  ],
+                  "Citation": "Hylin M.J., Orsi S.A., Moore A.N., Dash P.K. Disruption of the perineuronal net in the hippocampus or medial prefrontal cortex impairs fear conditioning. Learn. Mem. 2013;20:267–273."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4930141"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "27240256"
+                    }
+                  ],
+                  "Citation": "Ignatiadis N., Klaus B., Zaugg J.B., Huber W. Data-driven hypothesis weighting increases detection power in genome-scale multiple testing. Nat. Methods. 2016;13:577–580."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3951938"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "24581740"
+                    }
+                  ],
+                  "Citation": "Jacquemont S., Coe B.P., Hersch M., Duyzend M.H., Krumm N., Bergmann S., Beckmann J.S., Rosenfeld J.A., Eichler E.E. A higher mutational burden in females supports a “female protective model” in neurodevelopmental disorders. Am. J. Hum. Genet. 2014;94:415–425."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "31301273"
+                    }
+                  ],
+                  "Citation": "Jiang Y., Liu J., Chen L., Jin Y., Zhang G., Lin Z., Du S., Fu Z., Chen T., Qin Y., Sun X. Serum secreted miR-137-containing exosomes affects oxidative stress of neurons by regulating OXR1 in Parkinson’s disease. Brain Res. 2019;1722:146331."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "30104731"
+                    }
+                  ],
+                  "Citation": "Jung H., Park H., Choi Y., Kang H., Lee E., Kweon H., Roh J.D., Ellegood J., Choi W., Kang J. Sexually dimorphic behavior, neuronal activity, and gene expression in Chd8-mutant mice. Nat. Neurosci. 2018;21:1218–1228."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "20159591"
+                    }
+                  ],
+                  "Citation": "Kernohan K.D., Jiang Y., Tremblay D.C., Bonvissuto A.C., Eubanks J.H., Mann M.R., Bérubé N.G. ATRX partners with cohesin and MeCP2 and contributes to developmental silencing of imprinted genes in the brain. Dev. Cell. 2010;18:191–202."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4600471"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "25963561"
+                    }
+                  ],
+                  "Citation": "Kim C.H., Heath C.J., Kent B.A., Bussey T.J., Saksida L.M. The role of the dorsal hippocampus in two versions of the touchscreen automated paired associates learning (PAL) task for mice. Psychopharmacology (Berl.) 2015;232:3899–3910."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "25404090"
+                    }
+                  ],
+                  "Citation": "Kim K.C., Choi C.S., Kim J.W., Han S.H., Cheong J.H., Ryu J.H., Shin C.Y. MeCP2 Modulates Sex Differences in the Postsynaptic Development of the Valproate Animal Model of Autism. Mol. Neurobiol. 2016;53:40–56."
+                },
+                {
+                  "ArticleIdList": null,
+                  "Citation": "Kolde R. “Pheatmap: pretty heatmaps.”. R package version. 2012;61:617."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2569867"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "18614683"
+                    }
+                  ],
+                  "Citation": "Kurian J.R., Bychowski M.E., Forbes-Lorman R.M., Auger C.J., Auger A.P. Mecp2 organizes juvenile social behavior in a sex-specific manner. J. Neurosci. 2008;28:7137–7142."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "21029860"
+                    }
+                  ],
+                  "Citation": "Law M.J., Lower K.M., Voon H.P., Hughes J.R., Garrick D., Viprakasit V., Mitson M., De Gobbi M., Marra M., Morris A. ATR-X syndrome protein targets tandem repeats and influences allele-specific expression in a size-dependent manner. Cell. 2010;143:367–378."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "18387826"
+                    }
+                  ],
+                  "Citation": "Lerch J.P., Carroll J.B., Dorr A., Spring S., Evans A.C., Hayden M.R., Sled J.G., Henkelman R.M. Cortical thickness measured from MRI in the YAC128 mouse model of Huntington’s disease. Neuroimage. 2008;41:243–251."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "25452430"
+                    }
+                  ],
+                  "Citation": "Levy M.A., Kernohan K.D., Jiang Y., Bérubé N.G. ATRX promotes gene expression by facilitating transcriptional elongation through guanine-rich coding regions. Hum. Mol. Genet. 2015;24:1824–1835."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2922592"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "20651253"
+                    }
+                  ],
+                  "Citation": "Lewis P.W., Elsaesser S.J., Noh K.M., Stadler S.C., Allis C.D. Daxx is an H3.3-specific histone chaperone and cooperates with ATRX in replication-independent chromatin assembly at telomeres. Proc. Natl. Acad. Sci. USA. 2010;107:14075–14080."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "doi",
+                      "id": "10.1093/bioinformatics/btp352"
+                    },
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2723002"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "19505943"
+                    }
+                  ],
+                  "Citation": "Li H., Handsaker B., Wysoker A., Fennell T., Ruan J., Homer N., Marth G., Abecasis G., Durbin R., 1000 Genome Project Data Processing Subgroup The Sequence Alignment/Map format and SAMtools. Bioinformatics. 2009;25:2078–2079. doi: 10.1093/bioinformatics/btp352."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "23252729"
+                    }
+                  ],
+                  "Citation": "Li K.K., Yang L., Pang J.C., Chan A.K., Zhou L., Mao Y., Wang Y., Lau K.M., Poon W.S., Shi Z., Ng H.K. MIR-137 suppresses growth and invasion, is downregulated in oligodendroglial tumors and targets CSE1L. Brain Pathol. 2013;23:426–439."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "21727141"
+                    }
+                  ],
+                  "Citation": "Longair M.H., Baker D.A., Armstrong J.D. Simple Neurite Tracer: open source software for reconstruction, visualization and analysis of neuronal processes. Bioinformatics. 2011;27:2453–2454."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4302049"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "25516281"
+                    }
+                  ],
+                  "Citation": "Love M.I., Huber W., Anders S. Moderated estimation of fold change and dispersion for RNA-seq data with DESeq2. Genome Biol. 2014;15:550."
+                },
+                {
+                  "ArticleIdList": null,
+                  "Citation": "Martin M. Cutadapt removes adapter sequences from high-throughput sequencing reads. EMBnet.journal. 2011;17:10–12."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5761433"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29133437"
+                    }
+                  ],
+                  "Citation": "McGill B.E., Barve R.A., Maloney S.E., Strickland A., Rensing N., Wang P.L., Wong M., Head R., Wozniak D.F., Milbrandt J. Abnormal Microglia and Enhanced Inflammation-Related Gene Transcription in Mice with Conditional Deletion of Ctcf in Camk2a-Cre-Expressing Neurons. J. Neurosci. 2018;38:200–219."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5788272"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29180823"
+                    }
+                  ],
+                  "Citation": "Moortgat S., Berland S., Aukrust I., Maystadt I., Baker L., Benoit V., Caro-Llopis A., Cooper N.S., Debray F.G., Faivre L. HUWE1 variants cause dominant X-linked intellectual disability: a clinical study of 21 patients. Eur. J. Hum. Genet. 2018;26:64–74."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC6579127"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "8627357"
+                    }
+                  ],
+                  "Citation": "Nguyen P.V., Kandel E.R. A macromolecular synthesis-dependent late phase of long-term potentiation requiring cAMP in the medial perforant pathway of rat hippocampal slices. J. Neurosci. 1996;16:3189–3198."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "16410543"
+                    }
+                  ],
+                  "Citation": "Nieman B.J., Flenniken A.M., Adamson S.L., Henkelman R.M., Sled J.G. Anatomical phenotyping in the brain and skull of a mutant mouse by magnetic resonance imaging and computed tomography. Physiol. Genomics. 2006;24:154–162."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "29927554"
+                    }
+                  ],
+                  "Citation": "Nieman B.J., van Eede M.C., Spring S., Dazai J., Henkelman R.M., Lerch J.P. MRI to Assess Neurological Function. Curr. Protoc. Mouse Biol. 2018;8:e44."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4131247"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "23201973"
+                    }
+                  ],
+                  "Citation": "Nithianantharajah J., Komiyama N.H., McKechanie A., Johnstone M., Blackwood D.H., St Clair D., Emes R.D., van de Lagemaat L.N., Saksida L.M., Bussey T.J., Grant S.G. Synaptic scaffold evolution generated components of vertebrate cognitive complexity. Nat. Neurosci. 2013;16:16–24."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4589696"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "26423861"
+                    }
+                  ],
+                  "Citation": "Nithianantharajah J., McKechanie A.G., Stewart T.J., Johnstone M., Blackwood D.H., St Clair D., Grant S.G., Bussey T.J., Saksida L.M. Bridging the translational divide: identical cognitive touchscreen testing in mice and humans carrying mutations in a disease-relevant homologous gene. Sci. Rep. 2015;5:14613."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "26095359"
+                    }
+                  ],
+                  "Citation": "Olde Loohuis N.F., Ba W., Stoerchel P.H., Kos A., Jager A., Schratt G., Martens G.J., van Bokhoven H., Nadif Kasri N., Aschrafi A. MicroRNA-137 Controls AMPA-Receptor-Mediated Transmission and mGluR-Dependent LTD. Cell Rep. 2015;11:1876–1884."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3197693"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "22028674"
+                    }
+                  ],
+                  "Citation": "Oliver P.L., Finelli M.J., Edwards B., Bitoun E., Butts D.L., Becker E.B., Cheeseman M.T., Davies B., Davies K.E. Oxr1 is essential for protection against oxidative stress-induced neurodegeneration. PLOS Genet. 2011;7:e1002338."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4643835"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "25690850"
+                    }
+                  ],
+                  "Citation": "Pertea M., Pertea G.M., Antonescu C.M., Chang T.C., Mendell J.T., Salzberg S.L. StringTie enables improved reconstruction of a transcriptome from RNA-seq reads. Nat. Biotechnol. 2015;33:290–295."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "8968741"
+                    }
+                  ],
+                  "Citation": "Picketts D.J., Higgs D.R., Bachoo S., Blake D.J., Quarrell O.W., Gibbons R.J. ATRX encodes a novel member of the SNF2 family of proteins: mutations point to a common mechanism underlying the ATR-X syndrome. Hum. Mol. Genet. 1996;5:1899–1907."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC6033927"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29976930"
+                    }
+                  ],
+                  "Citation": "Qiu L.R., Fernandes D.J., Szulc-Lerch K.U., Dazai J., Nieman B.J., Turnbull D.H., Foster J.A., Palmert M.R., Lerch J.P. Mouse MRI shows brain areas relatively larger in males emerge before those larger in females. Nat. Commun. 2018;9:2615."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3969860"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "24157548"
+                    }
+                  ],
+                  "Citation": "Ran F.A., Hsu P.D., Wright J., Agarwala V., Scott D.A., Zhang F. Genome engineering using the CRISPR-Cas9 system. Nat. Protoc. 2013;8:2281–2308."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "15470431"
+                    }
+                  ],
+                  "Citation": "Remondes M., Schuman E.M. Role for a cortical input to hippocampal area CA1 in the consolidation of a long-term memory. Nature. 2004;431:699–703."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "21704710"
+                    }
+                  ],
+                  "Citation": "Richards K., Watson C., Buckley R.F., Kurniawan N.D., Yang Z., Keller M.D., Beare R., Bartlett P.F., Egan G.F., Galloway G.J. Segmentation of the mouse hippocampal formation in magnetic resonance images. Neuroimage. 2011;58:732–740."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4337328"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "25755632"
+                    }
+                  ],
+                  "Citation": "Ryan B., Joilin G., Williams J.M. Plasticity-related microRNA and their potential contribution to the maintenance of long-term potentiation. Front. Mol. Neurosci. 2015;8:4."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "3382917"
+                    }
+                  ],
+                  "Citation": "Sahakian B.J., Morris R.G., Evenden J.L., Heald A., Levy R., Philpot M., Robbins T.W. A comparative study of visuospatial memory and learning in Alzheimer-type dementia and Parkinson’s disease. Brain. 1988;111:695–718."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "28898627"
+                    }
+                  ],
+                  "Citation": "Sarma K., Cifuentes-Rojas C., Ergun A., Del Rosario A., Jeon Y., White F., Sadreyev R., Lee J.T. ATRX Directs Binding of PRC2 to Xist RNA and Polycomb Targets. Cell. 2014;159:1228."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3376495"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "22503632"
+                    }
+                  ],
+                  "Citation": "Sato D., Lionel A.C., Leblond C.S., Prasad A., Pinto D., Walker S., O’Connor I., Russell C., Drmic I.E., Hamdan F.F. SHANK1 Deletions in Males with Autism Spectrum Disorder. Am. J. Hum. Genet. 2012;90:879–887."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3855844"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "22743772"
+                    }
+                  ],
+                  "Citation": "Schindelin J., Arganda-Carreras I., Frise E., Kaynig V., Longair M., Pietzsch T., Preibisch S., Rueden C., Saalfeld S., Schmid B. Fiji: an open-source platform for biological-image analysis. Nat. Methods. 2012;9:676–682."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC6671724"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "19020049"
+                    }
+                  ],
+                  "Citation": "Seah C., Levy M.A., Jiang Y., Mokhtarzada S., Higgs D.R., Gibbons R.J., Bérubé N.G. Neuronal death resulting from targeted disruption of the Snf2 protein ATRX is mediated by p53. J. Neurosci. 2008;28:12570–12580."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "10806096"
+                    }
+                  ],
+                  "Citation": "Sheng M., Kim E. The Shank family of scaffold proteins. J. Cell Sci. 2000;113:1851–1856."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC6622766"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "21209221"
+                    }
+                  ],
+                  "Citation": "Shioda N., Beppu H., Fukuda T., Li E., Kitajima I., Fukunaga K. Aberrant calcium/calmodulin-dependent protein kinase II (CaMKII) activity is associated with abnormal dendritic spine morphology in the ATRX mutant mouse brain. J. Neurosci. 2011;31:346–358."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "29785027"
+                    }
+                  ],
+                  "Citation": "Shioda N., Yabuki Y., Yamaguchi K., Onozato M., Li Y., Kurosawa K., Tanabe H., Okamoto N., Era T., Sugiyama H. Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome. Nat. Med. 2018;24:802–813."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4506960"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "26005852"
+                    }
+                  ],
+                  "Citation": "Siegert S., Seo J., Kwon E.J., Rudenko A., Cho S., Wang W., Flood Z., Martorell A.J., Ericsson M., Mungenast A.E., Tsai L.H. The schizophrenia risk gene product miR-137 alters presynaptic plasticity. Nat. Neurosci. 2015;18:1008–1016."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4712774"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "26925227"
+                    }
+                  ],
+                  "Citation": "Soneson C., Love M.I., Robinson M.D. Differential analyses for RNA-seq: transcript-level estimates improve gene-level inferences. F1000Res. 2015;4:1521."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "28902423"
+                    }
+                  ],
+                  "Citation": "Spencer Noakes T.L., Henkelman R.M., Nieman B.J. Partitioning k-space for cylindrical three-dimensional rapid acquisition with relaxation enhancement imaging in the mouse brain. NMR Biomed. 2017;30 10.1002/nbm.3802."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4418792"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "24151012"
+                    }
+                  ],
+                  "Citation": "Steadman P.E., Ellegood J., Szulc K.U., Turnbull D.H., Joyner A.L., Henkelman R.M., Lerch J.P. Genetic effects on cerebellar structure across mouse models of autism using a magnetic resonance imaging atlas. Autism Res. 2014;7:124–137."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "19357840"
+                    }
+                  ],
+                  "Citation": "Talpos J.C., Winters B.D., Dias R., Saksida L.M., Bussey T.J. A novel touchscreen-automated paired-associate learning (PAL) task sensitive to pharmacological manipulation of the hippocampus: a translational rodent model of cognitive impairments in neurodegenerative disease. Psychopharmacology (Berl.) 2009;205:157–168."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5312007"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "28093507"
+                    }
+                  ],
+                  "Citation": "Tamming R.J., Siu J.R., Jiang Y., Prado M.A., Beier F., Bérubé N.G. Mosaic expression of Atrx in the mouse central nervous system causes memory deficits. Dis. Model. Mech. 2017;10:119–126."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "16429444"
+                    }
+                  ],
+                  "Citation": "Tanaka S., Ide M., Shibutani T., Ohtaki H., Numazawa S., Shioda S., Yoshida T. Lipopolysaccharide-induced microglial activation induces learning and memory deficits without neuronal cell death in rats. J. Neurosci. Res. 2006;83:557–566."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "24030948"
+                    }
+                  ],
+                  "Citation": "Thomas R.H., Chung S.K., Wood S.E., Cushion T.D., Drew C.J., Hammond C.L., Vanbellinghen J.F., Mullins J.G., Rees M.I. Genotype-phenotype correlations in hyperekplexia: apnoeas, learning difficulties and speech delay. Brain. 2013;136:3085–3095."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5745041"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "28683304"
+                    }
+                  ],
+                  "Citation": "Thomas K.T., Anderson B.R., Shah N., Zimmer S.E., Hawkins D., Valdez A.N., Gu Q., Bassell G.J. Inhibition of the Schizophrenia-Associated MicroRNA miR-137 Disrupts Nrg1α Neurodevelopmental Signal Transduction. Cell Rep. 2017;20:1–12."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "10471508"
+                    }
+                  ],
+                  "Citation": "Tronche F., Kellendonk C., Kretz O., Gass P., Anlag K., Orban P.C., Bock R., Klein R., Schütz G. Disruption of the glucocorticoid receptor gene in the nervous system results in reduced anxiety. Nat. Genet. 1999;23:99–103."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "8980237"
+                    }
+                  ],
+                  "Citation": "Tsien J.Z., Chen D.F., Gerber D., Tom C., Mercer E.H., Anderson D.J., Mayford M., Kandel E.R., Tonegawa S. Subregion- and cell type-restricted gene knockout in mouse brain. Cell. 1996;87:1317–1326."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5711804"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29196732"
+                    }
+                  ],
+                  "Citation": "Tsutiya A., Nakano Y., Hansen-Kiss E., Kelly B., Nishihara M., Goshima Y., Corsmeier D., White P., Herman G.E., Ohtani-Kaneko R. Human CRMP4 mutation and disrupted Crmp4 expression in mice are associated with ASD characteristics and sexual dimorphism. Sci. Rep. 2017;7:16812."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pubmed",
+                      "id": "23689500"
+                    }
+                  ],
+                  "Citation": "Ullmann J.F., Watson C., Janke A.L., Kurniawan N.D., Paxinos G., Reutens D.C. An MRI atlas of the mouse basal ganglia. Brain Struct. Funct. 2014;219:1343–1353."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2421012"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "18313770"
+                    }
+                  ],
+                  "Citation": "Vago D.R., Kesner R.P. Disruption of the direct perforant path input to the CA1 subregion of the dorsal hippocampus interferes with spatial working memory and novelty detection. Behav. Brain Res. 2008;189:273–283."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3607626"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "21614001"
+                    }
+                  ],
+                  "Citation": "Voineagu I., Wang X., Johnston P., Lowe J.K., Tian Y., Horvath S., Mill J., Cantor R.M., Blencowe B.J., Geschwind D.H. Transcriptomic analysis of autistic brain reveals convergent molecular pathology. Nature. 2011;474:380–384."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2895266"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "17406317"
+                    }
+                  ],
+                  "Citation": "Vorhees C.V., Williams M.T. Morris water maze: procedures for assessing spatial and related forms of learning and memory. Nat. Protoc. 2006;1:848–858."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC6136152"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "30209204"
+                    }
+                  ],
+                  "Citation": "Wang W., Le A.A., Hou B., Lauterborn J.C., Cox C.D., Levin E.R., Lynch G., Gall C.M. Memory-Related Synaptic Plasticity Is Sexually Dimorphic in Rodent Hippocampus. J. Neurosci. 2018;38:7935–7951."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC3635723"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "23563309"
+                    }
+                  ],
+                  "Citation": "Watson L.A., Solomon L.A., Li J.R., Jiang Y., Edwards M., Shin-ya K., Beier F., Bérubé N.G. Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span. J. Clin. Invest. 2013;123:2049–2063."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC2643472"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "18434530"
+                    }
+                  ],
+                  "Citation": "Xu J., Deng X., Watkins R., Disteche C.M. Sex-specific differences in expression of histone demethylases Utx and Uty in mouse brain and neurons. J. Neurosci. 2008;28:4521–4527."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5896116"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29650040"
+                    }
+                  ],
+                  "Citation": "Yi L., Pimentel H., Bray N.L., Pachter L. Gene-level differential analysis at transcript-level resolution. Genome Biol. 2018;19:53."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC5753206"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "29155950"
+                    }
+                  ],
+                  "Citation": "Zerbino D.R., Achuthan P., Akanni W., Amode M.R., Barrell D., Bhai J., Billis K., Cummins C., Gall A., Girón C.G. Ensembl 2018. Nucleic Acids Res. 2018;46(D1):D754–D761."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "pmc",
+                      "id": "PMC4146110"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "25206554"
+                    }
+                  ],
+                  "Citation": "Zhao L., Li H., Guo R., Ma T., Hou R., Ma X., Du Y. miR-137, a new target for post-stroke depression? Neural Regen. Res. 2013;8:2441–2448."
+                },
+                {
+                  "ArticleIdList": [
+                    {
+                      "IdType": "doi",
+                      "id": "10.23736/S0026-4806.19.06248-7"
+                    },
+                    {
+                      "IdType": "pubmed",
+                      "id": "31502810"
+                    }
+                  ],
+                  "Citation": "Zhou Y., Meng P., Tang B., Ke Z., Liu L., Chen Y., Zhu F. MiR-616 promotes the progression of pancreatic carcinoma by targeting OXR1. Minerva Med. 2019 doi: 10.23736/S0026-4806.19.06248-7."
+                }
+              ],
+              "ReferenceList": [],
+              "Title": null
+            }
+          ]
+        }
+      },
+      "authorProfiles": [
+        {
+          "ForeName": "Renee",
+          "LastName": "Tamming",
+          "abbrevName": "Tamming RJ",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Renee J Tamming",
+          "orcid": null
+        },
+        {
+          "ForeName": "Vanessa",
+          "LastName": "Dumeaux",
+          "abbrevName": "Dumeaux V",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Vanessa Dumeaux",
+          "orcid": null
+        },
+        {
+          "ForeName": "Yan",
+          "LastName": "Jiang",
+          "abbrevName": "Jiang Y",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Yan Jiang",
+          "orcid": null
+        },
+        {
+          "ForeName": "Sarfraz",
+          "LastName": "Shafiq",
+          "abbrevName": "Shafiq S",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Sarfraz Shafiq",
+          "orcid": null
+        },
+        {
+          "ForeName": "Luana",
+          "LastName": "Langlois",
+          "abbrevName": "Langlois L",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Luana Langlois",
+          "orcid": null
+        },
+        {
+          "ForeName": "Jacob",
+          "LastName": "Ellegood",
+          "abbrevName": "Ellegood J",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Jacob Ellegood",
+          "orcid": null
+        },
+        {
+          "ForeName": "Lily",
+          "LastName": "Qiu",
+          "abbrevName": "Qiu LR",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Lily R Qiu",
+          "orcid": "0000-0003-0482-9484"
+        },
+        {
+          "ForeName": "Jason",
+          "LastName": "Lerch",
+          "abbrevName": "Lerch JP",
+          "email": null,
+          "isCollectiveName": false,
+          "name": "Jason P Lerch",
+          "orcid": null
+        },
+        {
+          "ForeName": "Nathalie",
+          "LastName": "Bérubé",
+          "abbrevName": "Bérubé NG",
+          "email": "nberube@uwo.ca",
+          "isCollectiveName": false,
+          "name": "Nathalie G Bérubé",
+          "orcid": null
+        }
+      ],
+      "correspondence": {
+        "authorEmail": [],
+        "emails": []
+      },
+      "createdDate": 1601387235.682,
+      "entries": [
+        {
+          "id": "74715bf7-c1da-420f-923a-1f37983cf184"
+        },
+        {
+          "id": "6efd818a-b71f-4618-bd73-08232cdc63d8"
+        },
+        {
+          "id": "39ed6d4b-0ef1-4ea8-b1e2-823aef3e6363"
+        },
+        {
+          "id": "e0f02139-fc9e-4463-8ac6-8632630323a9"
+        },
+        {
+          "id": "9004e33a-f2ab-4ab2-b95f-3ed48ee36391"
+        },
+        {
+          "id": "109b5c89-5eee-482e-8986-d8ae6f23d319"
+        }
+      ],
+      "id": "a6b4351d-b474-49d9-bc3d-f044513d5a0c",
+      "issues": {
+        "authorEmail": null,
+        "paperId": null
+      },
+      "lastEditedDate": 1601387408.647,
+      "liveId": "54007c4b-b92e-4e0a-82b5-c5bc3ed13997",
+      "lock": null,
+      "locked": false,
+      "organisms": [],
+      "provided": {
+        "authorEmail": "user@email.org",
+        "authorName": "John Doe",
+        "name": "John Doe",
+        "paperId": "Some paper id"
+      },
+      "referencedPapers": [
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "31502810",
+          "pubmed": {
+            "ISODate": "2021-08-01T00:00:00.000Z",
+            "abstract": null,
+            "authors": {
+              "abbreviation": "Yi Zhou, Ping Meng, Biao Tang, ..., Fan Zhu",
+              "authorList": [
+                {
+                  "ForeName": "Yi",
+                  "LastName": "Zhou",
+                  "abbrevName": "Zhou Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yi Zhou"
+                },
+                {
+                  "ForeName": "Ping",
+                  "LastName": "Meng",
+                  "abbrevName": "Meng P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ping Meng"
+                },
+                {
+                  "ForeName": "Biao",
+                  "LastName": "Tang",
+                  "abbrevName": "Tang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Biao Tang"
+                },
+                {
+                  "ForeName": "Zhangming",
+                  "LastName": "Ke",
+                  "abbrevName": "Ke Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zhangming Ke"
+                },
+                {
+                  "ForeName": "Liming",
+                  "LastName": "Liu",
+                  "abbrevName": "Liu L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Liming Liu"
+                },
+                {
+                  "ForeName": "Yifa",
+                  "LastName": "Chen",
+                  "abbrevName": "Chen Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yifa Chen"
+                },
+                {
+                  "ForeName": "Fan",
+                  "LastName": "Zhu",
+                  "abbrevName": "Zhu F",
+                  "email": "zffgh65@163.com",
+                  "isCollectiveName": false,
+                  "name": "Fan Zhu"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Fan",
+                  "LastName": "Zhu",
+                  "email": [
+                    "zffgh65@163.com"
+                  ],
+                  "name": "Fan Zhu"
+                }
+              ]
+            },
+            "doi": "10.23736/S0026-4806.19.06248-7",
+            "pmid": "31502810",
+            "pubTypes": [
+              {
+                "UI": "D016422",
+                "value": "Letter"
+              }
+            ],
+            "reference": "Minerva Med 112 2021",
+            "title": "MiR-616 promotes the progression of pancreatic carcinoma by targeting OXR1."
+          }
+        },
+        {
+          "pmid": "31301273",
+          "pubmed": {
+            "ISODate": "2019-11-01T00:00:00.000Z",
+            "abstract": "Recently, it has been demonstrated that microRNA-137 (miR-137) plays a vital role in the induction of oxidative stress of neurons in Parkinson's disease (PD). Herein, the study aimed to investigate the effects of serum exosomal miR-137 on oxidative stress injury of neurons in PD. Microarray analysis was adopted to screen the PD-related differential expressed genes and predict the interaction between OXR1 and miR-137 in PD. It was found that OXR1 was down-regulated while miR-137 was up-regulated in PD. Additionally, miR-137 targeted OXR1 and negatively regulated its expression. Mouse and neuron models of PD were established to mimic the pathological changes, especially oxidative stress injury induced by PD. The significance of miR-137 and OXR1 in oxidative stress injury was investigated in neuron model of PD using gain- and loss-of-function approaches. The obtained data exhibited that inhibition of miR-137 or up-regulation of OXR1 ameliorated PD-induced oxidative stress injury, reduced pole-climbing time, but increased score for traction test as well as promoted viability and decreased apoptosis of neurons in PD model, accompanied with decreased MDA content and ROS levels, and increased SOD levels. Furthermore, PD mice were injected with serum-derived exosomes or neurons in PD models were exposed to exosomes derived from serum of PD mice. Loss-of-function experiments using miR-137 antagomir exhibited that inhibition of exosomal miR-137 ameliorated PD-induced oxidative stress injury in vitro, reduced pole-climbing time but increased score for traction test in vivo. Collectively, down-regulation of exosomal miR-137 alleviates oxidative stress injury in PD by up-regulating OXR1.",
+            "authors": {
+              "abbreviation": "Yan Jiang, Jing Liu, Luzhu Chen, ..., Xingyuan Sun",
+              "authorList": [
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Jing",
+                  "LastName": "Liu",
+                  "abbrevName": "Liu J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jing Liu"
+                },
+                {
+                  "ForeName": "Luzhu",
+                  "LastName": "Chen",
+                  "abbrevName": "Chen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luzhu Chen"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jin",
+                  "abbrevName": "Jin Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jin"
+                },
+                {
+                  "ForeName": "Guangping",
+                  "LastName": "Zhang",
+                  "abbrevName": "Zhang G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Guangping Zhang"
+                },
+                {
+                  "ForeName": "Zaihong",
+                  "LastName": "Lin",
+                  "abbrevName": "Lin Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zaihong Lin"
+                },
+                {
+                  "ForeName": "Shu",
+                  "LastName": "Du",
+                  "abbrevName": "Du S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shu Du"
+                },
+                {
+                  "ForeName": "Zenghui",
+                  "LastName": "Fu",
+                  "abbrevName": "Fu Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zenghui Fu"
+                },
+                {
+                  "ForeName": "Tuantuan",
+                  "LastName": "Chen",
+                  "abbrevName": "Chen T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tuantuan Chen"
+                },
+                {
+                  "ForeName": "Yinhui",
+                  "LastName": "Qin",
+                  "abbrevName": "Qin Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yinhui Qin"
+                },
+                {
+                  "ForeName": "Xingyuan",
+                  "LastName": "Sun",
+                  "abbrevName": "Sun X",
+                  "email": "sunxingyuan@sina.com",
+                  "isCollectiveName": false,
+                  "name": "Xingyuan Sun"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Xingyuan",
+                  "LastName": "Sun",
+                  "email": [
+                    "sunxingyuan@sina.com"
+                  ],
+                  "name": "Xingyuan Sun"
+                }
+              ]
+            },
+            "doi": "10.1016/j.brainres.2019.146331",
+            "pmid": "31301273",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Brain Res 1722 2019",
+            "title": "Serum secreted miR-137-containing exosomes affects oxidative stress of neurons by regulating OXR1 in Parkinson's disease."
+          }
+        },
+        {
+          "pmid": "30209204",
+          "pubmed": {
+            "ISODate": "2018-09-12T00:00:00.000Z",
+            "abstract": "Men are generally superior to women in remembering spatial relationships, whereas the reverse holds for semantic information, but the neurobiological bases for these differences are not understood. Here we describe striking sexual dimorphism in synaptic mechanisms of memory encoding in hippocampal field CA1, a region critical for spatial learning. Studies of acute hippocampal slices from adult rats and mice show that for excitatory Schaffer-commissural projections, the memory-related long-term potentiation (LTP) effect depends upon endogenous estrogen and membrane estrogen receptor α (ERα) in females but not in males; there was no evident involvement of nuclear ERα in females, or of ERβ or GPER1 (G-protein-coupled estrogen receptor 1) in either sex. Quantitative immunofluorescence showed that stimulation-induced activation of two LTP-related kinases (Src, ERK1/2), and of postsynaptic TrkB, required ERα in females only, and that postsynaptic ERα levels are higher in females than in males. Several downstream signaling events involved in LTP were comparable between the sexes. In contrast to endogenous estrogen effects, infused estradiol facilitated LTP and synaptic signaling in females via both ERα and ERβ. The estrogen dependence of LTP in females was associated with a higher threshold for both inducing potentiation and acquiring spatial information. These results indicate that the observed sexual dimorphism in hippocampal LTP reflects differences in synaptic kinase activation, including both a weaker association with NMDA receptors and a greater ERα-mediated kinase activation in response to locally produced estrogen in females. We propose that male/female differences in mechanisms and threshold for field CA1 LTP contribute to differences in encoding specific types of memories.SIGNIFICANCE STATEMENT There is good evidence for male/female differences in memory-related cognitive function, but the neurobiological basis for this sexual dimorphism is not understood. Here we describe sex differences in synaptic function in a brain area that is critical for learning spatial cues. Our results show that female rodents have higher synaptic levels of estrogen receptor α (ERα) and, in contrast to males, require membrane ERα for the activation of signaling kinases that support long-term potentiation (LTP), a form of synaptic plasticity thought to underlie learning. The additional requirement of estrogen signaling in females resulted in a higher threshold for both LTP and hippocampal field CA1-dependent spatial learning. These results describe a synaptic basis for sexual dimorphism in encoding spatial information.",
+            "authors": {
+              "abbreviation": "Weisheng Wang, Aliza A Le, Bowen Hou, ..., Christine M Gall",
+              "authorList": [
+                {
+                  "ForeName": "Weisheng",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Weisheng Wang"
+                },
+                {
+                  "ForeName": "Aliza",
+                  "LastName": "Le",
+                  "abbrevName": "Le AA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Aliza A Le"
+                },
+                {
+                  "ForeName": "Bowen",
+                  "LastName": "Hou",
+                  "abbrevName": "Hou B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bowen Hou"
+                },
+                {
+                  "ForeName": "Julie",
+                  "LastName": "Lauterborn",
+                  "abbrevName": "Lauterborn JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Julie C Lauterborn"
+                },
+                {
+                  "ForeName": "Conor",
+                  "LastName": "Cox",
+                  "abbrevName": "Cox CD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Conor D Cox"
+                },
+                {
+                  "ForeName": "Ellis",
+                  "LastName": "Levin",
+                  "abbrevName": "Levin ER",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ellis R Levin"
+                },
+                {
+                  "ForeName": "Gary",
+                  "LastName": "Lynch",
+                  "abbrevName": "Lynch G",
+                  "email": "cmgall@uci.edu",
+                  "isCollectiveName": false,
+                  "name": "Gary Lynch"
+                },
+                {
+                  "ForeName": "Christine",
+                  "LastName": "Gall",
+                  "abbrevName": "Gall CM",
+                  "email": "cmgall@uci.edu",
+                  "isCollectiveName": false,
+                  "name": "Christine M Gall"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Gary",
+                  "LastName": "Lynch",
+                  "email": [
+                    "cmgall@uci.edu",
+                    "ga.s.lynch@gmail.com"
+                  ],
+                  "name": "Gary Lynch"
+                },
+                {
+                  "ForeName": "Christine",
+                  "LastName": "Gall",
+                  "email": [
+                    "cmgall@uci.edu",
+                    "ga.s.lynch@gmail.com"
+                  ],
+                  "name": "Christine M Gall"
+                }
+              ]
+            },
+            "doi": "10.1523/JNEUROSCI.0801-18.2018",
+            "pmid": "30209204",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "J Neurosci 38 2018",
+            "title": "Memory-Related Synaptic Plasticity Is Sexually Dimorphic in Rodent Hippocampus."
+          }
+        },
+        {
+          "pmid": "30104731",
+          "pubmed": {
+            "ISODate": "2018-09-01T00:00:00.000Z",
+            "abstract": "Autism spectrum disorders (ASDs) are four times more common in males than in females, but the underlying mechanisms are poorly understood. We characterized sexually dimorphic changes in mice carrying a heterozygous mutation in Chd8 (Chd8+/N2373K) that was first identified in human CHD8 (Asn2373LysfsX2), a strong ASD-risk gene that encodes a chromatin remodeler. Notably, although male mutant mice displayed a range of abnormal behaviors during pup, juvenile, and adult stages, including enhanced mother-seeking ultrasonic vocalization, enhanced attachment to reunited mothers, and isolation-induced self-grooming, their female counterparts do not. This behavioral divergence was associated with sexually dimorphic changes in neuronal activity, synaptic transmission, and transcriptomic profiles. Specifically, female mice displayed suppressed baseline neuronal excitation, enhanced inhibitory synaptic transmission and neuronal firing, and increased expression of genes associated with extracellular vesicles and the extracellular matrix. Our results suggest that a human CHD8 mutation leads to sexually dimorphic changes ranging from transcription to behavior in mice.",
+            "authors": {
+              "abbreviation": "Hwajin Jung, Haram Park, Yeonsoo Choi, ..., Eunjoon Kim",
+              "authorList": [
+                {
+                  "ForeName": "Hwajin",
+                  "LastName": "Jung",
+                  "abbrevName": "Jung H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hwajin Jung"
+                },
+                {
+                  "ForeName": "Haram",
+                  "LastName": "Park",
+                  "abbrevName": "Park H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Haram Park"
+                },
+                {
+                  "ForeName": "Yeonsoo",
+                  "LastName": "Choi",
+                  "abbrevName": "Choi Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yeonsoo Choi"
+                },
+                {
+                  "ForeName": "Hyojin",
+                  "LastName": "Kang",
+                  "abbrevName": "Kang H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hyojin Kang"
+                },
+                {
+                  "ForeName": "Eunee",
+                  "LastName": "Lee",
+                  "abbrevName": "Lee E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Eunee Lee"
+                },
+                {
+                  "ForeName": "Hanseul",
+                  "LastName": "Kweon",
+                  "abbrevName": "Kweon H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hanseul Kweon"
+                },
+                {
+                  "ForeName": "Junyeop",
+                  "LastName": "Roh",
+                  "abbrevName": "Roh JD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Junyeop Daniel Roh"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Woochul",
+                  "LastName": "Choi",
+                  "abbrevName": "Choi W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Woochul Choi"
+                },
+                {
+                  "ForeName": "Jaeseung",
+                  "LastName": "Kang",
+                  "abbrevName": "Kang J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jaeseung Kang"
+                },
+                {
+                  "ForeName": "Issac",
+                  "LastName": "Rhim",
+                  "abbrevName": "Rhim I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Issac Rhim"
+                },
+                {
+                  "ForeName": "Su-Yeon",
+                  "LastName": "Choi",
+                  "abbrevName": "Choi SY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Su-Yeon Choi"
+                },
+                {
+                  "ForeName": "Mihyun",
+                  "LastName": "Bae",
+                  "abbrevName": "Bae M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mihyun Bae"
+                },
+                {
+                  "ForeName": "Sun-Gyun",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sun-Gyun Kim"
+                },
+                {
+                  "ForeName": "Jiseok",
+                  "LastName": "Lee",
+                  "abbrevName": "Lee J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jiseok Lee"
+                },
+                {
+                  "ForeName": "Changuk",
+                  "LastName": "Chung",
+                  "abbrevName": "Chung C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Changuk Chung"
+                },
+                {
+                  "ForeName": "Taesun",
+                  "LastName": "Yoo",
+                  "abbrevName": "Yoo T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Taesun Yoo"
+                },
+                {
+                  "ForeName": "Hanwool",
+                  "LastName": "Park",
+                  "abbrevName": "Park H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hanwool Park"
+                },
+                {
+                  "ForeName": "Yangsik",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yangsik Kim"
+                },
+                {
+                  "ForeName": "Seungmin",
+                  "LastName": "Ha",
+                  "abbrevName": "Ha S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seungmin Ha"
+                },
+                {
+                  "ForeName": "Seung",
+                  "LastName": "Um",
+                  "abbrevName": "Um SM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seung Min Um"
+                },
+                {
+                  "ForeName": "Seojung",
+                  "LastName": "Mo",
+                  "abbrevName": "Mo S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seojung Mo"
+                },
+                {
+                  "ForeName": "Yonghan",
+                  "LastName": "Kwon",
+                  "abbrevName": "Kwon Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yonghan Kwon"
+                },
+                {
+                  "ForeName": "Won",
+                  "LastName": "Mah",
+                  "abbrevName": "Mah W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Won Mah"
+                },
+                {
+                  "ForeName": "Yong",
+                  "LastName": "Bae",
+                  "abbrevName": "Bae YC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yong Chul Bae"
+                },
+                {
+                  "ForeName": "Hyun",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hyun Kim"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Se-Bum",
+                  "LastName": "Paik",
+                  "abbrevName": "Paik SB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Se-Bum Paik"
+                },
+                {
+                  "ForeName": "Eunjoon",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim E",
+                  "email": "kime@kaist.ac.kr",
+                  "isCollectiveName": false,
+                  "name": "Eunjoon Kim"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Eunjoon",
+                  "LastName": "Kim",
+                  "email": [
+                    "kime@kaist.ac.kr"
+                  ],
+                  "name": "Eunjoon Kim"
+                }
+              ]
+            },
+            "doi": "10.1038/s41593-018-0208-z",
+            "pmid": "30104731",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Neurosci 21 2018",
+            "title": "Sexually dimorphic behavior, neuronal activity, and gene expression in Chd8-mutant mice."
+          }
+        },
+        {
+          "pmid": "29976930",
+          "pubmed": {
+            "ISODate": "2018-07-05T00:00:00.000Z",
+            "abstract": "Sex differences exist in behaviors, disease and neuropsychiatric disorders. Sexual dimorphisms however, have yet to be studied across the whole brain and across a comprehensive time course of postnatal development. Here, we use manganese-enhanced MRI (MEMRI) to longitudinally image male and female C57BL/6J mice across 9 time points, beginning at postnatal day 3. We recapitulate findings on canonically dimorphic areas, demonstrating MEMRI's ability to study neuroanatomical sex differences. We discover, upon whole-brain volume correction, that neuroanatomical regions larger in males develop earlier than those larger in females. Groups of areas with shared sexually dimorphic developmental trajectories reflect behavioral and functional networks, and expression of genes involved with sex processes. Also, post-pubertal neuroanatomy is highly individualized, and individualization occurs earlier in males. Our results demonstrate the ability of MEMRI to reveal comprehensive developmental differences between male and female brains, which will improve our understanding of sex-specific predispositions to various neuropsychiatric disorders.",
+            "authors": {
+              "abbreviation": "Lily R Qiu, Darren J Fernandes, Kamila U Szulc-Lerch, ..., Jason P Lerch",
+              "authorList": [
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": "lily.qiu@sickkids.ca",
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Darren",
+                  "LastName": "Fernandes",
+                  "abbrevName": "Fernandes DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Darren J Fernandes"
+                },
+                {
+                  "ForeName": "Kamila",
+                  "LastName": "Szulc-Lerch",
+                  "abbrevName": "Szulc-Lerch KU",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kamila U Szulc-Lerch"
+                },
+                {
+                  "ForeName": "Jun",
+                  "LastName": "Dazai",
+                  "abbrevName": "Dazai J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jun Dazai"
+                },
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Nieman",
+                  "abbrevName": "Nieman BJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brian J Nieman"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Turnbull",
+                  "abbrevName": "Turnbull DH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel H Turnbull"
+                },
+                {
+                  "ForeName": "Jane",
+                  "LastName": "Foster",
+                  "abbrevName": "Foster JA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jane A Foster"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Palmert",
+                  "abbrevName": "Palmert MR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark R Palmert"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "email": [
+                    "lily.qiu@sickkids.ca"
+                  ],
+                  "name": "Lily R Qiu"
+                }
+              ]
+            },
+            "doi": "10.1038/s41467-018-04921-2",
+            "pmid": "29976930",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Commun 9 2018",
+            "title": "Mouse MRI shows brain areas relatively larger in males emerge before those larger in females."
+          }
+        },
+        {
+          "pmid": "29927554",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "This article describes a detailed set of protocols for mouse brain imaging using MRI. We focus primarily on measuring changes in neuroanatomy, and provide both instructions for mouse preparation and details on image acquisition, image processing, and statistics. Practical details as well as theoretical considerations are provided. © 2018 by John Wiley & Sons, Inc.",
+            "authors": {
+              "abbreviation": "Brian J Nieman, Matthijs C van Eede, Shoshana Spring, ..., Jason P Lerch",
+              "authorList": [
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Nieman",
+                  "abbrevName": "Nieman BJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brian J Nieman"
+                },
+                {
+                  "ForeName": "Matthijs",
+                  "LastName": "van Eede",
+                  "abbrevName": "van Eede MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthijs C van Eede"
+                },
+                {
+                  "ForeName": "Shoshana",
+                  "LastName": "Spring",
+                  "abbrevName": "Spring S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shoshana Spring"
+                },
+                {
+                  "ForeName": "Jun",
+                  "LastName": "Dazai",
+                  "abbrevName": "Dazai J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jun Dazai"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Henkelman",
+                  "abbrevName": "Henkelman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Mark Henkelman"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": "jason.lerch@sickkids.ca",
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "email": [
+                    "jason.lerch@sickkids.ca"
+                  ],
+                  "name": "Jason P Lerch"
+                }
+              ]
+            },
+            "doi": "10.1002/cpmo.44",
+            "pmid": "29927554",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Curr Protoc Mouse Biol 8 2018",
+            "title": "MRI to Assess Neurological Function."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "29665782",
+          "pubmed": {
+            "ISODate": "2018-04-17T00:00:00.000Z",
+            "abstract": "BACKGROUND: Mutations in the SHANK genes, which encode postsynaptic scaffolding proteins, have been linked to a spectrum of neurodevelopmental disorders. The SHANK genes and the schizophrenia-associated microRNA-137 show convergence on several levels, as they are both expressed at the synapse, influence neuronal development, and have a strong link to neurodevelopmental and neuropsychiatric disorders like intellectual disability, autism, and schizophrenia. This compiled evidence raised the question if the SHANKs might be targets of miR-137. METHODS: In silico analysis revealed a putative binding site for microRNA-137 (miR-137) in the SHANK2 3'UTR, while this was not the case for SHANK1 and SHANK3. Luciferase reporter assays were performed by overexpressing wild type and mutated SHANK2-3'UTR and miR-137 in human neuroblastoma cells and mouse primary hippocampal neurons. miR-137 was also overexpressed or inhibited in hippocampal neurons, and Shank2 expression was analyzed by quantitative real-time PCR and Western blot. Additionally, expression levels of experimentally validated miR-137 target genes were analyzed in the dorsolateral prefrontal cortex (DLPFC) of schizophrenia and control individuals using the RNA-Seq data from the CommonMind Consortium. RESULTS: miR-137 directly targets the 3'UTR of SHANK2 in a site-specific manner. Overexpression of miR-137 in mouse primary hippocampal neurons significantly lowered endogenous Shank2 protein levels without detectable influence on mRNA levels. Conversely, miR-137 inhibition increased Shank2 protein expression, indicating that miR-137 regulates SHANK2 expression by repressing protein translation rather than inducing mRNA degradation. To find out if the miR-137 signaling network is altered in schizophrenia, we compared miR-137 precursor and miR-137 target gene expression in the DLPFC of schizophrenia and control individuals using the CommonMind Consortium RNA sequencing data. Differential expression of 23% (16/69) of known miR-137 target genes was detected in the DLPFC of schizophrenia individuals compared with controls. We propose that in further targets (e.g., SHANK2, as described in this paper) which are not regulated on RNA level, effects may only be detectable on protein level. CONCLUSION: Our study provides evidence that a direct regulatory link exists between miR-137 and SHANK2 and supports the finding that miR-137 signaling might be altered in schizophrenia.",
+            "authors": {
+              "abbreviation": "Ana de Sena Cortabitarte, Simone Berkel, Flavia-Bianca Cristian, ..., Gudrun A Rappold",
+              "authorList": [
+                {
+                  "ForeName": "Ana",
+                  "LastName": "de Sena Cortabitarte",
+                  "abbrevName": "de Sena Cortabitarte A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ana de Sena Cortabitarte"
+                },
+                {
+                  "ForeName": "Simone",
+                  "LastName": "Berkel",
+                  "abbrevName": "Berkel S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Simone Berkel"
+                },
+                {
+                  "ForeName": "Flavia-Bianca",
+                  "LastName": "Cristian",
+                  "abbrevName": "Cristian FB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Flavia-Bianca Cristian"
+                },
+                {
+                  "ForeName": "Christine",
+                  "LastName": "Fischer",
+                  "abbrevName": "Fischer C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christine Fischer"
+                },
+                {
+                  "ForeName": "Gudrun",
+                  "LastName": "Rappold",
+                  "abbrevName": "Rappold GA",
+                  "email": "Gudrun.Rappold@med.uni-heidelberg.de",
+                  "isCollectiveName": false,
+                  "name": "Gudrun A Rappold"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Gudrun",
+                  "LastName": "Rappold",
+                  "email": [
+                    "Gudrun.Rappold@med.uni-heidelberg.de"
+                  ],
+                  "name": "Gudrun A Rappold"
+                }
+              ]
+            },
+            "doi": "10.1186/s11689-018-9233-1",
+            "pmid": "29665782",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Neurodev Disord 10 2018",
+            "title": "A direct regulatory link between microRNA-137 and SHANK2: implications for neuropsychiatric disorders."
+          }
+        },
+        {
+          "pmid": "29650040",
+          "pubmed": {
+            "ISODate": "2018-04-12T00:00:00.000Z",
+            "abstract": "Compared to RNA-sequencing transcript differential analysis, gene-level differential expression analysis is more robust and experimentally actionable. However, the use of gene counts for statistical analysis can mask transcript-level dynamics. We demonstrate that 'analysis first, aggregation second,' where the p values derived from transcript analysis are aggregated to obtain gene-level results, increase sensitivity and accuracy. The method we propose can also be applied to transcript compatibility counts obtained from pseudoalignment of reads, which circumvents the need for quantification and is fast, accurate, and model-free. The method generalizes to various levels of biology and we showcase an application to gene ontologies.",
+            "authors": {
+              "abbreviation": "Lynn Yi, Harold Pimentel, Nicolas L Bray, Lior Pachter",
+              "authorList": [
+                {
+                  "ForeName": "Lynn",
+                  "LastName": "Yi",
+                  "abbrevName": "Yi L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lynn Yi"
+                },
+                {
+                  "ForeName": "Harold",
+                  "LastName": "Pimentel",
+                  "abbrevName": "Pimentel H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Harold Pimentel"
+                },
+                {
+                  "ForeName": "Nicolas",
+                  "LastName": "Bray",
+                  "abbrevName": "Bray NL",
+                  "email": "nicolas.bray@gmail.com",
+                  "isCollectiveName": false,
+                  "name": "Nicolas L Bray"
+                },
+                {
+                  "ForeName": "Lior",
+                  "LastName": "Pachter",
+                  "abbrevName": "Pachter L",
+                  "email": "lpachter@caltech.edu",
+                  "isCollectiveName": false,
+                  "name": "Lior Pachter"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nicolas",
+                  "LastName": "Bray",
+                  "email": [
+                    "nicolas.bray@gmail.com"
+                  ],
+                  "name": "Nicolas L Bray"
+                },
+                {
+                  "ForeName": "Lior",
+                  "LastName": "Pachter",
+                  "email": [
+                    "lpachter@caltech.edu"
+                  ],
+                  "name": "Lior Pachter"
+                }
+              ]
+            },
+            "doi": "10.1186/s13059-018-1419-z",
+            "pmid": "29650040",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Genome Biol 19 2018",
+            "title": "Gene-level differential analysis at transcript-level resolution."
+          }
+        },
+        {
+          "pmid": "29635364",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "The MIR137 locus is a replicated genetic risk factor for schizophrenia. The risk-associated allele is reported to increase miR-137 expression and miR-137 overexpression alters synaptic transmission in mouse hippocampus. We investigated the cellular mechanisms underlying these observed effects in mouse hippocampal neurons in culture. First, we correlated the risk allele to expression of the genes in the MIR137 locus in human postmortem brain. Some evidence for increased MIR137HG expression was observed, especially in hippocampus of the disease-associated genotype. Second, in mouse hippocampal neurons, we confirmed previously observed changes in synaptic transmission upon miR-137 overexpression. Evoked synaptic transmission and spontaneous release were 50% reduced. We identified defects in release probability as the underlying cause. In contrast to previous observations, no evidence was obtained for selective synaptic vesicle docking defects. Instead, ultrastructural morphometry revealed multiple effects of miR-137 overexpression on docking, active zone length and total vesicle number. Moreover, proteomic analyses of neuronal protein showed that expression of Syt1 and Cplx1, previously reported as downregulated upon miR-137 overexpression, was unaltered. Immunocytochemistry of synapses overexpressing miR-137 showed normal Synaptotagmin1 and Complexin1 protein levels. Instead, our proteomic analyses revealed altered expression of genes involved in synaptogenesis. Concomitantly, synaptogenesis assays revealed 31% reduction in synapse formation. Taken together, these data show that miR-137 regulates synaptic function by regulating synaptogenesis, synaptic ultrastructure and synapse function. These effects are plausible contributors to the increased schizophrenia risk associated with miR-137 overexpression.",
+            "authors": {
+              "abbreviation": "Enqi He, Miguel A Gonzalez Lozano, Sven Stringer, ..., Matthijs Verhage",
+              "authorList": [
+                {
+                  "ForeName": "Enqi",
+                  "LastName": "He",
+                  "abbrevName": "He E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Enqi He"
+                },
+                {
+                  "ForeName": "Miguel",
+                  "LastName": "Lozano",
+                  "abbrevName": "Lozano MAG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Miguel A Gonzalez Lozano"
+                },
+                {
+                  "ForeName": "Sven",
+                  "LastName": "Stringer",
+                  "abbrevName": "Stringer S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sven Stringer"
+                },
+                {
+                  "ForeName": "Kyoko",
+                  "LastName": "Watanabe",
+                  "abbrevName": "Watanabe K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyoko Watanabe"
+                },
+                {
+                  "ForeName": "Kensuke",
+                  "LastName": "Sakamoto",
+                  "abbrevName": "Sakamoto K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kensuke Sakamoto"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "den Oudsten",
+                  "abbrevName": "den Oudsten F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank den Oudsten"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Koopmans",
+                  "abbrevName": "Koopmans F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Koopmans"
+                },
+                {
+                  "ForeName": "Stephanie",
+                  "LastName": "Giamberardino",
+                  "abbrevName": "Giamberardino SN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephanie N Giamberardino"
+                },
+                {
+                  "ForeName": "Anke",
+                  "LastName": "Hammerschlag",
+                  "abbrevName": "Hammerschlag A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anke Hammerschlag"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Cornelisse",
+                  "abbrevName": "Cornelisse LN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Niels Cornelisse"
+                },
+                {
+                  "ForeName": "Ka",
+                  "LastName": "Li",
+                  "abbrevName": "Li KW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ka Wan Li"
+                },
+                {
+                  "ForeName": "Jan",
+                  "LastName": "van Weering",
+                  "abbrevName": "van Weering J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jan van Weering"
+                },
+                {
+                  "ForeName": "Danielle",
+                  "LastName": "Posthuma",
+                  "abbrevName": "Posthuma D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Danielle Posthuma"
+                },
+                {
+                  "ForeName": "August",
+                  "LastName": "Smit",
+                  "abbrevName": "Smit AB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "August B Smit"
+                },
+                {
+                  "ForeName": "Patrick",
+                  "LastName": "Sullivan",
+                  "abbrevName": "Sullivan PF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Patrick F Sullivan"
+                },
+                {
+                  "ForeName": "Matthijs",
+                  "LastName": "Verhage",
+                  "abbrevName": "Verhage M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthijs Verhage"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddy089",
+            "pmid": "29635364",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 27 2018",
+            "title": "MIR137 schizophrenia-associated locus controls synaptic function by regulating synaptogenesis, synapse maturation and synaptic transmission."
+          }
+        },
+        {
+          "pmid": "29196732",
+          "pubmed": {
+            "ISODate": "2017-12-01T00:00:00.000Z",
+            "abstract": "Autism spectrum disorders (ASD) are more common among boys than girls. The mechanisms responsible for ASD symptoms and their sex differences remain mostly unclear. We previously identified collapsin response mediator protein 4 (CRMP4) as a protein exhibiting sex-different expression during sexual differentiation of the hypothalamic sexually dimorphic nucleus. This study investigated the relationship between the sex-different development of autistic features and CRMP4 deficiency. Whole-exome sequencing detected a de novo variant (S541Y) of CRMP4 in a male ASD patient. The expression of mutated mouse CRMP4 S540Y, which is homologous to human CRMP4 S541Y, in cultured hippocampal neurons derived from Crmp4-knockout (KO) mice had increased dendritic branching, compared to those transfected with wild-type (WT) Crmp4, indicating that this mutation results in altered CRMP4 function in neurons. Crmp4-KO mice showed decreased social interaction and several alterations of sensory responses. Most of these changes were more severe in male Crmp4-KO mice than in females. The mRNA expression levels of some genes related to neurotransmission and cell adhesion were altered in the brain of Crmp4-KO mice, mostly in a gender-dependent manner. These results indicate a functional link between a case-specific, rare variant of one gene, Crmp4, and several characteristics of ASD, including sexual differences.",
+            "authors": {
+              "abbreviation": "Atsuhiro Tsutiya, Yui Nakano, Emily Hansen-Kiss, ..., Ritsuko Ohtani-Kaneko",
+              "authorList": [
+                {
+                  "ForeName": "Atsuhiro",
+                  "LastName": "Tsutiya",
+                  "abbrevName": "Tsutiya A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Atsuhiro Tsutiya"
+                },
+                {
+                  "ForeName": "Yui",
+                  "LastName": "Nakano",
+                  "abbrevName": "Nakano Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yui Nakano"
+                },
+                {
+                  "ForeName": "Emily",
+                  "LastName": "Hansen-Kiss",
+                  "abbrevName": "Hansen-Kiss E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Emily Hansen-Kiss"
+                },
+                {
+                  "ForeName": "Benjamin",
+                  "LastName": "Kelly",
+                  "abbrevName": "Kelly B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Benjamin Kelly"
+                },
+                {
+                  "ForeName": "Masugi",
+                  "LastName": "Nishihara",
+                  "abbrevName": "Nishihara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masugi Nishihara"
+                },
+                {
+                  "ForeName": "Yoshio",
+                  "LastName": "Goshima",
+                  "abbrevName": "Goshima Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoshio Goshima"
+                },
+                {
+                  "ForeName": "Don",
+                  "LastName": "Corsmeier",
+                  "abbrevName": "Corsmeier D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Don Corsmeier"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "White",
+                  "abbrevName": "White P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter White"
+                },
+                {
+                  "ForeName": "Gail",
+                  "LastName": "Herman",
+                  "abbrevName": "Herman GE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gail E Herman"
+                },
+                {
+                  "ForeName": "Ritsuko",
+                  "LastName": "Ohtani-Kaneko",
+                  "abbrevName": "Ohtani-Kaneko R",
+                  "email": "r-kaneko@toyo.jp",
+                  "isCollectiveName": false,
+                  "name": "Ritsuko Ohtani-Kaneko"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ritsuko",
+                  "LastName": "Ohtani-Kaneko",
+                  "email": [
+                    "r-kaneko@toyo.jp"
+                  ],
+                  "name": "Ritsuko Ohtani-Kaneko"
+                }
+              ]
+            },
+            "doi": "10.1038/s41598-017-16782-8",
+            "pmid": "29196732",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Sci Rep 7 2017",
+            "title": "Human CRMP4 mutation and disrupted Crmp4 expression in mice are associated with ASD characteristics and sexual dimorphism."
+          }
+        },
+        {
+          "pmid": "29180823",
+          "pubmed": {
+            "ISODate": "2018-01-01T00:00:00.000Z",
+            "abstract": "Whole-gene duplications and missense variants in the HUWE1 gene (NM_031407.6) have been reported in association with intellectual disability (ID). Increased gene dosage has been observed in males with non-syndromic mild to moderate ID with speech delay. Missense variants reported previously appear to be associated with severe ID in males and mild or no ID in obligate carrier females. Here, we report the largest cohort of patients with HUWE1 variants, consisting of 14 females and 7 males, with 15 different missense variants and one splice site variant. Clinical assessment identified common clinical features consisting of moderate to profound ID, delayed or absent speech, short stature with small hands and feet and facial dysmorphism consisting of a broad nasal tip, deep set eyes, epicanthic folds, short palpebral fissures, and a short philtrum. We describe for the first time that females can be severely affected, despite preferential inactivation of the affected X chromosome. Three females with the c.329 G  >  A p.Arg110Gln variant, present with a phenotype of mild ID, specific facial features, scoliosis and craniosynostosis, as reported previously in a single patient. In these females, the X inactivation pattern appeared skewed in favour of the affected transcript. In summary, HUWE1 missense variants may cause syndromic ID in both males and females.",
+            "authors": {
+              "abbreviation": "Stéphanie Moortgat, Siren Berland, Ingvild Aukrust, ..., Ruth A Newbury-Ecob",
+              "authorList": [
+                {
+                  "ForeName": "Stéphanie",
+                  "LastName": "Moortgat",
+                  "abbrevName": "Moortgat S",
+                  "email": "stephanie.moortgat@ipg.be",
+                  "isCollectiveName": false,
+                  "name": "Stéphanie Moortgat"
+                },
+                {
+                  "ForeName": "Siren",
+                  "LastName": "Berland",
+                  "abbrevName": "Berland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Siren Berland"
+                },
+                {
+                  "ForeName": "Ingvild",
+                  "LastName": "Aukrust",
+                  "abbrevName": "Aukrust I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ingvild Aukrust"
+                },
+                {
+                  "ForeName": "Isabelle",
+                  "LastName": "Maystadt",
+                  "abbrevName": "Maystadt I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isabelle Maystadt"
+                },
+                {
+                  "ForeName": "Laura",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Laura Baker"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Benoit",
+                  "abbrevName": "Benoit V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie Benoit"
+                },
+                {
+                  "ForeName": "Alfonso",
+                  "LastName": "Caro-Llopis",
+                  "abbrevName": "Caro-Llopis A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alfonso Caro-Llopis"
+                },
+                {
+                  "ForeName": "Nicola",
+                  "LastName": "Cooper",
+                  "abbrevName": "Cooper NS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicola S Cooper"
+                },
+                {
+                  "ForeName": "François-Guillaume",
+                  "LastName": "Debray",
+                  "abbrevName": "Debray FG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "François-Guillaume Debray"
+                },
+                {
+                  "ForeName": "Laurence",
+                  "LastName": "Faivre",
+                  "abbrevName": "Faivre L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Laurence Faivre"
+                },
+                {
+                  "ForeName": "Thatjana",
+                  "LastName": "Gardeitchik",
+                  "abbrevName": "Gardeitchik T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thatjana Gardeitchik"
+                },
+                {
+                  "ForeName": "Bjørn",
+                  "LastName": "Haukanes",
+                  "abbrevName": "Haukanes BI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bjørn I Haukanes"
+                },
+                {
+                  "ForeName": "Gunnar",
+                  "LastName": "Houge",
+                  "abbrevName": "Houge G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gunnar Houge"
+                },
+                {
+                  "ForeName": "Emma",
+                  "LastName": "Kivuva",
+                  "abbrevName": "Kivuva E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Emma Kivuva"
+                },
+                {
+                  "ForeName": "Francisco",
+                  "LastName": "Martinez",
+                  "abbrevName": "Martinez F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Francisco Martinez"
+                },
+                {
+                  "ForeName": "Sarju",
+                  "LastName": "Mehta",
+                  "abbrevName": "Mehta SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarju G Mehta"
+                },
+                {
+                  "ForeName": "Marie-Cécile",
+                  "LastName": "Nassogne",
+                  "abbrevName": "Nassogne MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marie-Cécile Nassogne"
+                },
+                {
+                  "ForeName": "Nina",
+                  "LastName": "Powell-Hamilton",
+                  "abbrevName": "Powell-Hamilton N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nina Powell-Hamilton"
+                },
+                {
+                  "ForeName": "Rolph",
+                  "LastName": "Pfundt",
+                  "abbrevName": "Pfundt R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rolph Pfundt"
+                },
+                {
+                  "ForeName": "Monica",
+                  "LastName": "Rosello",
+                  "abbrevName": "Rosello M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Monica Rosello"
+                },
+                {
+                  "ForeName": "Trine",
+                  "LastName": "Prescott",
+                  "abbrevName": "Prescott T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Trine Prescott"
+                },
+                {
+                  "ForeName": "Pradeep",
+                  "LastName": "Vasudevan",
+                  "abbrevName": "Vasudevan P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pradeep Vasudevan"
+                },
+                {
+                  "ForeName": "Barbara",
+                  "LastName": "van Loon",
+                  "abbrevName": "van Loon B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Barbara van Loon"
+                },
+                {
+                  "ForeName": "Christine",
+                  "LastName": "Verellen-Dumoulin",
+                  "abbrevName": "Verellen-Dumoulin C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christine Verellen-Dumoulin"
+                },
+                {
+                  "ForeName": "Alain",
+                  "LastName": "Verloes",
+                  "abbrevName": "Verloes A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alain Verloes"
+                },
+                {
+                  "ForeName": "Charlotte",
+                  "LastName": "Lippe",
+                  "abbrevName": "Lippe CV",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Charlotte von der Lippe"
+                },
+                {
+                  "ForeName": "Emma",
+                  "LastName": "Wakeling",
+                  "abbrevName": "Wakeling E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Emma Wakeling"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "Wilkie",
+                  "abbrevName": "Wilkie AOM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew O M Wilkie"
+                },
+                {
+                  "ForeName": "Louise",
+                  "LastName": "Wilson",
+                  "abbrevName": "Wilson L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Louise Wilson"
+                },
+                {
+                  "ForeName": "Amy",
+                  "LastName": "Yuen",
+                  "abbrevName": "Yuen A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Amy Yuen"
+                },
+                {
+                  "ForeName": "Ddd",
+                  "LastName": "Study",
+                  "abbrevName": "Study D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ddd Study"
+                },
+                {
+                  "ForeName": "Karen",
+                  "LastName": "Low",
+                  "abbrevName": "Low KJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Karen J Low"
+                },
+                {
+                  "ForeName": "Ruth",
+                  "LastName": "Newbury-Ecob",
+                  "abbrevName": "Newbury-Ecob RA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ruth A Newbury-Ecob"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Stéphanie",
+                  "LastName": "Moortgat",
+                  "email": [
+                    "stephanie.moortgat@ipg.be"
+                  ],
+                  "name": "Stéphanie Moortgat"
+                }
+              ]
+            },
+            "doi": "10.1038/s41431-017-0038-6",
+            "pmid": "29180823",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Eur J Hum Genet 26 2018",
+            "title": "HUWE1 variants cause dominant X-linked intellectual disability: a clinical study of 21 patients."
+          }
+        },
+        {
+          "pmid": "29155950",
+          "pubmed": {
+            "ISODate": "2018-01-04T00:00:00.000Z",
+            "abstract": "The Ensembl project has been aggregating, processing, integrating and redistributing genomic datasets since the initial releases of the draft human genome, with the aim of accelerating genomics research through rapid open distribution of public data. Large amounts of raw data are thus transformed into knowledge, which is made available via a multitude of channels, in particular our browser (http://www.ensembl.org). Over time, we have expanded in multiple directions. First, our resources describe multiple fields of genomics, in particular gene annotation, comparative genomics, genetics and epigenomics. Second, we cover a growing number of genome assemblies; Ensembl Release 90 contains exactly 100. Third, our databases feed simultaneously into an array of services designed around different use cases, ranging from quick browsing to genome-wide bioinformatic analysis. We present here the latest developments of the Ensembl project, with a focus on managing an increasing number of assemblies, supporting efforts in genome interpretation and improving our browser.",
+            "authors": {
+              "abbreviation": "Daniel R Zerbino, Premanand Achuthan, Wasiu Akanni, ..., Paul Flicek",
+              "authorList": [
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Zerbino",
+                  "abbrevName": "Zerbino DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel R Zerbino"
+                },
+                {
+                  "ForeName": "Premanand",
+                  "LastName": "Achuthan",
+                  "abbrevName": "Achuthan P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Premanand Achuthan"
+                },
+                {
+                  "ForeName": "Wasiu",
+                  "LastName": "Akanni",
+                  "abbrevName": "Akanni W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wasiu Akanni"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Amode",
+                  "abbrevName": "Amode MR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Ridwan Amode"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Barrell",
+                  "abbrevName": "Barrell D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel Barrell"
+                },
+                {
+                  "ForeName": "Jyothish",
+                  "LastName": "Bhai",
+                  "abbrevName": "Bhai J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jyothish Bhai"
+                },
+                {
+                  "ForeName": "Konstantinos",
+                  "LastName": "Billis",
+                  "abbrevName": "Billis K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Konstantinos Billis"
+                },
+                {
+                  "ForeName": "Carla",
+                  "LastName": "Cummins",
+                  "abbrevName": "Cummins C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Carla Cummins"
+                },
+                {
+                  "ForeName": "Astrid",
+                  "LastName": "Gall",
+                  "abbrevName": "Gall A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Astrid Gall"
+                },
+                {
+                  "ForeName": "Carlos",
+                  "LastName": "Girón",
+                  "abbrevName": "Girón CG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Carlos García Girón"
+                },
+                {
+                  "ForeName": "Laurent",
+                  "LastName": "Gil",
+                  "abbrevName": "Gil L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Laurent Gil"
+                },
+                {
+                  "ForeName": "Leo",
+                  "LastName": "Gordon",
+                  "abbrevName": "Gordon L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Leo Gordon"
+                },
+                {
+                  "ForeName": "Leanne",
+                  "LastName": "Haggerty",
+                  "abbrevName": "Haggerty L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Leanne Haggerty"
+                },
+                {
+                  "ForeName": "Erin",
+                  "LastName": "Haskell",
+                  "abbrevName": "Haskell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Erin Haskell"
+                },
+                {
+                  "ForeName": "Thibaut",
+                  "LastName": "Hourlier",
+                  "abbrevName": "Hourlier T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thibaut Hourlier"
+                },
+                {
+                  "ForeName": "Osagie",
+                  "LastName": "Izuogu",
+                  "abbrevName": "Izuogu OG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Osagie G Izuogu"
+                },
+                {
+                  "ForeName": "Sophie",
+                  "LastName": "Janacek",
+                  "abbrevName": "Janacek SH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sophie H Janacek"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Juettemann",
+                  "abbrevName": "Juettemann T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas Juettemann"
+                },
+                {
+                  "ForeName": "Jimmy",
+                  "LastName": "To",
+                  "abbrevName": "To JK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jimmy Kiang To"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Laird",
+                  "abbrevName": "Laird MR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew R Laird"
+                },
+                {
+                  "ForeName": "Ilias",
+                  "LastName": "Lavidas",
+                  "abbrevName": "Lavidas I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ilias Lavidas"
+                },
+                {
+                  "ForeName": "Zhicheng",
+                  "LastName": "Liu",
+                  "abbrevName": "Liu Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zhicheng Liu"
+                },
+                {
+                  "ForeName": "Jane",
+                  "LastName": "Loveland",
+                  "abbrevName": "Loveland JE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jane E Loveland"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Maurel",
+                  "abbrevName": "Maurel T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas Maurel"
+                },
+                {
+                  "ForeName": "William",
+                  "LastName": "McLaren",
+                  "abbrevName": "McLaren W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "William McLaren"
+                },
+                {
+                  "ForeName": "Benjamin",
+                  "LastName": "Moore",
+                  "abbrevName": "Moore B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Benjamin Moore"
+                },
+                {
+                  "ForeName": "Jonathan",
+                  "LastName": "Mudge",
+                  "abbrevName": "Mudge J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jonathan Mudge"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Murphy",
+                  "abbrevName": "Murphy DN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel N Murphy"
+                },
+                {
+                  "ForeName": "Victoria",
+                  "LastName": "Newman",
+                  "abbrevName": "Newman V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Victoria Newman"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Nuhn",
+                  "abbrevName": "Nuhn M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Nuhn"
+                },
+                {
+                  "ForeName": "Denye",
+                  "LastName": "Ogeh",
+                  "abbrevName": "Ogeh D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Denye Ogeh"
+                },
+                {
+                  "ForeName": "Chuang",
+                  "LastName": "Ong",
+                  "abbrevName": "Ong CK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chuang Kee Ong"
+                },
+                {
+                  "ForeName": "Anne",
+                  "LastName": "Parker",
+                  "abbrevName": "Parker A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anne Parker"
+                },
+                {
+                  "ForeName": "Mateus",
+                  "LastName": "Patricio",
+                  "abbrevName": "Patricio M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mateus Patricio"
+                },
+                {
+                  "ForeName": "Harpreet",
+                  "LastName": "Riat",
+                  "abbrevName": "Riat HS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Harpreet Singh Riat"
+                },
+                {
+                  "ForeName": "Helen",
+                  "LastName": "Schuilenburg",
+                  "abbrevName": "Schuilenburg H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Helen Schuilenburg"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Sheppard",
+                  "abbrevName": "Sheppard D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Sheppard"
+                },
+                {
+                  "ForeName": "Helen",
+                  "LastName": "Sparrow",
+                  "abbrevName": "Sparrow H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Helen Sparrow"
+                },
+                {
+                  "ForeName": "Kieron",
+                  "LastName": "Taylor",
+                  "abbrevName": "Taylor K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kieron Taylor"
+                },
+                {
+                  "ForeName": "Anja",
+                  "LastName": "Thormann",
+                  "abbrevName": "Thormann A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anja Thormann"
+                },
+                {
+                  "ForeName": "Alessandro",
+                  "LastName": "Vullo",
+                  "abbrevName": "Vullo A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alessandro Vullo"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Walts",
+                  "abbrevName": "Walts B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Walts"
+                },
+                {
+                  "ForeName": "Amonida",
+                  "LastName": "Zadissa",
+                  "abbrevName": "Zadissa A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Amonida Zadissa"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Frankish",
+                  "abbrevName": "Frankish A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam Frankish"
+                },
+                {
+                  "ForeName": "Sarah",
+                  "LastName": "Hunt",
+                  "abbrevName": "Hunt SE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarah E Hunt"
+                },
+                {
+                  "ForeName": "Myrto",
+                  "LastName": "Kostadima",
+                  "abbrevName": "Kostadima M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Myrto Kostadima"
+                },
+                {
+                  "ForeName": "Nicholas",
+                  "LastName": "Langridge",
+                  "abbrevName": "Langridge N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicholas Langridge"
+                },
+                {
+                  "ForeName": "Fergal",
+                  "LastName": "Martin",
+                  "abbrevName": "Martin FJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Fergal J Martin"
+                },
+                {
+                  "ForeName": "Matthieu",
+                  "LastName": "Muffato",
+                  "abbrevName": "Muffato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthieu Muffato"
+                },
+                {
+                  "ForeName": "Emily",
+                  "LastName": "Perry",
+                  "abbrevName": "Perry E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Emily Perry"
+                },
+                {
+                  "ForeName": "Magali",
+                  "LastName": "Ruffier",
+                  "abbrevName": "Ruffier M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Magali Ruffier"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Staines",
+                  "abbrevName": "Staines DM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan M Staines"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Trevanion",
+                  "abbrevName": "Trevanion SJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen J Trevanion"
+                },
+                {
+                  "ForeName": "Bronwen",
+                  "LastName": "Aken",
+                  "abbrevName": "Aken BL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bronwen L Aken"
+                },
+                {
+                  "ForeName": "Fiona",
+                  "LastName": "Cunningham",
+                  "abbrevName": "Cunningham F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Fiona Cunningham"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "Yates",
+                  "abbrevName": "Yates A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew Yates"
+                },
+                {
+                  "ForeName": "Paul",
+                  "LastName": "Flicek",
+                  "abbrevName": "Flicek P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Paul Flicek"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/nar/gkx1098",
+            "pmid": "29155950",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nucleic Acids Res 46 2018",
+            "title": "Ensembl 2018."
+          }
+        },
+        {
+          "pmid": "29133437",
+          "pubmed": {
+            "ISODate": "2018-01-03T00:00:00.000Z",
+            "abstract": "CCCTC-binding factor (CTCF) is an 11 zinc finger DNA-binding domain protein that regulates gene expression by modifying 3D chromatin structure. Human mutations in CTCF cause intellectual disability and autistic features. Knocking out Ctcf in mouse embryonic neurons is lethal by neonatal age, but the effects of CTCF deficiency in postnatal neurons are less well studied. We knocked out Ctcf postnatally in glutamatergic forebrain neurons under the control of Camk2a-Cre. CtcfloxP/loxP;Camk2a-Cre+ (Ctcf CKO) mice of both sexes were viable and exhibited profound deficits in spatial learning/memory, impaired motor coordination, and decreased sociability by 4 months of age. Ctcf CKO mice also had reduced dendritic spine density in the hippocampus and cerebral cortex. Microarray analysis of mRNA from Ctcf CKO mouse hippocampus identified increased transcription of inflammation-related genes linked to microglia. Separate microarray analysis of mRNA isolated specifically from Ctcf CKO mouse hippocampal neurons by ribosomal affinity purification identified upregulation of chemokine signaling genes, suggesting crosstalk between neurons and microglia in Ctcf CKO hippocampus. Finally, we found that microglia in Ctcf CKO mouse hippocampus had abnormal morphology by Sholl analysis and increased immunostaining for CD68, a marker of microglial activation. Our findings confirm that Ctcf KO in postnatal neurons causes a neurobehavioral phenotype in mice and provide novel evidence that CTCF depletion leads to overexpression of inflammation-related genes and microglial dysfunction.SIGNIFICANCE STATEMENT CCCTC-binding factor (CTCF) is a DNA-binding protein that organizes nuclear chromatin topology. Mutations in CTCF cause intellectual disability and autistic features in humans. CTCF deficiency in embryonic neurons is lethal in mice, but mice with postnatal CTCF depletion are less well studied. We find that mice lacking Ctcf in Camk2a-expressing neurons (Ctcf CKO mice) have spatial learning/memory deficits, impaired fine motor skills, subtly altered social interactions, and decreased dendritic spine density. We demonstrate that Ctcf CKO mice overexpress inflammation-related genes in the brain and have microglia with abnormal morphology that label positive for CD68, a marker of microglial activation. Our findings suggest that inflammation and dysfunctional neuron-microglia interactions are factors in the pathology of CTCF deficiency.",
+            "authors": {
+              "abbreviation": "Bryan E McGill, Ruteja A Barve, Susan E Maloney, ..., Jeffrey Milbrandt",
+              "authorList": [
+                {
+                  "ForeName": "Bryan",
+                  "LastName": "McGill",
+                  "abbrevName": "McGill BE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bryan E McGill"
+                },
+                {
+                  "ForeName": "Ruteja",
+                  "LastName": "Barve",
+                  "abbrevName": "Barve RA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ruteja A Barve"
+                },
+                {
+                  "ForeName": "Susan",
+                  "LastName": "Maloney",
+                  "abbrevName": "Maloney SE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susan E Maloney"
+                },
+                {
+                  "ForeName": "Amy",
+                  "LastName": "Strickland",
+                  "abbrevName": "Strickland A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Amy Strickland"
+                },
+                {
+                  "ForeName": "Nicholas",
+                  "LastName": "Rensing",
+                  "abbrevName": "Rensing N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicholas Rensing"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang PL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter L Wang"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Wong",
+                  "abbrevName": "Wong M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Wong"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Head",
+                  "abbrevName": "Head R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard Head"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Wozniak",
+                  "abbrevName": "Wozniak DF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David F Wozniak"
+                },
+                {
+                  "ForeName": "Jeffrey",
+                  "LastName": "Milbrandt",
+                  "abbrevName": "Milbrandt J",
+                  "email": "jmilbrandt@wustl.edu",
+                  "isCollectiveName": false,
+                  "name": "Jeffrey Milbrandt"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Jeffrey",
+                  "LastName": "Milbrandt",
+                  "email": [
+                    "jmilbrandt@wustl.edu"
+                  ],
+                  "name": "Jeffrey Milbrandt"
+                }
+              ]
+            },
+            "doi": "10.1523/JNEUROSCI.0936-17.2017",
+            "pmid": "29133437",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "J Neurosci 38 2018",
+            "title": "Abnormal Microglia and Enhanced Inflammation-Related Gene Transcription in Mice with Conditional Deletion of Ctcf in Camk2a-Cre-Expressing Neurons."
+          }
+        },
+        {
+          "pmid": "28902423",
+          "pubmed": {
+            "ISODate": "2017-11-01T00:00:00.000Z",
+            "abstract": "Three-dimensional rapid acquisition with relaxation enhancement (RARE) scans require the assignment of each phase encode step in two dimensions to an echo in the echo train. Although this assignment is frequently made across the entire Cartesian grid, collection of only the central cylinder of k-space by eliminating the corners in each phase encode dimension reduces the scan time by ~22% with negligible impact on image quality. The recipe for the assignment of echoes to grid points for such an acquisition is less straightforward than for the simple full Cartesian acquisition case, and has important implications for image quality. We explored several methods of partitioning k-space-exploiting angular symmetry in one extreme or emulating a cropped Cartesian acquisition in the other-and acquired three-dimensional RARE magnetic resonance imaging (MRI) scans of the ex vivo mouse brain. We evaluated each partitioning method for sensitivity to artifacts and then further considered strategies to minimize these through averaging or interleaving of echoes and by empirical phase correction. All scans were collected 16 at a time with multiple-mouse MRI. Although all schemes considered could be used to generate images, the results indicate that the emulation of a standard Cartesian echo assignment, by partitioning preferentially along one dimension within the cylinder, is more robust to artifacts. Samples at the periphery of the bore showed larger phase deviations and higher sensitivity to artifacts, but images of good quality could still be obtained with an optimized acquisition protocol. A protocol for high-resolution (40 μm) ex vivo images using this approach is presented, and has been used routinely with a success rate of 99% in over 1000 images.",
+            "authors": {
+              "abbreviation": "T Leigh Spencer Noakes, R Mark Henkelman, Brian J Nieman",
+              "authorList": [
+                {
+                  "ForeName": "T",
+                  "LastName": "Spencer Noakes",
+                  "abbrevName": "Spencer Noakes TL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "T Leigh Spencer Noakes"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Henkelman",
+                  "abbrevName": "Henkelman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Mark Henkelman"
+                },
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Nieman",
+                  "abbrevName": "Nieman BJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brian J Nieman"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/nbm.3802",
+            "pmid": "28902423",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "NMR Biomed 30 2017",
+            "title": "Partitioning k-space for cylindrical three-dimensional rapid acquisition with relaxation enhancement imaging in the mouse brain."
+          }
+        },
+        {
+          "pmid": "28898627",
+          "pubmed": {
+            "ISODate": "2014-11-20T00:00:00.000Z",
+            "abstract": null,
+            "authors": {
+              "abbreviation": "Kavitha Sarma, Catherine Cifuentes-Rojas, Ayla Ergun, ..., Jeannie T Lee",
+              "authorList": [
+                {
+                  "ForeName": "Kavitha",
+                  "LastName": "Sarma",
+                  "abbrevName": "Sarma K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kavitha Sarma"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Cifuentes-Rojas",
+                  "abbrevName": "Cifuentes-Rojas C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Cifuentes-Rojas"
+                },
+                {
+                  "ForeName": "Ayla",
+                  "LastName": "Ergun",
+                  "abbrevName": "Ergun A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ayla Ergun"
+                },
+                {
+                  "ForeName": "Amanda",
+                  "LastName": "Del Rosario",
+                  "abbrevName": "Del Rosario A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Amanda Del Rosario"
+                },
+                {
+                  "ForeName": "Yesu",
+                  "LastName": "Jeon",
+                  "abbrevName": "Jeon Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yesu Jeon"
+                },
+                {
+                  "ForeName": "Forest",
+                  "LastName": "White",
+                  "abbrevName": "White F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Forest White"
+                },
+                {
+                  "ForeName": "Ruslan",
+                  "LastName": "Sadreyev",
+                  "abbrevName": "Sadreyev R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ruslan Sadreyev"
+                },
+                {
+                  "ForeName": "Jeannie",
+                  "LastName": "Lee",
+                  "abbrevName": "Lee JT",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jeannie T Lee"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.cell.2014.11.010",
+            "pmid": "28898627",
+            "pubTypes": [
+              {
+                "UI": "D016425",
+                "value": "Published Erratum"
+              }
+            ],
+            "reference": "Cell 159 2014",
+            "title": "ATRX Directs Binding of PRC2 to Xist RNA and Polycomb Targets."
+          }
+        },
+        {
+          "pmid": "28683304",
+          "pubmed": {
+            "ISODate": "2017-07-05T00:00:00.000Z",
+            "abstract": "Genomic studies have repeatedly associated variants in the gene encoding the microRNA miR-137 with increased schizophrenia risk. Bioinformatic predictions suggest that miR-137 regulates schizophrenia-associated signaling pathways critical to neural development, but these predictions remain largely unvalidated. In the present study, we demonstrate that miR-137 regulates neuronal levels of p55γ, PTEN, Akt2, GSK3β, mTOR, and rictor. All are key proteins within the PI3K-Akt-mTOR pathway and act downstream of neuregulin (Nrg)/ErbB and BDNF signaling. Inhibition of miR-137 ablates Nrg1α-induced increases in dendritic protein synthesis, phosphorylated S6, AMPA receptor subunits, and outgrowth. Inhibition of miR-137 also blocks mTORC1-dependent responses to BDNF, including increased mRNA translation and dendritic outgrowth, while leaving mTORC1-independent S6 phosphorylation intact. We conclude that miR-137 regulates neuronal responses to Nrg1α and BDNF through convergent mechanisms, which might contribute to schizophrenia risk by altering neural development.",
+            "authors": {
+              "abbreviation": "Kristen Therese Thomas, Bart Russell Anderson, Niraj Shah, ..., Gary Jonathan Bassell",
+              "authorList": [
+                {
+                  "ForeName": "Kristen",
+                  "LastName": "Thomas",
+                  "abbrevName": "Thomas KT",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristen Therese Thomas"
+                },
+                {
+                  "ForeName": "Bart",
+                  "LastName": "Anderson",
+                  "abbrevName": "Anderson BR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bart Russell Anderson"
+                },
+                {
+                  "ForeName": "Niraj",
+                  "LastName": "Shah",
+                  "abbrevName": "Shah N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Niraj Shah"
+                },
+                {
+                  "ForeName": "Stephanie",
+                  "LastName": "Zimmer",
+                  "abbrevName": "Zimmer SE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephanie Elaine Zimmer"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Hawkins",
+                  "abbrevName": "Hawkins D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel Hawkins"
+                },
+                {
+                  "ForeName": "Arielle",
+                  "LastName": "Valdez",
+                  "abbrevName": "Valdez AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Arielle Nicole Valdez"
+                },
+                {
+                  "ForeName": "Qiaochu",
+                  "LastName": "Gu",
+                  "abbrevName": "Gu Q",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Qiaochu Gu"
+                },
+                {
+                  "ForeName": "Gary",
+                  "LastName": "Bassell",
+                  "abbrevName": "Bassell GJ",
+                  "email": "gbassel@emory.edu",
+                  "isCollectiveName": false,
+                  "name": "Gary Jonathan Bassell"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Gary",
+                  "LastName": "Bassell",
+                  "email": [
+                    "gbassel@emory.edu"
+                  ],
+                  "name": "Gary Jonathan Bassell"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2017.06.038",
+            "pmid": "28683304",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "Cell Rep 20 2017",
+            "title": "Inhibition of the Schizophrenia-Associated MicroRNA miR-137 Disrupts Nrg1α Neurodevelopmental Signal Transduction."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "27468717",
+          "pubmed": {
+            "ISODate": "2016-10-01T00:00:00.000Z",
+            "abstract": "Aberrant expression of miR-137 has been reported in many kinds of cancers, but its mechanisms seem to be diversely. In the present study, we compared the expression level of miR-137 in 18 paired gastric cancer (GC) samples and surgical margin (SM) samples by RNA extraction and quantitative real-time PCR (QRT-PCR). Then, we investigated the effects of miR-137 on cell proliferation, cell cycle, and cell migration separately by cell growth counting assay, cell cycle analysis, and transwell assay. Candidate targets of miR-137 were selected by biological information analysis from the intersection of miRDB, Pictar, and TarScan. Finally, mRNA and protein expression level of Krűppel-like factor 12 (KLF12) and Myosin 1C (MYO1C) were tested by QRT-PCR and western blotting assay, followed by the Luciferase reporter assay to investigate the direct interaction between them and miR-137. The results showed that miR-137 was down-regulated in GC samples than in SM samples. The expression level of miR-137 was significantly higher in patients without the vascular embolus than those with vascular embolus. And the overall survival time of patients with high miR-137 expression was longer than those with low miR-137 expression. Over expression of miR-137 could inhibit the cell migration, proliferation, and promote cell cycle arrest in G0/G1 stage in BGC-823 and SGC-7901 cell lines. KLF12 and MYO1C might be the candidate target genes of miR-137 with direct interactions between them and miR-137. In conclusion, miR-137 plays tumor suppressor roles in gastric cancer cell lines by targeting KLF12 and MYO1C.",
+            "authors": {
+              "abbreviation": "Yantao Du, Yichen Chen, Furong Wang, Liankun Gu",
+              "authorList": [
+                {
+                  "ForeName": "Yantao",
+                  "LastName": "Du",
+                  "abbrevName": "Du Y",
+                  "email": "duyantao_2000@163.com",
+                  "isCollectiveName": false,
+                  "name": "Yantao Du"
+                },
+                {
+                  "ForeName": "Yichen",
+                  "LastName": "Chen",
+                  "abbrevName": "Chen Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yichen Chen"
+                },
+                {
+                  "ForeName": "Furong",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Furong Wang"
+                },
+                {
+                  "ForeName": "Liankun",
+                  "LastName": "Gu",
+                  "abbrevName": "Gu L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Liankun Gu"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Yantao",
+                  "LastName": "Du",
+                  "email": [
+                    "duyantao_2000@163.com"
+                  ],
+                  "name": "Yantao Du"
+                }
+              ]
+            },
+            "doi": "10.1007/s13277-016-5199-3",
+            "pmid": "27468717",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Tumour Biol 37 2016",
+            "title": "miR-137 plays tumor suppressor roles in gastric cancer cell lines by targeting KLF12 and MYO1C."
+          }
+        },
+        {
+          "pmid": "27335314",
+          "pubmed": {
+            "ISODate": "2016-11-15T00:00:00.000Z",
+            "abstract": "Ex vivo magnetic resonance imaging (MRI) requires chemical fixation to preserve tissue during storage or extended imaging sessions. Although it is commonly understood that fixation may alter tissue volume and shape, the potential confounding effects of fixation and storage on morphometric analyses have not been well characterized. With increasing use of ex vivo MRI for mouse brain phenotying and opportunities for inter-study comparisons, we sought to characterize how changes in fixation and/or storage times affected tissue volume, and how this might impact phenotyping results. Mouse brain samples that had been perfusion fixed, within the skull as per our standard protocol, were immersed in formaldehyde-based fixative for 1 to 5days before being stored in saline or water. Throughout fixation and storage, samples were repeatedly scanned using magnetic resonance imaging, and analyzed for volume expansion or shrinkage. We found that most of the brain continued to shrink post fixation, with the rate of shrinkage dependent on the solution in which the samples were submerged. Maximum changes in volume of 3.5% per day and 3% per month were detected during fixation and storage (in PBS), respectively. Most notably, changes were non-uniform, with some structures shrinking slower, or even expanding, when compared to other structures in the brain. Our results highlight that caution is necessary when interpreting results from experiments with inconsistent fixation and storage protocols, so as not to mistake these changes for phenotypic differences.",
+            "authors": {
+              "abbreviation": "A Elizabeth de Guzman, Michael D Wong, Jacqueline A Gleave, Brian J Nieman",
+              "authorList": [
+                {
+                  "ForeName": "A",
+                  "LastName": "de Guzman",
+                  "abbrevName": "de Guzman AE",
+                  "email": "aelizabeth.deguzman@sickkids.ca",
+                  "isCollectiveName": false,
+                  "name": "A Elizabeth de Guzman"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Wong",
+                  "abbrevName": "Wong MD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael D Wong"
+                },
+                {
+                  "ForeName": "Jacqueline",
+                  "LastName": "Gleave",
+                  "abbrevName": "Gleave JA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacqueline A Gleave"
+                },
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Nieman",
+                  "abbrevName": "Nieman BJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brian J Nieman"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "A",
+                  "LastName": "de Guzman",
+                  "email": [
+                    "aelizabeth.deguzman@sickkids.ca"
+                  ],
+                  "name": "A Elizabeth de Guzman"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuroimage.2016.06.028",
+            "pmid": "27335314",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Neuroimage 142 2016",
+            "title": "Variations in post-perfusion immersion fixation and storage alter MRI measurements of mouse brain morphometry."
+          }
+        },
+        {
+          "pmid": "27286292",
+          "pubmed": {
+            "ISODate": "2016-06-01T00:00:00.000Z",
+            "abstract": "A detailed protocol is provided here to identify amyloid Aβ plaques in brain sections from Alzheimer's disease mouse models before pre-embedding immunostaining (specifically for ionized calcium-binding adapter molecule 1 (IBA1), a calcium binding protein expressed by microglia) and tissue processing for electron microscopy (EM). Methoxy-X04 is a fluorescent dye that crosses the blood-brain barrier and selectively binds to β-pleated sheets found in dense core Aβ plaques. Injection of the animals with methoxy-X04 prior to sacrifice and brain fixation allows pre-screening and selection of the plaque-containing brain sections for further processing with time-consuming manipulations. This is particularly helpful when studying early AD pathology within specific brain regions or layers that may contain very few plaques, present in only a small fraction of the sections. Post-mortem processing of tissue sections with Congo Red, Thioflavin S, and Thioflavin T (or even with methoxy-X04) can label β-pleated sheets, but requires extensive clearing with ethanol to remove excess dye and these procedures are incompatible with ultrastructural preservation. It would also be inefficient to perform labeling for Aβ (and other cellular markers such as IBA1) on all brain sections from the regions of interest, only to yield a small fraction containing Aβ plaques at the right location. Importantly, Aβ plaques are still visible after tissue processing for EM, allowing for a precise identification of the areas (generally down to a few square millimeters) to examine with the electron microscope.",
+            "authors": {
+              "abbreviation": "Kanchan Bisht, Hassan El Hajj, Julie C Savage, ..., Marie-Ève Tremblay",
+              "authorList": [
+                {
+                  "ForeName": "Kanchan",
+                  "LastName": "Bisht",
+                  "abbrevName": "Bisht K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kanchan Bisht"
+                },
+                {
+                  "ForeName": "Hassan",
+                  "LastName": "El Hajj",
+                  "abbrevName": "El Hajj H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hassan El Hajj"
+                },
+                {
+                  "ForeName": "Julie",
+                  "LastName": "Savage",
+                  "abbrevName": "Savage JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Julie C Savage"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Sánchez",
+                  "abbrevName": "Sánchez MG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria G Sánchez"
+                },
+                {
+                  "ForeName": "Marie-Ève",
+                  "LastName": "Tremblay",
+                  "abbrevName": "Tremblay MÈ",
+                  "email": "Tremblay.Marie-Eve@crchudequebec.ulaval.ca",
+                  "isCollectiveName": false,
+                  "name": "Marie-Ève Tremblay"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Marie-Ève",
+                  "LastName": "Tremblay",
+                  "email": [
+                    "Tremblay.Marie-Eve@crchudequebec.ulaval.ca"
+                  ],
+                  "name": "Marie-Ève Tremblay"
+                }
+              ]
+            },
+            "doi": "10.3791/54060",
+            "pmid": "27286292",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D059040",
+                "value": "Video-Audio Media"
+              }
+            ],
+            "reference": "J Vis Exp 2016",
+            "title": "Correlative Light and Electron Microscopy to Study Microglial Interactions with β-Amyloid Plaques."
+          }
+        },
+        {
+          "pmid": "27240256",
+          "pubmed": {
+            "ISODate": "2016-07-01T00:00:00.000Z",
+            "abstract": "Hypothesis weighting improves the power of large-scale multiple testing. We describe independent hypothesis weighting (IHW), a method that assigns weights using covariates independent of the P-values under the null hypothesis but informative of each test's power or prior probability of the null hypothesis (http://www.bioconductor.org/packages/IHW). IHW increases power while controlling the false discovery rate and is a practical approach to discovering associations in genomics, high-throughput biology and other large data sets.",
+            "authors": {
+              "abbreviation": "Nikolaos Ignatiadis, Bernd Klaus, Judith B Zaugg, Wolfgang Huber",
+              "authorList": [
+                {
+                  "ForeName": "Nikolaos",
+                  "LastName": "Ignatiadis",
+                  "abbrevName": "Ignatiadis N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nikolaos Ignatiadis"
+                },
+                {
+                  "ForeName": "Bernd",
+                  "LastName": "Klaus",
+                  "abbrevName": "Klaus B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bernd Klaus"
+                },
+                {
+                  "ForeName": "Judith",
+                  "LastName": "Zaugg",
+                  "abbrevName": "Zaugg JB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Judith B Zaugg"
+                },
+                {
+                  "ForeName": "Wolfgang",
+                  "LastName": "Huber",
+                  "abbrevName": "Huber W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wolfgang Huber"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nmeth.3885",
+            "pmid": "27240256",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Methods 13 2016",
+            "title": "Data-driven hypothesis weighting increases detection power in genome-scale multiple testing."
+          }
+        },
+        {
+          "pmid": "27130160",
+          "pubmed": {
+            "ISODate": "2016-04-29T00:00:00.000Z",
+            "abstract": "BACKGROUND: X linked intellectual disability (XLID) syndromes account for a substantial number of males with ID. Much progress has been made in identifying the genetic cause in many of the syndromes described 20-40 years ago. Next generation sequencing (NGS) has contributed to the rapid discovery of XLID genes and identifying novel mutations in known XLID genes for many of these syndromes. METHODS: 2 NGS approaches were employed to identify mutations in X linked genes in families with XLID disorders. 1 involved exome sequencing of genes on the X chromosome using the Agilent SureSelect Human X Chromosome Kit. The second approach was to conduct targeted NGS sequencing of 90 known XLID genes. RESULTS: We identified the same mutation, a c.12928 G>C transversion in the HUWE1 gene, which gives rise to a p.G4310R missense mutation in 2 XLID disorders: Juberg-Marsidi syndrome (JMS) and Brooks syndrome. Although the original families with these disorders were considered separate entities, they indeed overlap clinically. A third family was also found to have a novel HUWE1 mutation. CONCLUSIONS: As we identified a HUWE1 mutation in an affected male from the original family reported by Juberg and Marsidi, it is evident the syndrome does not result from a mutation in ATRX as reported in the literature. Additionally, our data indicate that JMS and Brooks syndromes are allelic having the same HUWE1 mutation.",
+            "authors": {
+              "abbreviation": "Michael J Friez, Susan Sklower Brooks, Roger E Stevenson, ..., Charles E Schwartz",
+              "authorList": [
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Friez",
+                  "abbrevName": "Friez MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael J Friez"
+                },
+                {
+                  "ForeName": "Susan",
+                  "LastName": "Brooks",
+                  "abbrevName": "Brooks SS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susan Sklower Brooks"
+                },
+                {
+                  "ForeName": "Roger",
+                  "LastName": "Stevenson",
+                  "abbrevName": "Stevenson RE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Roger E Stevenson"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Field",
+                  "abbrevName": "Field M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Field"
+                },
+                {
+                  "ForeName": "Monica",
+                  "LastName": "Basehore",
+                  "abbrevName": "Basehore MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Monica J Basehore"
+                },
+                {
+                  "ForeName": "Lesley",
+                  "LastName": "Adès",
+                  "abbrevName": "Adès LC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lesley C Adès"
+                },
+                {
+                  "ForeName": "Courtney",
+                  "LastName": "Sebold",
+                  "abbrevName": "Sebold C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Courtney Sebold"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "McGee",
+                  "abbrevName": "McGee S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen McGee"
+                },
+                {
+                  "ForeName": "Samantha",
+                  "LastName": "Saxon",
+                  "abbrevName": "Saxon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Samantha Saxon"
+                },
+                {
+                  "ForeName": "Cindy",
+                  "LastName": "Skinner",
+                  "abbrevName": "Skinner C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Cindy Skinner"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Craig",
+                  "abbrevName": "Craig ME",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria E Craig"
+                },
+                {
+                  "ForeName": "Lucy",
+                  "LastName": "Murray",
+                  "abbrevName": "Murray L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lucy Murray"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Simensen",
+                  "abbrevName": "Simensen RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Simensen"
+                },
+                {
+                  "ForeName": "Ying",
+                  "LastName": "Yap",
+                  "abbrevName": "Yap YY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ying Yzu Yap"
+                },
+                {
+                  "ForeName": "Marie",
+                  "LastName": "Shaw",
+                  "abbrevName": "Shaw MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marie A Shaw"
+                },
+                {
+                  "ForeName": "Alison",
+                  "LastName": "Gardner",
+                  "abbrevName": "Gardner A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alison Gardner"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Corbett",
+                  "abbrevName": "Corbett M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark Corbett"
+                },
+                {
+                  "ForeName": "Raman",
+                  "LastName": "Kumar",
+                  "abbrevName": "Kumar R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Raman Kumar"
+                },
+                {
+                  "ForeName": "Matthias",
+                  "LastName": "Bosshard",
+                  "abbrevName": "Bosshard M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthias Bosshard"
+                },
+                {
+                  "ForeName": "Barbara",
+                  "LastName": "van Loon",
+                  "abbrevName": "van Loon B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Barbara van Loon"
+                },
+                {
+                  "ForeName": "Patrick",
+                  "LastName": "Tarpey",
+                  "abbrevName": "Tarpey PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Patrick S Tarpey"
+                },
+                {
+                  "ForeName": "Fatima",
+                  "LastName": "Abidi",
+                  "abbrevName": "Abidi F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Fatima Abidi"
+                },
+                {
+                  "ForeName": "Jozef",
+                  "LastName": "Gecz",
+                  "abbrevName": "Gecz J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jozef Gecz"
+                },
+                {
+                  "ForeName": "Charles",
+                  "LastName": "Schwartz",
+                  "abbrevName": "Schwartz CE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Charles E Schwartz"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1136/bmjopen-2015-009537",
+            "pmid": "27130160",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "BMJ Open 6 2016",
+            "title": "HUWE1 mutations in Juberg-Marsidi and Brooks syndromes: the results of an X-chromosome exome sequencing study."
+          }
+        },
+        {
+          "pmid": "26925227",
+          "pubmed": {
+            "ISODate": "2015-01-01T00:00:00.000Z",
+            "abstract": "High-throughput sequencing of cDNA (RNA-seq) is used extensively to characterize the transcriptome of cells. Many transcriptomic studies aim at comparing either abundance levels or the transcriptome composition between given conditions, and as a first step, the sequencing reads must be used as the basis for abundance quantification of transcriptomic features of interest, such as genes or transcripts. Various quantification approaches have been proposed, ranging from simple counting of reads that overlap given genomic regions to more complex estimation of underlying transcript abundances. In this paper, we show that gene-level abundance estimates and statistical inference offer advantages over transcript-level analyses, in terms of performance and interpretability. We also illustrate that the presence of differential isoform usage can lead to inflated false discovery rates in differential gene expression analyses on simple count matrices but that this can be addressed by incorporating offsets derived from transcript-level abundance estimates. We also show that the problem is relatively minor in several real data sets. Finally, we provide an R package ( tximport) to help users integrate transcript-level abundance estimates from common quantification pipelines into count-based statistical inference engines. ",
+            "authors": {
+              "abbreviation": "Charlotte Soneson, Michael I Love, Mark D Robinson",
+              "authorList": [
+                {
+                  "ForeName": "Charlotte",
+                  "LastName": "Soneson",
+                  "abbrevName": "Soneson C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Charlotte Soneson"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Love",
+                  "abbrevName": "Love MI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael I Love"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Robinson",
+                  "abbrevName": "Robinson MD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark D Robinson"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.12688/f1000research.7563.2",
+            "pmid": "26925227",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "F1000Res 4 2015",
+            "title": "Differential analyses for RNA-seq: transcript-level estimates improve gene-level inferences."
+          }
+        },
+        {
+          "pmid": "26423861",
+          "pubmed": {
+            "ISODate": "2015-10-01T00:00:00.000Z",
+            "abstract": "Development of effective therapies for brain disorders has been hampered by a lack of translational cognitive testing methods. We present the first example of using the identical touchscreen-based cognitive test to assess mice and humans carrying disease-related genetic mutations. This new paradigm has significant implications for improving how we measure and model cognitive dysfunction in human disorders in animals, thus bridging the gap towards effective translation to the clinic. ",
+            "authors": {
+              "abbreviation": "J Nithianantharajah, A G McKechanie, T J Stewart, ..., L M Saksida",
+              "authorList": [
+                {
+                  "ForeName": "J",
+                  "LastName": "Nithianantharajah",
+                  "abbrevName": "Nithianantharajah J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J Nithianantharajah"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "McKechanie",
+                  "abbrevName": "McKechanie AG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A G McKechanie"
+                },
+                {
+                  "ForeName": "T",
+                  "LastName": "Stewart",
+                  "abbrevName": "Stewart TJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "T J Stewart"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Johnstone",
+                  "abbrevName": "Johnstone M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Johnstone"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Blackwood",
+                  "abbrevName": "Blackwood DH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D H Blackwood"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "St Clair",
+                  "abbrevName": "St Clair D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D St Clair"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Grant",
+                  "abbrevName": "Grant SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S G N Grant"
+                },
+                {
+                  "ForeName": "T",
+                  "LastName": "Bussey",
+                  "abbrevName": "Bussey TJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "T J Bussey"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Saksida",
+                  "abbrevName": "Saksida LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L M Saksida"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/srep14613",
+            "pmid": "26423861",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Sci Rep 5 2015",
+            "title": "Bridging the translational divide: identical cognitive touchscreen testing in mice and humans carrying mutations in a disease-relevant homologous gene."
+          }
+        },
+        {
+          "pmid": "26350204",
+          "pubmed": {
+            "ISODate": "2015-12-01T00:00:00.000Z",
+            "abstract": "To identify genetic causes of intellectual disability (ID), we screened a cohort of 986 individuals with moderate to severe ID for variants in 565 known or candidate ID-associated genes using targeted next-generation sequencing. Likely pathogenic rare variants were found in ∼11% of the cases (113 variants in 107/986 individuals: ∼8% of the individuals had a likely pathogenic loss-of-function [LoF] variant, whereas ∼3% had a known pathogenic missense variant). Variants in SETD5, ATRX, CUL4B, MECP2, and ARID1B were the most common causes of ID. This study assessed the value of sequencing a cohort of probands to provide a molecular diagnosis of ID, without the availability of DNA from both parents for de novo sequence analysis. This modeling is clinically relevant as 28% of all UK families with dependent children are single parent households. In conclusion, to diagnose patients with ID in the absence of parental DNA, we recommend investigation of all LoF variants in known genes that cause ID and assessment of a limited list of proven pathogenic missense variants in these genes. This will provide 11% additional diagnostic yield beyond the 10%-15% yield from array CGH alone. ",
+            "authors": {
+              "abbreviation": "Detelina Grozeva, Keren Carss, Olivera Spasic-Boskovic, ..., F Lucy Raymond",
+              "authorList": [
+                {
+                  "ForeName": "Detelina",
+                  "LastName": "Grozeva",
+                  "abbrevName": "Grozeva D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Detelina Grozeva"
+                },
+                {
+                  "ForeName": "Keren",
+                  "LastName": "Carss",
+                  "abbrevName": "Carss K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keren Carss"
+                },
+                {
+                  "ForeName": "Olivera",
+                  "LastName": "Spasic-Boskovic",
+                  "abbrevName": "Spasic-Boskovic O",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Olivera Spasic-Boskovic"
+                },
+                {
+                  "ForeName": "Maria-Isabel",
+                  "LastName": "Tejada",
+                  "abbrevName": "Tejada MI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria-Isabel Tejada"
+                },
+                {
+                  "ForeName": "Jozef",
+                  "LastName": "Gecz",
+                  "abbrevName": "Gecz J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jozef Gecz"
+                },
+                {
+                  "ForeName": "Marie",
+                  "LastName": "Shaw",
+                  "abbrevName": "Shaw M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marie Shaw"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Corbett",
+                  "abbrevName": "Corbett M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark Corbett"
+                },
+                {
+                  "ForeName": "Eric",
+                  "LastName": "Haan",
+                  "abbrevName": "Haan E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Eric Haan"
+                },
+                {
+                  "ForeName": "Elizabeth",
+                  "LastName": "Thompson",
+                  "abbrevName": "Thompson E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Elizabeth Thompson"
+                },
+                {
+                  "ForeName": "Kathryn",
+                  "LastName": "Friend",
+                  "abbrevName": "Friend K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kathryn Friend"
+                },
+                {
+                  "ForeName": "Zaamin",
+                  "LastName": "Hussain",
+                  "abbrevName": "Hussain Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zaamin Hussain"
+                },
+                {
+                  "ForeName": "Anna",
+                  "LastName": "Hackett",
+                  "abbrevName": "Hackett A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anna Hackett"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Field",
+                  "abbrevName": "Field M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Field"
+                },
+                {
+                  "ForeName": "Alessandra",
+                  "LastName": "Renieri",
+                  "abbrevName": "Renieri A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alessandra Renieri"
+                },
+                {
+                  "ForeName": "Roger",
+                  "LastName": "Stevenson",
+                  "abbrevName": "Stevenson R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Roger Stevenson"
+                },
+                {
+                  "ForeName": "Charles",
+                  "LastName": "Schwartz",
+                  "abbrevName": "Schwartz C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Charles Schwartz"
+                },
+                {
+                  "ForeName": "James",
+                  "LastName": "Floyd",
+                  "abbrevName": "Floyd JA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "James A B Floyd"
+                },
+                {
+                  "ForeName": "Jamie",
+                  "LastName": "Bentham",
+                  "abbrevName": "Bentham J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jamie Bentham"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Cosgrove",
+                  "abbrevName": "Cosgrove C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Cosgrove"
+                },
+                {
+                  "ForeName": "Bernard",
+                  "LastName": "Keavney",
+                  "abbrevName": "Keavney B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bernard Keavney"
+                },
+                {
+                  "ForeName": "Shoumo",
+                  "LastName": "Bhattacharya",
+                  "abbrevName": "Bhattacharya S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shoumo Bhattacharya"
+                },
+                {
+                  "ForeName": null,
+                  "LastName": null,
+                  "abbrevName": "Italian X-linked Mental Retardation Project",
+                  "email": null,
+                  "isCollectiveName": true,
+                  "name": "Italian X-linked Mental Retardation Project"
+                },
+                {
+                  "ForeName": null,
+                  "LastName": null,
+                  "abbrevName": "UK10K Consortium",
+                  "email": null,
+                  "isCollectiveName": true,
+                  "name": "UK10K Consortium"
+                },
+                {
+                  "ForeName": null,
+                  "LastName": null,
+                  "abbrevName": "GOLD Consortium",
+                  "email": null,
+                  "isCollectiveName": true,
+                  "name": "GOLD Consortium"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Hurles",
+                  "abbrevName": "Hurles M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Hurles"
+                },
+                {
+                  "ForeName": "F",
+                  "LastName": "Raymond",
+                  "abbrevName": "Raymond FL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "F Lucy Raymond"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/humu.22901",
+            "pmid": "26350204",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mutat 36 2015",
+            "title": "Targeted Next-Generation Sequencing Analysis of 1,000 Individuals with Intellectual Disability."
+          }
+        },
+        {
+          "pmid": "26095359",
+          "pubmed": {
+            "ISODate": "2015-06-30T00:00:00.000Z",
+            "abstract": "Mutations affecting the levels of microRNA miR-137 are associated with intellectual disability and schizophrenia. However, the pathophysiological role of miR-137 remains poorly understood. Here, we describe a highly conserved miR-137-binding site within the mRNA encoding the GluA1 subunit of AMPA-type glutamate receptors (AMPARs) and confirm that GluA1 is a direct target of miR-137. Postsynaptic downregulation of miR-137 at the CA3-CA1 hippocampal synapse selectively enhances AMPAR-mediated synaptic transmission and converts silent synapses to active synapses. Conversely, miR-137 overexpression selectively reduces AMPAR-mediated synaptic transmission and silences active synapses. In addition, we find that miR-137 is transiently upregulated in response to metabotropic glutamate receptor 5 (mGluR5), but not mGluR1 activation. Consequently, acute interference with miR-137 function impedes mGluR-LTD expression. Our findings suggest that miR-137 is a key factor in the control of synaptic efficacy and mGluR-dependent synaptic plasticity, supporting the notion that glutamatergic dysfunction contributes to the pathogenesis of miR-137-linked cognitive impairments.",
+            "authors": {
+              "abbreviation": "Nikkie F M Olde Loohuis, Wei Ba, Peter H Stoerchel, ..., Armaz Aschrafi",
+              "authorList": [
+                {
+                  "ForeName": "Nikkie",
+                  "LastName": "Olde Loohuis",
+                  "abbrevName": "Olde Loohuis NF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nikkie F M Olde Loohuis"
+                },
+                {
+                  "ForeName": "Wei",
+                  "LastName": "Ba",
+                  "abbrevName": "Ba W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wei Ba"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Stoerchel",
+                  "abbrevName": "Stoerchel PH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter H Stoerchel"
+                },
+                {
+                  "ForeName": "Aron",
+                  "LastName": "Kos",
+                  "abbrevName": "Kos A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Aron Kos"
+                },
+                {
+                  "ForeName": "Amanda",
+                  "LastName": "Jager",
+                  "abbrevName": "Jager A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Amanda Jager"
+                },
+                {
+                  "ForeName": "Gerhard",
+                  "LastName": "Schratt",
+                  "abbrevName": "Schratt G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gerhard Schratt"
+                },
+                {
+                  "ForeName": "Gerard",
+                  "LastName": "Martens",
+                  "abbrevName": "Martens GJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gerard J M Martens"
+                },
+                {
+                  "ForeName": "Hans",
+                  "LastName": "van Bokhoven",
+                  "abbrevName": "van Bokhoven H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hans van Bokhoven"
+                },
+                {
+                  "ForeName": "Nael",
+                  "LastName": "Nadif Kasri",
+                  "abbrevName": "Nadif Kasri N",
+                  "email": "n.nadif@donders.ru.nl",
+                  "isCollectiveName": false,
+                  "name": "Nael Nadif Kasri"
+                },
+                {
+                  "ForeName": "Armaz",
+                  "LastName": "Aschrafi",
+                  "abbrevName": "Aschrafi A",
+                  "email": "a.aschrafi@donders.ru.nl",
+                  "isCollectiveName": false,
+                  "name": "Armaz Aschrafi"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nael",
+                  "LastName": "Nadif Kasri",
+                  "email": [
+                    "n.nadif@donders.ru.nl"
+                  ],
+                  "name": "Nael Nadif Kasri"
+                },
+                {
+                  "ForeName": "Armaz",
+                  "LastName": "Aschrafi",
+                  "email": [
+                    "a.aschrafi@donders.ru.nl"
+                  ],
+                  "name": "Armaz Aschrafi"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2015.05.040",
+            "pmid": "26095359",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 11 2015",
+            "title": "MicroRNA-137 Controls AMPA-Receptor-Mediated Transmission and mGluR-Dependent LTD."
+          }
+        },
+        {
+          "pmid": "26056561",
+          "pubmed": {
+            "ISODate": "2015-01-01T00:00:00.000Z",
+            "abstract": "BACKGROUND: Autism spectrum disorder (ASD) is a neurodevelopmental condition characterized by significant impairment in reciprocal social interactions and communication coupled with stereotyped, repetitive behaviors and restricted interests. Although genomic and functional studies are beginning to reveal some of the genetic complexity and underlying pathobiology of ASD, the consistently reported male bias of ASD remains an enigma. We have recently proposed that retinoic acid-related orphan receptor alpha (RORA), which is reduced in the brain and lymphoblastoid cell lines of multiple cohorts of individuals with ASD and oppositely regulated by male and female hormones, might contribute to the sex bias in autism by differentially regulating target genes, including CYP19A1 (aromatase), in a sex-dependent manner that can also lead to elevated testosterone levels, a proposed risk factor for autism. METHODS: In this study, we examine sex differences in RORA and aromatase protein levels in cortical tissues of unaffected and affected males and females by re-analyzing pre-existing confocal immunofluorescence data from our laboratory. We further investigated the expression of RORA and its correlation with several of its validated transcriptional targets in the orbital frontal cortex and cerebellum as a function of development using RNAseq data from the BrainSpan Atlas of the Developing Human Brain. In a pilot study, we also analyzed the expression of Rora and the same transcriptional targets in the cortex and cerebellum of adult wild-type male and female C57BL/6 mice. RESULTS: Our findings suggest that Rora/RORA and several of its transcriptional targets may exhibit sexually dimorphic expression in certain regions of the brain of both mice and humans. Interestingly, the correlation coefficients between Rora expression and that of its targets are much higher in the cortex of male mice relative to that of female mice. A strong positive correlation between the levels of RORA and aromatase proteins is also seen in the cortex of control human males and females as well as ASD males, but not ASD females. CONCLUSIONS: Based on these studies, we suggest that disruption of Rora/RORA expression may have a greater impact on males, since sex differences in the correlation of RORA and target gene expression indicate that RORA-deficient males may experience greater dysregulation of genes relevant to ASD in certain brain regions during development.",
+            "authors": {
+              "abbreviation": "Valerie W Hu, Tewarit Sarachana, Rachel M Sherrard, Kristen M Kocher",
+              "authorList": [
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Hu",
+                  "abbrevName": "Hu VW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie W Hu"
+                },
+                {
+                  "ForeName": "Tewarit",
+                  "LastName": "Sarachana",
+                  "abbrevName": "Sarachana T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tewarit Sarachana"
+                },
+                {
+                  "ForeName": "Rachel",
+                  "LastName": "Sherrard",
+                  "abbrevName": "Sherrard RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rachel M Sherrard"
+                },
+                {
+                  "ForeName": "Kristen",
+                  "LastName": "Kocher",
+                  "abbrevName": "Kocher KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristen M Kocher"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1186/2040-2392-6-7",
+            "pmid": "26056561",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Mol Autism 6 2015",
+            "title": "Investigation of sex differences in the expression of RORA and its transcriptional targets in the brain as a potential contributor to the sex bias in autism."
+          }
+        },
+        {
+          "pmid": "26005852",
+          "pubmed": {
+            "ISODate": "2015-07-01T00:00:00.000Z",
+            "abstract": "Noncoding variants in the human MIR137 gene locus increase schizophrenia risk with genome-wide significance. However, the functional consequence of these risk alleles is unknown. Here we examined induced human neurons harboring the minor alleles of four disease-associated single nucleotide polymorphisms in MIR137. We observed increased MIR137 levels compared to those in major allele-carrying cells. microRNA-137 gain of function caused downregulation of the presynaptic target genes complexin-1 (Cplx1), Nsf and synaptotagmin-1 (Syt1), leading to impaired vesicle release. In vivo, miR-137 gain of function resulted in changes in synaptic vesicle pool distribution, impaired induction of mossy fiber long-term potentiation and deficits in hippocampus-dependent learning and memory. By sequestering endogenous miR-137, we were able to ameliorate the synaptic phenotypes. Moreover, reinstatement of Syt1 expression partially restored synaptic plasticity, demonstrating the importance of Syt1 as a miR-137 target. Our data provide new insight into the mechanism by which miR-137 dysregulation can impair synaptic plasticity in the hippocampus. ",
+            "authors": {
+              "abbreviation": "Sandra Siegert, Jinsoo Seo, Ester J Kwon, ..., Li-Huei Tsai",
+              "authorList": [
+                {
+                  "ForeName": "Sandra",
+                  "LastName": "Siegert",
+                  "abbrevName": "Siegert S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sandra Siegert"
+                },
+                {
+                  "ForeName": "Jinsoo",
+                  "LastName": "Seo",
+                  "abbrevName": "Seo J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jinsoo Seo"
+                },
+                {
+                  "ForeName": "Ester",
+                  "LastName": "Kwon",
+                  "abbrevName": "Kwon EJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ester J Kwon"
+                },
+                {
+                  "ForeName": "Andrii",
+                  "LastName": "Rudenko",
+                  "abbrevName": "Rudenko A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrii Rudenko"
+                },
+                {
+                  "ForeName": "Sukhee",
+                  "LastName": "Cho",
+                  "abbrevName": "Cho S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sukhee Cho"
+                },
+                {
+                  "ForeName": "Wenyuan",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wenyuan Wang"
+                },
+                {
+                  "ForeName": "Zachary",
+                  "LastName": "Flood",
+                  "abbrevName": "Flood Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zachary Flood"
+                },
+                {
+                  "ForeName": "Anthony",
+                  "LastName": "Martorell",
+                  "abbrevName": "Martorell AJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anthony J Martorell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Ericsson",
+                  "abbrevName": "Ericsson M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Ericsson"
+                },
+                {
+                  "ForeName": "Alison",
+                  "LastName": "Mungenast",
+                  "abbrevName": "Mungenast AE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alison E Mungenast"
+                },
+                {
+                  "ForeName": "Li-Huei",
+                  "LastName": "Tsai",
+                  "abbrevName": "Tsai LH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li-Huei Tsai"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nn.4023",
+            "pmid": "26005852",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Neurosci 18 2015",
+            "title": "The schizophrenia risk gene product miR-137 alters presynaptic plasticity."
+          }
+        },
+        {
+          "pmid": "25963561",
+          "pubmed": {
+            "ISODate": "2015-11-01T00:00:00.000Z",
+            "abstract": "RATIONALE: The CANTAB object-location paired-associate learning (PAL) test can detect cognitive deficits in schizophrenia and Alzheimer's disease. A rodent version of touch screen PAL (dPAL) has been developed, but the underlying neural mechanisms are not fully understood. Although there is evidence that inactivation of the hippocampus following training leads to impairments in rats, this has not been tested in mice. Furthermore, it is not known whether acquisition, as opposed to performance, of the rodent version depends on the hippocampus. This is critical as many mouse models may have hippocampal dysfunction prior to the onset of task training. OBJECTIVES: The objectives of this study are to examine the effects of dorsal hippocampal (dHp) dysfunction on both performance and acquisition of mouse dPAL and to determine if hippocampal task sensitivity could be increased using a newly developed context-disambiguated PAL (cdPAL) paradigm. METHODS: In experiment 1, C57Bl/6 mice received post-acquisition dHp infusions of the GABA agonist muscimol. In experiment 2, C57Bl/6 mice received excitotoxic dHp lesions prior to dPAL/cdPAL acquisition. RESULTS: Post-acquisition muscimol dose-dependently impaired dPAL and cdPAL performance. Pre-acquisition dHp lesions had only mild effects on both PAL tasks. Behavioural challenges including addition of objects and degradation of the visual stimuli with noise did not reveal any further impairments. CONCLUSIONS: dPAL and cdPAL performance is hippocampus-dependent in the mouse, but both tasks can be learned in the absence of a functional dHp.",
+            "authors": {
+              "abbreviation": "Chi Hun Kim, Christopher J Heath, Brianne A Kent, ..., Lisa M Saksida",
+              "authorList": [
+                {
+                  "ForeName": "Chi",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim CH",
+                  "email": "chk35@cam.ac.uk",
+                  "isCollectiveName": false,
+                  "name": "Chi Hun Kim"
+                },
+                {
+                  "ForeName": "Christopher",
+                  "LastName": "Heath",
+                  "abbrevName": "Heath CJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christopher J Heath"
+                },
+                {
+                  "ForeName": "Brianne",
+                  "LastName": "Kent",
+                  "abbrevName": "Kent BA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brianne A Kent"
+                },
+                {
+                  "ForeName": "Timothy",
+                  "LastName": "Bussey",
+                  "abbrevName": "Bussey TJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Timothy J Bussey"
+                },
+                {
+                  "ForeName": "Lisa",
+                  "LastName": "Saksida",
+                  "abbrevName": "Saksida LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lisa M Saksida"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Chi",
+                  "LastName": "Kim",
+                  "email": [
+                    "chk35@cam.ac.uk"
+                  ],
+                  "name": "Chi Hun Kim"
+                }
+              ]
+            },
+            "doi": "10.1007/s00213-015-3949-3",
+            "pmid": "25963561",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Psychopharmacology (Berl) 232 2015",
+            "title": "The role of the dorsal hippocampus in two versions of the touchscreen automated paired associates learning (PAL) task for mice."
+          }
+        },
+        {
+          "pmid": "25755632",
+          "pubmed": {
+            "ISODate": "2015-01-01T00:00:00.000Z",
+            "abstract": "Long-term potentiation (LTP) is a form of synaptic plasticity that is an excellent model for the molecular mechanisms that underlie memory. LTP, like memory, is persistent, and both are widely believed to be maintained by a coordinated genomic response. Recently, a novel class of non-coding RNA, microRNA, has been implicated in the regulation of LTP. MicroRNA negatively regulate protein synthesis by binding to specific messenger RNA response elements. The aim of this review is to summarize experimental evidence for the proposal that microRNA play a major role in the regulation of LTP. We discuss a growing body of research which indicates that specific microRNA regulate synaptic proteins relevant to LTP maintenance, as well as studies that have reported differential expression of microRNA in response to LTP induction. We conclude that microRNA are ideally suited to contribute to the regulation of LTP-related gene expression; microRNA are pleiotropic, synaptically located, tightly regulated, and function in response to synaptic activity. The potential impact of microRNA on LTP maintenance as regulators of gene expression is enormous. ",
+            "authors": {
+              "abbreviation": "Brigid Ryan, Greig Joilin, Joanna M Williams",
+              "authorList": [
+                {
+                  "ForeName": "Brigid",
+                  "LastName": "Ryan",
+                  "abbrevName": "Ryan B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brigid Ryan"
+                },
+                {
+                  "ForeName": "Greig",
+                  "LastName": "Joilin",
+                  "abbrevName": "Joilin G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Greig Joilin"
+                },
+                {
+                  "ForeName": "Joanna",
+                  "LastName": "Williams",
+                  "abbrevName": "Williams JM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Joanna M Williams"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.3389/fnmol.2015.00004",
+            "pmid": "25755632",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D016454",
+                "value": "Review"
+              }
+            ],
+            "reference": "Front Mol Neurosci 8 2015",
+            "title": "Plasticity-related microRNA and their potential contribution to the maintenance of long-term potentiation."
+          }
+        },
+        {
+          "pmid": "25690850",
+          "pubmed": {
+            "ISODate": "2015-03-01T00:00:00.000Z",
+            "abstract": "Methods used to sequence the transcriptome often produce more than 200 million short sequences. We introduce StringTie, a computational method that applies a network flow algorithm originally developed in optimization theory, together with optional de novo assembly, to assemble these complex data sets into transcripts. When used to analyze both simulated and real data sets, StringTie produces more complete and accurate reconstructions of genes and better estimates of expression levels, compared with other leading transcript assembly programs including Cufflinks, IsoLasso, Scripture and Traph. For example, on 90 million reads from human blood, StringTie correctly assembled 10,990 transcripts, whereas the next best assembly was of 7,187 transcripts by Cufflinks, which is a 53% increase in transcripts assembled. On a simulated data set, StringTie correctly assembled 7,559 transcripts, which is 20% more than the 6,310 assembled by Cufflinks. As well as producing a more complete transcriptome assembly, StringTie runs faster on all data sets tested to date compared with other assembly software, including Cufflinks. ",
+            "authors": {
+              "abbreviation": "Mihaela Pertea, Geo M Pertea, Corina M Antonescu, ..., Steven L Salzberg",
+              "authorList": [
+                {
+                  "ForeName": "Mihaela",
+                  "LastName": "Pertea",
+                  "abbrevName": "Pertea M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mihaela Pertea"
+                },
+                {
+                  "ForeName": "Geo",
+                  "LastName": "Pertea",
+                  "abbrevName": "Pertea GM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Geo M Pertea"
+                },
+                {
+                  "ForeName": "Corina",
+                  "LastName": "Antonescu",
+                  "abbrevName": "Antonescu CM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Corina M Antonescu"
+                },
+                {
+                  "ForeName": "Tsung-Cheng",
+                  "LastName": "Chang",
+                  "abbrevName": "Chang TC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tsung-Cheng Chang"
+                },
+                {
+                  "ForeName": "Joshua",
+                  "LastName": "Mendell",
+                  "abbrevName": "Mendell JT",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Joshua T Mendell"
+                },
+                {
+                  "ForeName": "Steven",
+                  "LastName": "Salzberg",
+                  "abbrevName": "Salzberg SL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Steven L Salzberg"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nbt.3122",
+            "pmid": "25690850",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "Nat Biotechnol 33 2015",
+            "title": "StringTie enables improved reconstruction of a transcriptome from RNA-seq reads."
+          }
+        },
+        {
+          "pmid": "25687692",
+          "pubmed": {
+            "ISODate": "2015-04-01T00:00:00.000Z",
+            "abstract": "In mammals, hippocampal and striatal regions are engaged in separable cognitive processes usually assessed through species-specific paradigms. To reconcile cognitive testing among species, translational advantages of the touchscreen-based automated method have been recently promoted. However, it remains undetermined whether similar neural substrates would be involved in such behavioral tasks both in humans and rodents. To address this question, the effects of hippocampal or dorso-striatal fiber-sparing lesions were first assessed in mice through a battery of tasks (experiment A) comprising the acquisition of two touchscreen paradigms, the Paired Associates Learning (dPAL) and Visuo-Motor Conditional Learning (VMCL) tasks, and a more classical T-maze alternation task. Additionally, we sought to determine whether post-acquisition hippocampal lesions would alter memory retrieval in the dPAL task (experiment B). Pre-training lesions of dorsal striatum caused major impairments in all paradigms. In contrast, pre-training hippocampal lesions disrupted the performance of animals trained in the T-maze assay, but spared the acquisition in touchscreen tasks. Nonetheless, post-training hippocampal lesions severely impacted the recall of the previously learned dPAL task. Altogether, our data show that, after having demonstrated their potential in genetically modified mice, touchscreens also reveal perfectly adapted to taxing functional implications of brain structures in mice by means of lesion approaches. Unlike its human counterpart requiring an intact hippocampus, the acquisition of the dPAL task requires the integrity of the dorsal striatum in mice. The hippocampus only later intervenes, when acquired information needs to be retrieved. Touchscreen assays may therefore be suited to study striatal- or hippocampal-dependent forms of learnings in mice. ",
+            "authors": {
+              "abbreviation": "David F Delotterie, Chantal Mathis, Jean-Christophe Cassel, ..., Anelise Marti",
+              "authorList": [
+                {
+                  "ForeName": "David",
+                  "LastName": "Delotterie",
+                  "abbrevName": "Delotterie DF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David F Delotterie"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mathis",
+                  "abbrevName": "Mathis C",
+                  "email": "chantal.mathis@unistra.fr",
+                  "isCollectiveName": false,
+                  "name": "Chantal Mathis"
+                },
+                {
+                  "ForeName": "Jean-Christophe",
+                  "LastName": "Cassel",
+                  "abbrevName": "Cassel JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jean-Christophe Cassel"
+                },
+                {
+                  "ForeName": "Holger",
+                  "LastName": "Rosenbrock",
+                  "abbrevName": "Rosenbrock H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Holger Rosenbrock"
+                },
+                {
+                  "ForeName": "Cornelia",
+                  "LastName": "Dorner-Ciossek",
+                  "abbrevName": "Dorner-Ciossek C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Cornelia Dorner-Ciossek"
+                },
+                {
+                  "ForeName": "Anelise",
+                  "LastName": "Marti",
+                  "abbrevName": "Marti A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anelise Marti"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mathis",
+                  "email": [
+                    "chantal.mathis@unistra.fr"
+                  ],
+                  "name": "Chantal Mathis"
+                }
+              ]
+            },
+            "doi": "10.1016/j.nlm.2015.02.007",
+            "pmid": "25687692",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Neurobiol Learn Mem 120 2015",
+            "title": "Touchscreen tasks in mice to demonstrate differences between hippocampal and striatal functions."
+          }
+        },
+        {
+          "pmid": "25516281",
+          "pubmed": {
+            "ISODate": "2014-01-01T00:00:00.000Z",
+            "abstract": "In comparative high-throughput sequencing assays, a fundamental task is the analysis of count data, such as read counts per gene in RNA-seq, for evidence of systematic changes across experimental conditions. Small replicate numbers, discreteness, large dynamic range and the presence of outliers require a suitable statistical approach. We present DESeq2, a method for differential analysis of count data, using shrinkage estimation for dispersions and fold changes to improve stability and interpretability of estimates. This enables a more quantitative analysis focused on the strength rather than the mere presence of differential expression. The DESeq2 package is available at http://www.bioconductor.org/packages/release/bioc/html/DESeq2.html webcite.",
+            "authors": {
+              "abbreviation": "Michael I Love, Wolfgang Huber, Simon Anders",
+              "authorList": [
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Love",
+                  "abbrevName": "Love MI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael I Love"
+                },
+                {
+                  "ForeName": "Wolfgang",
+                  "LastName": "Huber",
+                  "abbrevName": "Huber W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wolfgang Huber"
+                },
+                {
+                  "ForeName": "Simon",
+                  "LastName": "Anders",
+                  "abbrevName": "Anders S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Simon Anders"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1186/s13059-014-0550-8",
+            "pmid": "25516281",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Genome Biol 15 2014",
+            "title": "Moderated estimation of fold change and  dispersion for RNA-seq data with DESeq2."
+          }
+        },
+        {
+          "pmid": "25452430",
+          "pubmed": {
+            "ISODate": "2015-04-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein involved in deposition of the histone variant H3.3 at telomeres and pericentromeric heterochromatin. It also influences the expression level of specific genes; however, deposition of H3.3 at transcribed genes is currently thought to occur independently of ATRX. We focused on a set of genes, including the autism susceptibility gene Neuroligin 4 (Nlgn4), that exhibit decreased expression in ATRX-null cells to investigate the mechanisms used by ATRX to promote gene transcription. Overall TERRA levels, as well as DNA methylation and histone modifications at ATRX target genes are not altered and thus cannot explain transcriptional dysregulation. We found that ATRX does not associate with the promoter of these genes, but rather binds within regions of the gene body corresponding to high H3.3 occupancy. These intragenic regions consist of guanine-rich DNA sequences predicted to form non-B DNA structures called G-quadruplexes during transcriptional elongation. We demonstrate that ATRX deficiency corresponds to reduced H3.3 incorporation and stalling of RNA polymerase II at these G-rich intragenic sites. These findings suggest that ATRX promotes the incorporation of histone H3.3 at particular transcribed genes and facilitates transcriptional elongation through G-rich sequences. The inability to transcribe genes such as Nlgn4 could cause deficits in neuronal connectivity and cognition associated with ATRX mutations in humans. ",
+            "authors": {
+              "abbreviation": "Michael A Levy, Kristin D Kernohan, Yan Jiang, Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Levy",
+                  "abbrevName": "Levy MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael A Levy"
+                },
+                {
+                  "ForeName": "Kristin",
+                  "LastName": "Kernohan",
+                  "abbrevName": "Kernohan KD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristin D Kernohan"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1093/hmg/ddu596",
+            "pmid": "25452430",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 24 2015",
+            "title": "ATRX promotes gene expression by facilitating transcriptional elongation through guanine-rich coding regions."
+          }
+        },
+        {
+          "pmid": "25404090",
+          "pubmed": {
+            "ISODate": "2016-01-01T00:00:00.000Z",
+            "abstract": "Males are predominantly affected by autism spectrum disorders (ASD) with a prevalence ratio of 5:1. However, the underlying pathological mechanisms governing the male preponderance of ASD remain unclear. Recent studies suggested that epigenetic aberrations may cause synaptic dysfunctions, which might be related to the pathophysiology of ASD. In this study, we used rat offspring prenatally exposed to valproic acid (VPA) as an animal model of ASD. We found male-selective abnormalities in the kinetic profile of the excitatory glutamatergic synaptic protein expressions linked to N-methyl-D-aspartate receptor (NMDAR), alpha-amino-3-hydroxy-5-methyl-4-isoxazolepropionic acid receptor (AMPAR) and metabotropic glutamate receptor 5 (mGluR5) pathways in the prefrontal cortex of the VPA-exposed offspring at postnatal weeks 1, 2, and 4. Furthermore, VPA exposure showed a male-specific attenuation of the methyl-CpG-binding protein 2 (MeCP2) expressions both in the prefrontal cortex of offspring and in the gender-isolated neural progenitor cells (NPCs). In the gender-isolated NPCs culture, higher concentration of VPA induced an increased glutamatergic synaptic development along with decreased MeCP2 expression in both genders suggesting the role of MeCP2 in the modulation of synaptic development. In the small interfering RNA (siRNA) knock-down study, 50 pmol of Mecp2 siRNA inhibited the MeCP2 expression in male- but not in female-derived NPCs with concomitant induction of postsynaptic proteins such as PSD95. Taken together, we suggest that the male-inclined reduction of MeCP2 expression is involved in the abnormal development of glutamatergic synapse and male preponderance in the VPA animal models of ASD.",
+            "authors": {
+              "abbreviation": "Ki Chan Kim, Chang Soon Choi, Ji-Woon Kim, ..., Chan Young Shin",
+              "authorList": [
+                {
+                  "ForeName": "Ki",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim KC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ki Chan Kim"
+                },
+                {
+                  "ForeName": "Chang",
+                  "LastName": "Choi",
+                  "abbrevName": "Choi CS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chang Soon Choi"
+                },
+                {
+                  "ForeName": "Ji-Woon",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim JW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ji-Woon Kim"
+                },
+                {
+                  "ForeName": "Seol-Heui",
+                  "LastName": "Han",
+                  "abbrevName": "Han SH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seol-Heui Han"
+                },
+                {
+                  "ForeName": "Jae",
+                  "LastName": "Cheong",
+                  "abbrevName": "Cheong JH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jae Hoon Cheong"
+                },
+                {
+                  "ForeName": "Jong",
+                  "LastName": "Ryu",
+                  "abbrevName": "Ryu JH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jong Hoon Ryu"
+                },
+                {
+                  "ForeName": "Chan",
+                  "LastName": "Shin",
+                  "abbrevName": "Shin CY",
+                  "email": "chanyshin@kku.ac.kr",
+                  "isCollectiveName": false,
+                  "name": "Chan Young Shin"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Chan",
+                  "LastName": "Shin",
+                  "email": [
+                    "chanyshin@kku.ac.kr"
+                  ],
+                  "name": "Chan Young Shin"
+                }
+              ]
+            },
+            "doi": "10.1007/s12035-014-8987-z",
+            "pmid": "25404090",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Mol Neurobiol 53 2016",
+            "title": "MeCP2 Modulates Sex Differences in the Postsynaptic Development of the Valproate Animal Model of Autism."
+          }
+        },
+        {
+          "pmid": "25264773",
+          "pubmed": {
+            "ISODate": "2014-10-01T00:00:00.000Z",
+            "abstract": null,
+            "authors": {
+              "abbreviation": "Tiago A Ferreira, Arne V Blackman, Julia Oyrer, ..., Donald J van Meyel",
+              "authorList": [
+                {
+                  "ForeName": "Tiago",
+                  "LastName": "Ferreira",
+                  "abbrevName": "Ferreira TA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tiago A Ferreira"
+                },
+                {
+                  "ForeName": "Arne",
+                  "LastName": "Blackman",
+                  "abbrevName": "Blackman AV",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Arne V Blackman"
+                },
+                {
+                  "ForeName": "Julia",
+                  "LastName": "Oyrer",
+                  "abbrevName": "Oyrer J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Julia Oyrer"
+                },
+                {
+                  "ForeName": "Sriram",
+                  "LastName": "Jayabal",
+                  "abbrevName": "Jayabal S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sriram Jayabal"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "Chung",
+                  "abbrevName": "Chung AJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew J Chung"
+                },
+                {
+                  "ForeName": "Alanna",
+                  "LastName": "Watt",
+                  "abbrevName": "Watt AJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alanna J Watt"
+                },
+                {
+                  "ForeName": "P",
+                  "LastName": "Sjöström",
+                  "abbrevName": "Sjöström PJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "P Jesper Sjöström"
+                },
+                {
+                  "ForeName": "Donald",
+                  "LastName": "van Meyel",
+                  "abbrevName": "van Meyel DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Donald J van Meyel"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nmeth.3125",
+            "pmid": "25264773",
+            "pubTypes": [
+              {
+                "UI": "D016422",
+                "value": "Letter"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Methods 11 2014",
+            "title": "Neuronal morphometry directly from bitmap images."
+          }
+        },
+        {
+          "pmid": "25206554",
+          "pubmed": {
+            "ISODate": "2013-09-15T00:00:00.000Z",
+            "abstract": "Expression of miR-137 is downregulated in brain tissue from patients with depression and suicidal behavior, and is also downregulated in peripheral blood from stroke patients. However, it is not yet known if miR-137 acts as a bridge between stroke and depression. To test this, we used middle cerebral artery occlusion and chronic mild stress to establish a post-stroke depression model in rats. Compared with controls, we found significantly lower miR-137 levels in the brain and peripheral blood from post-stroke depression rats. Injection of a miR-137 antagonist into the brain ventricles upregulated miR-137 levels, and improved behavioral changes in post-stroke depression rats. Luciferase assays showed miR-137 bound to the 3'UTR of Grin2A, regulating Grin2A expression in a neuronal cell line. Grin2A gene overexpression in the brain of post-stroke depression rats, noticeably suppressed the inhibitory effect of miR-137 on post-stroke depression. Overall, our results show that miR-137 suppresses Grin2A protein expression through binding to Grin2A mRNA, thereby exerting an inhibitory effect on post-stroke depression. Our results offer a new therapeutic direction for post-stroke depression. ",
+            "authors": {
+              "abbreviation": "Lixia Zhao, Huazi Li, Ruiyou Guo, ..., Yifeng Du",
+              "authorList": [
+                {
+                  "ForeName": "Lixia",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lixia Zhao"
+                },
+                {
+                  "ForeName": "Huazi",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Huazi Li"
+                },
+                {
+                  "ForeName": "Ruiyou",
+                  "LastName": "Guo",
+                  "abbrevName": "Guo R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ruiyou Guo"
+                },
+                {
+                  "ForeName": "Teng",
+                  "LastName": "Ma",
+                  "abbrevName": "Ma T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Teng Ma"
+                },
+                {
+                  "ForeName": "Rongyao",
+                  "LastName": "Hou",
+                  "abbrevName": "Hou R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rongyao Hou"
+                },
+                {
+                  "ForeName": "Xiaowei",
+                  "LastName": "Ma",
+                  "abbrevName": "Ma X",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Xiaowei Ma"
+                },
+                {
+                  "ForeName": "Yifeng",
+                  "LastName": "Du",
+                  "abbrevName": "Du Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yifeng Du"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.3969/j.issn.1673-5374.2013.26.005",
+            "pmid": "25206554",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Neural Regen Res 8 2013",
+            "title": "miR-137, a new target for post-stroke depression?"
+          }
+        },
+        {
+          "pmid": "24581740",
+          "pubmed": {
+            "ISODate": "2014-03-06T00:00:00.000Z",
+            "abstract": "Increased male prevalence has been repeatedly reported in several neurodevelopmental disorders (NDs), leading to the concept of a \"female protective model.\" We investigated the molecular basis of this sex-based difference in liability and demonstrated an excess of deleterious autosomal copy-number variants (CNVs) in females compared to males (odds ratio [OR] = 1.46, p = 8 × 10(-10)) in a cohort of 15,585 probands ascertained for NDs. In an independent autism spectrum disorder (ASD) cohort of 762 families, we found a 3-fold increase in deleterious autosomal CNVs (p = 7 × 10(-4)) and an excess of private deleterious single-nucleotide variants (SNVs) in female compared to male probands (OR = 1.34, p = 0.03). We also showed that the deleteriousness of autosomal SNVs was significantly higher in female probands (p = 0.0006). A similar bias was observed in parents of probands ascertained for NDs. Deleterious CNVs (>400 kb) were maternally inherited more often (up to 64%, p = 10(-15)) than small CNVs < 400 kb (OR = 1.45, p = 0.0003). In the ASD cohort, increased maternal transmission was also observed for deleterious CNVs and SNVs. Although ASD females showed higher mutational burden and lower cognition, the excess mutational burden remained, even after adjustment for those cognitive differences. These results strongly suggest that females have an increased etiological burden unlinked to rare deleterious variants on the X chromosome. Carefully phenotyped and genotyped cohorts will be required for identifying the symptoms, which show gender-specific liability to mutational burden.",
+            "authors": {
+              "abbreviation": "Sébastien Jacquemont, Bradley P Coe, Micha Hersch, ..., Evan E Eichler",
+              "authorList": [
+                {
+                  "ForeName": "Sébastien",
+                  "LastName": "Jacquemont",
+                  "abbrevName": "Jacquemont S",
+                  "email": "sebastien.jacquemont@chuv.ch",
+                  "isCollectiveName": false,
+                  "name": "Sébastien Jacquemont"
+                },
+                {
+                  "ForeName": "Bradley",
+                  "LastName": "Coe",
+                  "abbrevName": "Coe BP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bradley P Coe"
+                },
+                {
+                  "ForeName": "Micha",
+                  "LastName": "Hersch",
+                  "abbrevName": "Hersch M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Micha Hersch"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Duyzend",
+                  "abbrevName": "Duyzend MH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael H Duyzend"
+                },
+                {
+                  "ForeName": "Niklas",
+                  "LastName": "Krumm",
+                  "abbrevName": "Krumm N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Niklas Krumm"
+                },
+                {
+                  "ForeName": "Sven",
+                  "LastName": "Bergmann",
+                  "abbrevName": "Bergmann S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sven Bergmann"
+                },
+                {
+                  "ForeName": "Jacques",
+                  "LastName": "Beckmann",
+                  "abbrevName": "Beckmann JS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacques S Beckmann"
+                },
+                {
+                  "ForeName": "Jill",
+                  "LastName": "Rosenfeld",
+                  "abbrevName": "Rosenfeld JA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jill A Rosenfeld"
+                },
+                {
+                  "ForeName": "Evan",
+                  "LastName": "Eichler",
+                  "abbrevName": "Eichler EE",
+                  "email": "eee@gs.washington.edu",
+                  "isCollectiveName": false,
+                  "name": "Evan E Eichler"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Sébastien",
+                  "LastName": "Jacquemont",
+                  "email": [
+                    "sebastien.jacquemont@chuv.ch"
+                  ],
+                  "name": "Sébastien Jacquemont"
+                },
+                {
+                  "ForeName": "Evan",
+                  "LastName": "Eichler",
+                  "email": [
+                    "eee@gs.washington.edu"
+                  ],
+                  "name": "Evan E Eichler"
+                }
+              ]
+            },
+            "doi": "10.1016/j.ajhg.2014.02.001",
+            "pmid": "24581740",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Am J Hum Genet 94 2014",
+            "title": "A higher mutational burden in females supports a \"female protective model\" in neurodevelopmental disorders."
+          }
+        },
+        {
+          "pmid": "24157548",
+          "pubmed": {
+            "ISODate": "2013-11-01T00:00:00.000Z",
+            "abstract": "Targeted nucleases are powerful tools for mediating genome alteration with high precision. The RNA-guided Cas9 nuclease from the microbial clustered regularly interspaced short palindromic repeats (CRISPR) adaptive immune system can be used to facilitate efficient genome engineering in eukaryotic cells by simply specifying a 20-nt targeting sequence within its guide RNA. Here we describe a set of tools for Cas9-mediated genome editing via nonhomologous end joining (NHEJ) or homology-directed repair (HDR) in mammalian cells, as well as generation of modified cell lines for downstream functional studies. To minimize off-target cleavage, we further describe a double-nicking strategy using the Cas9 nickase mutant with paired guide RNAs. This protocol provides experimentally derived guidelines for the selection of target sites, evaluation of cleavage efficiency and analysis of off-target activity. Beginning with target design, gene modifications can be achieved within as little as 1-2 weeks, and modified clonal cell lines can be derived within 2-3 weeks. ",
+            "authors": {
+              "abbreviation": "F Ann Ran, Patrick D Hsu, Jason Wright, ..., Feng Zhang",
+              "authorList": [
+                {
+                  "ForeName": "F",
+                  "LastName": "Ran",
+                  "abbrevName": "Ran FA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "F Ann Ran"
+                },
+                {
+                  "ForeName": "Patrick",
+                  "LastName": "Hsu",
+                  "abbrevName": "Hsu PD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Patrick D Hsu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Wright",
+                  "abbrevName": "Wright J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason Wright"
+                },
+                {
+                  "ForeName": "Vineeta",
+                  "LastName": "Agarwala",
+                  "abbrevName": "Agarwala V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vineeta Agarwala"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Scott",
+                  "abbrevName": "Scott DA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David A Scott"
+                },
+                {
+                  "ForeName": "Feng",
+                  "LastName": "Zhang",
+                  "abbrevName": "Zhang F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Feng Zhang"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nprot.2013.143",
+            "pmid": "24157548",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "Nat Protoc 8 2013",
+            "title": "Genome engineering using the CRISPR-Cas9 system."
+          }
+        },
+        {
+          "pmid": "24151012",
+          "pubmed": {
+            "ISODate": "2014-02-01T00:00:00.000Z",
+            "abstract": "Magnetic resonance imaging (MRI) of autism populations is confounded by the inherent heterogeneity in the individuals' genetics and environment, two factors difficult to control for. Imaging genetic animal models that recapitulate a mutation associated with autism quantify the impact of genetics on brain morphology and mitigate the confounding factors in human studies. Here, we used MRI to image three genetic mouse models with single mutations implicated in autism: Neuroligin-3 R451C knock-in, Methyl-CpG binding protein-2 (MECP2) 308-truncation and integrin β3 homozygous knockout. This study identified the morphological differences specific to the cerebellum, a structure repeatedly linked to autism in human neuroimaging and postmortem studies. To accomplish a comparative analysis, a segmented cerebellum template was created and used to segment each study image. This template delineated 39 different cerebellar structures. For Neuroligin-3 R451C male mutants, the gray (effect size (ES) = 1.94, FDR q = 0.03) and white (ES = 1.84, q = 0.037) matter of crus II lobule and the gray matter of the paraflocculus (ES = 1.45, q = 0.045) were larger in volume. The MECP2 mutant mice had cerebellar volume changes that increased in scope depending on the genotype: hemizygous males to homozygous females. The integrin β3 mutant mouse had a drastically smaller cerebellum than controls with 28 out of 39 cerebellar structures smaller. These imaging results are discussed in relation to repetitive behaviors, sociability, and learning in the context of autism. This work further illuminates the cerebellum's role in autism.",
+            "authors": {
+              "abbreviation": "Patrick E Steadman, Jacob Ellegood, Kamila U Szulc, ..., Jason P Lerch",
+              "authorList": [
+                {
+                  "ForeName": "Patrick",
+                  "LastName": "Steadman",
+                  "abbrevName": "Steadman PE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Patrick E Steadman"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Kamila",
+                  "LastName": "Szulc",
+                  "abbrevName": "Szulc KU",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kamila U Szulc"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Turnbull",
+                  "abbrevName": "Turnbull DH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel H Turnbull"
+                },
+                {
+                  "ForeName": "Alexandra",
+                  "LastName": "Joyner",
+                  "abbrevName": "Joyner AL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alexandra L Joyner"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Henkelman",
+                  "abbrevName": "Henkelman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Mark Henkelman"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/aur.1344",
+            "pmid": "24151012",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Autism Res 7 2014",
+            "title": "Genetic effects on cerebellar structure across mouse models of autism using a magnetic resonance imaging atlas."
+          }
+        },
+        {
+          "pmid": "24030948",
+          "pubmed": {
+            "ISODate": "2013-10-01T00:00:00.000Z",
+            "abstract": "Congenital hyperekplexia is a rare, potentially treatable neuromotor disorder. Three major genes of effect are known, and all three affect glycinergic neurotransmission. Two genes encode for subunits of the postsynaptic inhibitory glycine receptor, GLRA1 encoding the α1 subunit and GLRB encoding the β subunit. The third, SLC6A5, encodes the cognate presynaptic glycine transporter 2. Ninety-seven individuals had a clinical diagnosis of hyperekplexia confirmed by genetic testing: 61 cases had mutations in GLRA1, 24 cases in SLC6A5 and 12 in GLRB. Detailed retrospective clinical analysis ascertained that all gene-positive cases present in the neonatal period (occasionally prenatally) and that clonazepam is the treatment of choice (95% found it to be efficacious). We confirm that hyperekplexia is predominantly a recessive condition but dominant cases are seen (16%). We found no genetic evidence for 'major' or 'minor' forms of hyperekplexia on a population basis. Thirty-five gene-negative cases were studied for comparison, their cardinal feature was presentation after the first month of life (P < 0.001). In addition to the characteristic 'stiffness, startles and stumbles' of hyperekplexia, apnoea attacks (50 of 89) and delayed development (47 of 92) were frequently reported. Patients with SLC6A5 mutations were significantly more likely to have had recurrent infantile apnoeas (RR1.9; P < 0.005) than those with GLRA1 mutations. Patients with GLRB and SLC6A5 mutations were more likely to have developmental delay (RR1.5 P < 0.01; RR1.9 P < 0.03) than those with GLRA1 mutations; 92% of GLRB cases reported a mild to severe delay in speech acquisition. Molecular modelling of pathogenic mutations demonstrates specific patterns of protein disruption that can be used to predict phenotype severity. The developmental delay in hyperekplexia, and speech acquisition in particular, may represent failure of developmental neural networks or subtle neurogenic migration defects in the absence of presynaptic glycine release. We recommend early genetic testing for symptomatic neonates and possibly preconception counselling for those at risk for GLRB and SLC6A5 mutations, because of the more challenging phenotype. ",
+            "authors": {
+              "abbreviation": "Rhys H Thomas, Seo-Kyung Chung, Sian E Wood, ..., Mark I Rees",
+              "authorList": [
+                {
+                  "ForeName": "Rhys",
+                  "LastName": "Thomas",
+                  "abbrevName": "Thomas RH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rhys H Thomas"
+                },
+                {
+                  "ForeName": "Seo-Kyung",
+                  "LastName": "Chung",
+                  "abbrevName": "Chung SK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seo-Kyung Chung"
+                },
+                {
+                  "ForeName": "Sian",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sian E Wood"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Cushion",
+                  "abbrevName": "Cushion TD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas D Cushion"
+                },
+                {
+                  "ForeName": "Cheney",
+                  "LastName": "Drew",
+                  "abbrevName": "Drew CJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Cheney J G Drew"
+                },
+                {
+                  "ForeName": "Carrie",
+                  "LastName": "Hammond",
+                  "abbrevName": "Hammond CL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Carrie L Hammond"
+                },
+                {
+                  "ForeName": "Jean-Francois",
+                  "LastName": "Vanbellinghen",
+                  "abbrevName": "Vanbellinghen JF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jean-Francois Vanbellinghen"
+                },
+                {
+                  "ForeName": "Jonathan",
+                  "LastName": "Mullins",
+                  "abbrevName": "Mullins JG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jonathan G L Mullins"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Rees",
+                  "abbrevName": "Rees MI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark I Rees"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/brain/awt207",
+            "pmid": "24030948",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Brain 136 2013",
+            "title": "Genotype-phenotype correlations in hyperekplexia: apnoeas, learning difficulties and speech delay."
+          }
+        },
+        {
+          "pmid": "23689500",
+          "pubmed": {
+            "ISODate": "2014-07-01T00:00:00.000Z",
+            "abstract": "The basal ganglia are a group of subpallial nuclei that play an important role in motor, emotional, and cognitive functions. Morphological changes and disrupted afferent/efferent connections in the basal ganglia have been associated with a variety of neurological disorders including psychiatric and movement disorders. While high-resolution magnetic resonance imaging has been used to characterize changes in brain structure in mouse models of these disorders, no systematic method for segmentation of the C57BL/6 J mouse basal ganglia exists. In this study we have used high-resolution MR images of ex vivo C57BL/6 J mouse brain to create a detailed protocol for segmenting the basal ganglia. We created a three-dimensional minimum deformation atlas, which includes the segmentation of 35 striatal, pallidal, and basal ganglia-related structures. In addition, we provide mean volumes, mean T2 contrast intensities and mean FA and ADC values for each structure. This MR atlas is available for download, and enables researchers to perform automated segmentation in genetic models of basal ganglia disorders.",
+            "authors": {
+              "abbreviation": "Jeremy F P Ullmann, Charles Watson, Andrew L Janke, ..., David C Reutens",
+              "authorList": [
+                {
+                  "ForeName": "Jeremy",
+                  "LastName": "Ullmann",
+                  "abbrevName": "Ullmann JF",
+                  "email": "j.ullmann@uq.edu.au",
+                  "isCollectiveName": false,
+                  "name": "Jeremy F P Ullmann"
+                },
+                {
+                  "ForeName": "Charles",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Charles Watson"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "Janke",
+                  "abbrevName": "Janke AL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew L Janke"
+                },
+                {
+                  "ForeName": "Nyoman",
+                  "LastName": "Kurniawan",
+                  "abbrevName": "Kurniawan ND",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nyoman D Kurniawan"
+                },
+                {
+                  "ForeName": "George",
+                  "LastName": "Paxinos",
+                  "abbrevName": "Paxinos G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "George Paxinos"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Reutens",
+                  "abbrevName": "Reutens DC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David C Reutens"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Jeremy",
+                  "LastName": "Ullmann",
+                  "email": [
+                    "j.ullmann@uq.edu.au"
+                  ],
+                  "name": "Jeremy F P Ullmann"
+                }
+              ]
+            },
+            "doi": "10.1007/s00429-013-0572-0",
+            "pmid": "23689500",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Brain Struct Funct 219 2014",
+            "title": "An MRI atlas of the mouse basal ganglia."
+          }
+        },
+        {
+          "pmid": "23592037",
+          "pubmed": {
+            "ISODate": "2013-04-16T00:00:00.000Z",
+            "abstract": "The perineuronal net (PNN) surrounds neurons in the central nervous system and is thought to regulate developmental plasticity. A few studies have shown an involvement of the PNN in hippocampal plasticity and memory storage in adult animals. In addition to the hippocampus, plasticity in the medial prefrontal cortex (mPFC) has been demonstrated to be critical for the storage of long-term memory, particularly memories for temporally separated events. In the present study, we examined the role of PNN in the acquisition and retention of memories for trace (in which the conditioned and unconditioned stimuli are temporally separated) and delayed (in which the conditioned and unconditioned stimuli overlap) fear conditioning in both the hippocampus and the mPFC. Consistent with a role for the hippocampus in memory storage in both delayed and trace fear conditioning, removal of hippocampal PNN disrupted contextual and trace fear memory. Disruption of the PNN in the mPFC impaired long-term trace and conditioned stimulus (CS)-elicited fear memory in the trace fear conditioning task. Interestingly, CS-elicited fear memory was also impaired when a delayed fear conditioning paradigm was used. These findings further support a role for the PNN in neural plasticity and implicate PNN-regulated plasticity in neocortical memory storage.",
+            "authors": {
+              "abbreviation": "Michael J Hylin, Sara A Orsi, Anthony N Moore, Pramod K Dash",
+              "authorList": [
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Hylin",
+                  "abbrevName": "Hylin MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael J Hylin"
+                },
+                {
+                  "ForeName": "Sara",
+                  "LastName": "Orsi",
+                  "abbrevName": "Orsi SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sara A Orsi"
+                },
+                {
+                  "ForeName": "Anthony",
+                  "LastName": "Moore",
+                  "abbrevName": "Moore AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anthony N Moore"
+                },
+                {
+                  "ForeName": "Pramod",
+                  "LastName": "Dash",
+                  "abbrevName": "Dash PK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pramod K Dash"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1101/lm.030197.112",
+            "pmid": "23592037",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "Learn Mem 20 2013",
+            "title": "Disruption of the perineuronal net in the hippocampus or medial prefrontal cortex impairs fear conditioning."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "23252729",
+          "pubmed": {
+            "ISODate": "2013-07-01T00:00:00.000Z",
+            "abstract": "MicroRNA-137 (miR-137) expression has been reported to be decreased in astrocytic tumors in two expression profiling studies but its role in the pathogenesis of oligodendroglial tumors is still limited. In this study, we demonstrate that miR-137 expression is significantly downregulated in a cohort of 35 oligodendroglial tumors and nine glioma cell lines compared with normal brains. Lower miR-137 expression is associated with shorter progressive-free survival and overall survival. Restoration of miR-137 expression in an oligodendroglial cells TC620, and also glioblastoma cells of U87 and U373 significantly suppressed cell growth, anchorage-independent growth, as well as invasion. Demethylation and deacetylation treatments resulted in upregulation of miR-137 expression in TC620 cells. In silico analysis showed that CSE1 chromosome segregation 1-like (yeast) (CSE1L) is a potential target gene of miR-137. Luciferase reporter assay demonstrated that miR-137 negatively regulates CSE1L by interaction between miR-137 and complementary sequences in the 3' UTR of CSE1L. Immunohistochemistry revealed that CSE1L is upregulated in oligodendroglial tumors. Knockdown of CSE1L resulted in similar outcomes as overexpressing miR-137 in oligodendroglioma cells and glioblastoma cells. Overall, our data suggest that miR-137 regulates growth of glioma cells and targets CSE1L, providing further understanding in the tumorigenesis of gliomas.",
+            "authors": {
+              "abbreviation": "Kay Ka-Wai Li, Ling Yang, Jesse Chung-Sean Pang, ..., Ho-Keung Ng",
+              "authorList": [
+                {
+                  "ForeName": "Kay",
+                  "LastName": "Li",
+                  "abbrevName": "Li KK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kay Ka-Wai Li"
+                },
+                {
+                  "ForeName": "Ling",
+                  "LastName": "Yang",
+                  "abbrevName": "Yang L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ling Yang"
+                },
+                {
+                  "ForeName": "Jesse",
+                  "LastName": "Pang",
+                  "abbrevName": "Pang JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jesse Chung-Sean Pang"
+                },
+                {
+                  "ForeName": "Aden",
+                  "LastName": "Chan",
+                  "abbrevName": "Chan AK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Aden Ka-Yin Chan"
+                },
+                {
+                  "ForeName": "Liangfu",
+                  "LastName": "Zhou",
+                  "abbrevName": "Zhou L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Liangfu Zhou"
+                },
+                {
+                  "ForeName": "Ying",
+                  "LastName": "Mao",
+                  "abbrevName": "Mao Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ying Mao"
+                },
+                {
+                  "ForeName": "Yin",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yin Wang"
+                },
+                {
+                  "ForeName": "Kin-Mang",
+                  "LastName": "Lau",
+                  "abbrevName": "Lau KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kin-Mang Lau"
+                },
+                {
+                  "ForeName": "Wai",
+                  "LastName": "Poon",
+                  "abbrevName": "Poon WS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wai Sang Poon"
+                },
+                {
+                  "ForeName": "Zhifeng",
+                  "LastName": "Shi",
+                  "abbrevName": "Shi Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zhifeng Shi"
+                },
+                {
+                  "ForeName": "Ho-Keung",
+                  "LastName": "Ng",
+                  "abbrevName": "Ng HK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ho-Keung Ng"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1111/bpa.12015",
+            "pmid": "23252729",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Brain Pathol 23 2013",
+            "title": "MIR-137 suppresses growth and invasion, is downregulated in oligodendroglial tumors and targets CSE1L."
+          }
+        },
+        {
+          "pmid": "23201973",
+          "pubmed": {
+            "ISODate": "2013-01-01T00:00:00.000Z",
+            "abstract": "The origins and evolution of higher cognitive functions, including complex forms of learning, attention and executive functions, are unknown. A potential mechanism driving the evolution of vertebrate cognition early in the vertebrate lineage (550 million years ago) was genome duplication and subsequent diversification of postsynaptic genes. Here we report, to our knowledge, the first genetic analysis of a vertebrate gene family in cognitive functions measured using computerized touchscreens. Comparison of mice carrying mutations in each of the four Dlg paralogs showed that simple associative learning required Dlg4, whereas Dlg2 and Dlg3 diversified to have opposing functions in complex cognitive processes. Exploiting the translational utility of touchscreens in humans and mice, testing Dlg2 mutations in both species showed that Dlg2's role in complex learning, cognitive flexibility and attention has been highly conserved over 100 million years. Dlg-family mutations underlie psychiatric disorders, suggesting that genome evolution expanded the complexity of vertebrate cognition at the cost of susceptibility to mental illness.",
+            "authors": {
+              "abbreviation": "Jess Nithianantharajah, Noboru H Komiyama, Andrew McKechanie, ..., Seth G N Grant",
+              "authorList": [
+                {
+                  "ForeName": "Jess",
+                  "LastName": "Nithianantharajah",
+                  "abbrevName": "Nithianantharajah J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jess Nithianantharajah"
+                },
+                {
+                  "ForeName": "Noboru",
+                  "LastName": "Komiyama",
+                  "abbrevName": "Komiyama NH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Noboru H Komiyama"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "McKechanie",
+                  "abbrevName": "McKechanie A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew McKechanie"
+                },
+                {
+                  "ForeName": "Mandy",
+                  "LastName": "Johnstone",
+                  "abbrevName": "Johnstone M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mandy Johnstone"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Blackwood",
+                  "abbrevName": "Blackwood DH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas H Blackwood"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "St Clair",
+                  "abbrevName": "St Clair D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David St Clair"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Emes",
+                  "abbrevName": "Emes RD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard D Emes"
+                },
+                {
+                  "ForeName": "Louie",
+                  "LastName": "van de Lagemaat",
+                  "abbrevName": "van de Lagemaat LN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Louie N van de Lagemaat"
+                },
+                {
+                  "ForeName": "Lisa",
+                  "LastName": "Saksida",
+                  "abbrevName": "Saksida LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lisa M Saksida"
+                },
+                {
+                  "ForeName": "Timothy",
+                  "LastName": "Bussey",
+                  "abbrevName": "Bussey TJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Timothy J Bussey"
+                },
+                {
+                  "ForeName": "Seth",
+                  "LastName": "Grant",
+                  "abbrevName": "Grant SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seth G N Grant"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nn.3276",
+            "pmid": "23201973",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D016448",
+                "value": "Multicenter Study"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Neurosci 16 2013",
+            "title": "Synaptic scaffold evolution generated components of vertebrate cognitive complexity."
+          }
+        },
+        {
+          "pmid": "22743772",
+          "pubmed": {
+            "ISODate": "2012-06-28T00:00:00.000Z",
+            "abstract": "Fiji is a distribution of the popular open-source software ImageJ focused on biological-image analysis. Fiji uses modern software engineering practices to combine powerful software libraries with a broad range of scripting languages to enable rapid prototyping of image-processing algorithms. Fiji facilitates the transformation of new algorithms into ImageJ plugins that can be shared with end users through an integrated update system. We propose Fiji as a platform for productive collaboration between computer science and biology research communities.",
+            "authors": {
+              "abbreviation": "Johannes Schindelin, Ignacio Arganda-Carreras, Erwin Frise, ..., Albert Cardona",
+              "authorList": [
+                {
+                  "ForeName": "Johannes",
+                  "LastName": "Schindelin",
+                  "abbrevName": "Schindelin J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Johannes Schindelin"
+                },
+                {
+                  "ForeName": "Ignacio",
+                  "LastName": "Arganda-Carreras",
+                  "abbrevName": "Arganda-Carreras I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ignacio Arganda-Carreras"
+                },
+                {
+                  "ForeName": "Erwin",
+                  "LastName": "Frise",
+                  "abbrevName": "Frise E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Erwin Frise"
+                },
+                {
+                  "ForeName": "Verena",
+                  "LastName": "Kaynig",
+                  "abbrevName": "Kaynig V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Verena Kaynig"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Longair",
+                  "abbrevName": "Longair M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark Longair"
+                },
+                {
+                  "ForeName": "Tobias",
+                  "LastName": "Pietzsch",
+                  "abbrevName": "Pietzsch T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tobias Pietzsch"
+                },
+                {
+                  "ForeName": "Stephan",
+                  "LastName": "Preibisch",
+                  "abbrevName": "Preibisch S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephan Preibisch"
+                },
+                {
+                  "ForeName": "Curtis",
+                  "LastName": "Rueden",
+                  "abbrevName": "Rueden C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Curtis Rueden"
+                },
+                {
+                  "ForeName": "Stephan",
+                  "LastName": "Saalfeld",
+                  "abbrevName": "Saalfeld S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephan Saalfeld"
+                },
+                {
+                  "ForeName": "Benjamin",
+                  "LastName": "Schmid",
+                  "abbrevName": "Schmid B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Benjamin Schmid"
+                },
+                {
+                  "ForeName": "Jean-Yves",
+                  "LastName": "Tinevez",
+                  "abbrevName": "Tinevez JY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jean-Yves Tinevez"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "White",
+                  "abbrevName": "White DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel James White"
+                },
+                {
+                  "ForeName": "Volker",
+                  "LastName": "Hartenstein",
+                  "abbrevName": "Hartenstein V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Volker Hartenstein"
+                },
+                {
+                  "ForeName": "Kevin",
+                  "LastName": "Eliceiri",
+                  "abbrevName": "Eliceiri K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kevin Eliceiri"
+                },
+                {
+                  "ForeName": "Pavel",
+                  "LastName": "Tomancak",
+                  "abbrevName": "Tomancak P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pavel Tomancak"
+                },
+                {
+                  "ForeName": "Albert",
+                  "LastName": "Cardona",
+                  "abbrevName": "Cardona A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Albert Cardona"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nmeth.2019",
+            "pmid": "22743772",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Methods 9 2012",
+            "title": "Fiji: an open-source platform for biological-image analysis."
+          }
+        },
+        {
+          "pmid": "22537595",
+          "pubmed": {
+            "ISODate": "2012-08-01T00:00:00.000Z",
+            "abstract": "Previous research has indicated that chronic stress induces inflammatory responses, cognitive impairments, and changes in microglia and astrocytes. However, whether stress-induced changes following recovery are reversible is unclear. The present study examined the effects of chronic unpredictable stress (CUS) following recovery on spatial learning and memory impairments, changes in microglia and astrocytes, and interleukine-1β (IL-1β) and glial-derived neurotrophic factor (GDNF) levels. Mice were randomly divided into control, stress, and recovery groups, and CUS was applied to mice in the stress and recovery groups for 40 days. Following the application of CUS, the recovery group was allowed 40 days without stress. The results of the Morris water maze illustrated that CUS-induced spatial learning and memory impairments could be reversed or even improved by a period of recovery. Immunohistochemical tests revealed that CUS-induced alterations in microglia could dissipate with time in the CA3 region of the hippocampus and prelimbic areas. However, CUS-induced activation of astrocytes was sustained in the CA3 area following recovery. Western blot analyses revealed that CUS induced a significant increase of GDNF and a significant decrease in IL-1β. Additionally, increased GDNF levels were sustained in the hippocampus during recovery. In conclusion, this study provides evidence that CUS-induced learning and memory impairments could be reversible following recovery. However, activated astrocytes and increased GDNF levels in the hippocampus remained elevated after recovery, suggesting that activated astrocytes and increased GDNF play important roles in the adaptation of the brain to CUS and in repairing CUS-induced impairments during recovery.",
+            "authors": {
+              "abbreviation": "Yanqing Bian, Zhuo Pan, Ziyuan Hou, ..., Baohua Zhao",
+              "authorList": [
+                {
+                  "ForeName": "Yanqing",
+                  "LastName": "Bian",
+                  "abbrevName": "Bian Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yanqing Bian"
+                },
+                {
+                  "ForeName": "Zhuo",
+                  "LastName": "Pan",
+                  "abbrevName": "Pan Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zhuo Pan"
+                },
+                {
+                  "ForeName": "Ziyuan",
+                  "LastName": "Hou",
+                  "abbrevName": "Hou Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ziyuan Hou"
+                },
+                {
+                  "ForeName": "Cui",
+                  "LastName": "Huang",
+                  "abbrevName": "Huang C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Cui Huang"
+                },
+                {
+                  "ForeName": "Wei",
+                  "LastName": "Li",
+                  "abbrevName": "Li W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wei Li"
+                },
+                {
+                  "ForeName": "Baohua",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Baohua Zhao"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.brainresbull.2012.04.008",
+            "pmid": "22537595",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Brain Res Bull 88 2012",
+            "title": "Learning, memory, and glial cell changes following recovery from chronic unpredictable stress."
+          }
+        },
+        {
+          "pmid": "22503632",
+          "pubmed": {
+            "ISODate": "2012-05-04T00:00:00.000Z",
+            "abstract": "Recent studies have highlighted the involvement of rare (<1% frequency) copy-number variations and point mutations in the genetic etiology of autism spectrum disorder (ASD); these variants particularly affect genes involved in the neuronal synaptic complex. The SHANK gene family consists of three members (SHANK1, SHANK2, and SHANK3), which encode scaffolding proteins required for the proper formation and function of neuronal synapses. Although SHANK2 and SHANK3 mutations have been implicated in ASD and intellectual disability, the involvement of SHANK1 is unknown. Here, we assess microarray data from 1,158 Canadian and 456 European individuals with ASD to discover microdeletions at the SHANK1 locus on chromosome 19. We identify a hemizygous SHANK1 deletion that segregates in a four-generation family in which male carriers--but not female carriers--have ASD with higher functioning. A de novo SHANK1 deletion was also detected in an unrelated male individual with ASD with higher functioning, and no equivalent SHANK1 mutations were found in >15,000 controls (p = 0.009). The discovery of apparent reduced penetrance of ASD in females bearing inherited autosomal SHANK1 deletions provides a possible contributory model for the male gender bias in autism. The data are also informative for clinical-genetics interpretations of both inherited and sporadic forms of ASD involving SHANK1.",
+            "authors": {
+              "abbreviation": "Daisuke Sato, Anath C Lionel, Claire S Leblond, ..., Stephen W Scherer",
+              "authorList": [
+                {
+                  "ForeName": "Daisuke",
+                  "LastName": "Sato",
+                  "abbrevName": "Sato D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daisuke Sato"
+                },
+                {
+                  "ForeName": "Anath",
+                  "LastName": "Lionel",
+                  "abbrevName": "Lionel AC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anath C Lionel"
+                },
+                {
+                  "ForeName": "Claire",
+                  "LastName": "Leblond",
+                  "abbrevName": "Leblond CS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Claire S Leblond"
+                },
+                {
+                  "ForeName": "Aparna",
+                  "LastName": "Prasad",
+                  "abbrevName": "Prasad A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Aparna Prasad"
+                },
+                {
+                  "ForeName": "Dalila",
+                  "LastName": "Pinto",
+                  "abbrevName": "Pinto D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dalila Pinto"
+                },
+                {
+                  "ForeName": "Susan",
+                  "LastName": "Walker",
+                  "abbrevName": "Walker S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susan Walker"
+                },
+                {
+                  "ForeName": "Irene",
+                  "LastName": "O'Connor",
+                  "abbrevName": "O'Connor I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Irene O'Connor"
+                },
+                {
+                  "ForeName": "Carolyn",
+                  "LastName": "Russell",
+                  "abbrevName": "Russell C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Carolyn Russell"
+                },
+                {
+                  "ForeName": "Irene",
+                  "LastName": "Drmic",
+                  "abbrevName": "Drmic IE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Irene E Drmic"
+                },
+                {
+                  "ForeName": "Fadi",
+                  "LastName": "Hamdan",
+                  "abbrevName": "Hamdan FF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Fadi F Hamdan"
+                },
+                {
+                  "ForeName": "Jacques",
+                  "LastName": "Michaud",
+                  "abbrevName": "Michaud JL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacques L Michaud"
+                },
+                {
+                  "ForeName": "Volker",
+                  "LastName": "Endris",
+                  "abbrevName": "Endris V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Volker Endris"
+                },
+                {
+                  "ForeName": "Ralph",
+                  "LastName": "Roeth",
+                  "abbrevName": "Roeth R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ralph Roeth"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Delorme",
+                  "abbrevName": "Delorme R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard Delorme"
+                },
+                {
+                  "ForeName": "Guillaume",
+                  "LastName": "Huguet",
+                  "abbrevName": "Huguet G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Guillaume Huguet"
+                },
+                {
+                  "ForeName": "Marion",
+                  "LastName": "Leboyer",
+                  "abbrevName": "Leboyer M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marion Leboyer"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Rastam",
+                  "abbrevName": "Rastam M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Rastam"
+                },
+                {
+                  "ForeName": "Christopher",
+                  "LastName": "Gillberg",
+                  "abbrevName": "Gillberg C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christopher Gillberg"
+                },
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Lathrop",
+                  "abbrevName": "Lathrop M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mark Lathrop"
+                },
+                {
+                  "ForeName": "Dimitri",
+                  "LastName": "Stavropoulos",
+                  "abbrevName": "Stavropoulos DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dimitri J Stavropoulos"
+                },
+                {
+                  "ForeName": "Evdokia",
+                  "LastName": "Anagnostou",
+                  "abbrevName": "Anagnostou E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Evdokia Anagnostou"
+                },
+                {
+                  "ForeName": "Rosanna",
+                  "LastName": "Weksberg",
+                  "abbrevName": "Weksberg R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rosanna Weksberg"
+                },
+                {
+                  "ForeName": "Eric",
+                  "LastName": "Fombonne",
+                  "abbrevName": "Fombonne E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Eric Fombonne"
+                },
+                {
+                  "ForeName": "Lonnie",
+                  "LastName": "Zwaigenbaum",
+                  "abbrevName": "Zwaigenbaum L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lonnie Zwaigenbaum"
+                },
+                {
+                  "ForeName": "Bridget",
+                  "LastName": "Fernandez",
+                  "abbrevName": "Fernandez BA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bridget A Fernandez"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Roberts",
+                  "abbrevName": "Roberts W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Roberts"
+                },
+                {
+                  "ForeName": "Gudrun",
+                  "LastName": "Rappold",
+                  "abbrevName": "Rappold GA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gudrun A Rappold"
+                },
+                {
+                  "ForeName": "Christian",
+                  "LastName": "Marshall",
+                  "abbrevName": "Marshall CR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christian R Marshall"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Bourgeron",
+                  "abbrevName": "Bourgeron T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas Bourgeron"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Szatmari",
+                  "abbrevName": "Szatmari P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter Szatmari"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Scherer",
+                  "abbrevName": "Scherer SW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen W Scherer"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.ajhg.2012.03.017",
+            "pmid": "22503632",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Am J Hum Genet 90 2012",
+            "title": "SHANK1 Deletions in Males with Autism Spectrum Disorder."
+          }
+        },
+        {
+          "pmid": "22028674",
+          "pubmed": {
+            "ISODate": "2011-10-01T00:00:00.000Z",
+            "abstract": "Oxidative stress is a common etiological feature of neurological disorders, although the pathways that govern defence against reactive oxygen species (ROS) in neurodegeneration remain unclear. We have identified the role of oxidation resistance 1 (Oxr1) as a vital protein that controls the sensitivity of neuronal cells to oxidative stress; mice lacking Oxr1 display cerebellar neurodegeneration, and neurons are less susceptible to exogenous stress when the gene is over-expressed. A conserved short isoform of Oxr1 is also sufficient to confer this neuroprotective property both in vitro and in vivo. In addition, biochemical assays indicate that Oxr1 itself is susceptible to cysteine-mediated oxidation. Finally we show up-regulation of Oxr1 in both human and pre-symptomatic mouse models of amyotrophic lateral sclerosis, indicating that Oxr1 is potentially a novel neuroprotective factor in neurodegenerative disease.",
+            "authors": {
+              "abbreviation": "Peter L Oliver, Mattéa J Finelli, Benjamin Edwards, ..., Kay E Davies",
+              "authorList": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Oliver",
+                  "abbrevName": "Oliver PL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter L Oliver"
+                },
+                {
+                  "ForeName": "Mattéa",
+                  "LastName": "Finelli",
+                  "abbrevName": "Finelli MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mattéa J Finelli"
+                },
+                {
+                  "ForeName": "Benjamin",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Benjamin Edwards"
+                },
+                {
+                  "ForeName": "Emmanuelle",
+                  "LastName": "Bitoun",
+                  "abbrevName": "Bitoun E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Emmanuelle Bitoun"
+                },
+                {
+                  "ForeName": "Darcy",
+                  "LastName": "Butts",
+                  "abbrevName": "Butts DL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Darcy L Butts"
+                },
+                {
+                  "ForeName": "Esther",
+                  "LastName": "Becker",
+                  "abbrevName": "Becker EB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Esther B E Becker"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Cheeseman",
+                  "abbrevName": "Cheeseman MT",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael T Cheeseman"
+                },
+                {
+                  "ForeName": "Ben",
+                  "LastName": "Davies",
+                  "abbrevName": "Davies B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ben Davies"
+                },
+                {
+                  "ForeName": "Kay",
+                  "LastName": "Davies",
+                  "abbrevName": "Davies KE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kay E Davies"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1371/journal.pgen.1002338",
+            "pmid": "22028674",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "PLoS Genet 7 2011",
+            "title": "Oxr1 is essential for protection against oxidative stress-induced neurodegeneration."
+          }
+        },
+        {
+          "pmid": "21727141",
+          "pubmed": {
+            "ISODate": "2011-09-01T00:00:00.000Z",
+            "abstract": "MOTIVATION: Advances in techniques to sparsely label neurons unlock the potential to reconstruct connectivity from 3D image stacks acquired by light microscopy. We present an application for semi-automated tracing of neurons to quickly annotate noisy datasets and construct complex neuronal topologies, which we call the Simple Neurite Tracer. AVAILABILITY: Simple Neurite Tracer is open source software, licensed under the GNU General Public Licence (GPL) and based on the public domain image processing software ImageJ. The software and further documentation are available via http://fiji.sc/Simple_Neurite_Tracer as part of the package Fiji, and can be used on Windows, Mac OS and Linux. Documentation and introductory screencasts are available at the same URL. CONTACT: longair@ini.phys.ethz.ch; longair@ini.phys.ethz.ch.",
+            "authors": {
+              "abbreviation": "Mark H Longair, Dean A Baker, J Douglas Armstrong",
+              "authorList": [
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Longair",
+                  "abbrevName": "Longair MH",
+                  "email": "longair@ini.phys.ethz.ch",
+                  "isCollectiveName": false,
+                  "name": "Mark H Longair"
+                },
+                {
+                  "ForeName": "Dean",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker DA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dean A Baker"
+                },
+                {
+                  "ForeName": "J",
+                  "LastName": "Armstrong",
+                  "abbrevName": "Armstrong JD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J Douglas Armstrong"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Mark",
+                  "LastName": "Longair",
+                  "email": [
+                    "longair@ini.phys.ethz.ch"
+                  ],
+                  "name": "Mark H Longair"
+                }
+              ]
+            },
+            "doi": "10.1093/bioinformatics/btr390",
+            "pmid": "21727141",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Bioinformatics 27 2011",
+            "title": "Simple Neurite Tracer: open source software for reconstruction, visualization and analysis of neuronal processes."
+          }
+        },
+        {
+          "pmid": "21704710",
+          "pubmed": {
+            "ISODate": "2011-10-01T00:00:00.000Z",
+            "abstract": "The hippocampal formation plays an important role in cognition, spatial navigation, learning, and memory. High resolution magnetic resonance (MR) imaging makes it possible to study in vivo changes in the hippocampus over time and is useful for comparing hippocampal volume and structure in wild type and mutant mice. Such comparisons demand a reliable way to segment the hippocampal formation. We have developed a method for the systematic segmentation of the hippocampal formation using the perfusion-fixed C57BL/6 mouse brain for application in longitudinal and comparative studies. Our aim was to develop a guide for segmenting over 40 structures in an adult mouse brain using 30 μm isotropic resolution images acquired with a 16.4 T MR imaging system and combined using super-resolution reconstruction.",
+            "authors": {
+              "abbreviation": "Kay Richards, Charles Watson, Rachel F Buckley, ..., David C Reutens",
+              "authorList": [
+                {
+                  "ForeName": "Kay",
+                  "LastName": "Richards",
+                  "abbrevName": "Richards K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kay Richards"
+                },
+                {
+                  "ForeName": "Charles",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Charles Watson"
+                },
+                {
+                  "ForeName": "Rachel",
+                  "LastName": "Buckley",
+                  "abbrevName": "Buckley RF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rachel F Buckley"
+                },
+                {
+                  "ForeName": "Nyoman",
+                  "LastName": "Kurniawan",
+                  "abbrevName": "Kurniawan ND",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nyoman D Kurniawan"
+                },
+                {
+                  "ForeName": "Zhengyi",
+                  "LastName": "Yang",
+                  "abbrevName": "Yang Z",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Zhengyi Yang"
+                },
+                {
+                  "ForeName": "Marianne",
+                  "LastName": "Keller",
+                  "abbrevName": "Keller MD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marianne D Keller"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Beare",
+                  "abbrevName": "Beare R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard Beare"
+                },
+                {
+                  "ForeName": "Perry",
+                  "LastName": "Bartlett",
+                  "abbrevName": "Bartlett PF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Perry F Bartlett"
+                },
+                {
+                  "ForeName": "Gary",
+                  "LastName": "Egan",
+                  "abbrevName": "Egan GF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gary F Egan"
+                },
+                {
+                  "ForeName": "Graham",
+                  "LastName": "Galloway",
+                  "abbrevName": "Galloway GJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Graham J Galloway"
+                },
+                {
+                  "ForeName": "George",
+                  "LastName": "Paxinos",
+                  "abbrevName": "Paxinos G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "George Paxinos"
+                },
+                {
+                  "ForeName": "Steven",
+                  "LastName": "Petrou",
+                  "abbrevName": "Petrou S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Steven Petrou"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Reutens",
+                  "abbrevName": "Reutens DC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David C Reutens"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.neuroimage.2011.06.025",
+            "pmid": "21704710",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuroimage 58 2011",
+            "title": "Segmentation of the mouse hippocampal formation in magnetic resonance images."
+          }
+        },
+        {
+          "pmid": "21666677",
+          "pubmed": {
+            "ISODate": "2011-06-12T00:00:00.000Z",
+            "abstract": "Accurate read-out of chromatin modifications is essential for eukaryotic life. Mutations in the gene encoding X-linked ATRX protein cause a mental-retardation syndrome, whereas wild-type ATRX protein targets pericentric and telomeric heterochromatin for deposition of the histone variant H3.3 by means of a largely unknown mechanism. Here we show that the ADD domain of ATRX, in which most syndrome-causing mutations occur, engages the N-terminal tail of histone H3 through two rigidly oriented binding pockets, one for unmodified Lys4 and the other for di- or trimethylated Lys9. In vivo experiments show this combinatorial readout is required for ATRX localization, with recruitment enhanced by a third interaction through heterochromatin protein-1 (HP1) that also recognizes trimethylated Lys9. The cooperation of ATRX ADD domain and HP1 in chromatin recruitment results in a tripartite interaction that may span neighboring nucleosomes and illustrates how the 'histone-code' is interpreted by a combination of multivalent effector-chromatin interactions.",
+            "authors": {
+              "abbreviation": "Sebastian Eustermann, Ji-Chun Yang, Martin J Law, ..., David Neuhaus",
+              "authorList": [
+                {
+                  "ForeName": "Sebastian",
+                  "LastName": "Eustermann",
+                  "abbrevName": "Eustermann S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sebastian Eustermann"
+                },
+                {
+                  "ForeName": "Ji-Chun",
+                  "LastName": "Yang",
+                  "abbrevName": "Yang JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ji-Chun Yang"
+                },
+                {
+                  "ForeName": "Martin",
+                  "LastName": "Law",
+                  "abbrevName": "Law MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Martin J Law"
+                },
+                {
+                  "ForeName": "Rachel",
+                  "LastName": "Amos",
+                  "abbrevName": "Amos R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rachel Amos"
+                },
+                {
+                  "ForeName": "Lynda",
+                  "LastName": "Chapman",
+                  "abbrevName": "Chapman LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lynda M Chapman"
+                },
+                {
+                  "ForeName": "Clare",
+                  "LastName": "Jelinska",
+                  "abbrevName": "Jelinska C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Clare Jelinska"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Garrick",
+                  "abbrevName": "Garrick D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Garrick"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Clynes",
+                  "abbrevName": "Clynes D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Clynes"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Daniela",
+                  "LastName": "Rhodes",
+                  "abbrevName": "Rhodes D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniela Rhodes"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas R Higgs"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Neuhaus",
+                  "abbrevName": "Neuhaus D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Neuhaus"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nsmb.2070",
+            "pmid": "21666677",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Struct Mol Biol 18 2011",
+            "title": "Combinatorial readout of histone H3 modifications specifies localization of ATRX to heterochromatin."
+          }
+        },
+        {
+          "pmid": "21614001",
+          "pubmed": {
+            "ISODate": "2011-05-25T00:00:00.000Z",
+            "abstract": "Autism spectrum disorder (ASD) is a common, highly heritable neurodevelopmental condition characterized by marked genetic heterogeneity. Thus, a fundamental question is whether autism represents an aetiologically heterogeneous disorder in which the myriad genetic or environmental risk factors perturb common underlying molecular pathways in the brain. Here, we demonstrate consistent differences in transcriptome organization between autistic and normal brain by gene co-expression network analysis. Remarkably, regional patterns of gene expression that typically distinguish frontal and temporal cortex are significantly attenuated in the ASD brain, suggesting abnormalities in cortical patterning. We further identify discrete modules of co-expressed genes associated with autism: a neuronal module enriched for known autism susceptibility genes, including the neuronal specific splicing factor A2BP1 (also known as FOX1), and a module enriched for immune genes and glial markers. Using high-throughput RNA sequencing we demonstrate dysregulated splicing of A2BP1-dependent alternative exons in the ASD brain. Moreover, using a published autism genome-wide association study (GWAS) data set, we show that the neuronal module is enriched for genetically associated variants, providing independent support for the causal involvement of these genes in autism. In contrast, the immune-glial module showed no enrichment for autism GWAS signals, indicating a non-genetic aetiology for this process. Collectively, our results provide strong evidence for convergent molecular abnormalities in ASD, and implicate transcriptional and splicing dysregulation as underlying mechanisms of neuronal dysfunction in this disorder.",
+            "authors": {
+              "abbreviation": "Irina Voineagu, Xinchen Wang, Patrick Johnston, ..., Daniel H Geschwind",
+              "authorList": [
+                {
+                  "ForeName": "Irina",
+                  "LastName": "Voineagu",
+                  "abbrevName": "Voineagu I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Irina Voineagu"
+                },
+                {
+                  "ForeName": "Xinchen",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang X",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Xinchen Wang"
+                },
+                {
+                  "ForeName": "Patrick",
+                  "LastName": "Johnston",
+                  "abbrevName": "Johnston P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Patrick Johnston"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Lowe",
+                  "abbrevName": "Lowe JK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer K Lowe"
+                },
+                {
+                  "ForeName": "Yuan",
+                  "LastName": "Tian",
+                  "abbrevName": "Tian Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yuan Tian"
+                },
+                {
+                  "ForeName": "Steve",
+                  "LastName": "Horvath",
+                  "abbrevName": "Horvath S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Steve Horvath"
+                },
+                {
+                  "ForeName": "Jonathan",
+                  "LastName": "Mill",
+                  "abbrevName": "Mill J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jonathan Mill"
+                },
+                {
+                  "ForeName": "Rita",
+                  "LastName": "Cantor",
+                  "abbrevName": "Cantor RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rita M Cantor"
+                },
+                {
+                  "ForeName": "Benjamin",
+                  "LastName": "Blencowe",
+                  "abbrevName": "Blencowe BJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Benjamin J Blencowe"
+                },
+                {
+                  "ForeName": "Daniel",
+                  "LastName": "Geschwind",
+                  "abbrevName": "Geschwind DH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniel H Geschwind"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nature10110",
+            "pmid": "21614001",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nature 474 2011",
+            "title": "Transcriptomic analysis of autistic brain reveals convergent molecular pathology."
+          }
+        },
+        {
+          "pmid": "21530550",
+          "pubmed": {
+            "ISODate": "2012-03-01T00:00:00.000Z",
+            "abstract": "We describe a touchscreen method that satisfies a proposed 'wish-list' of desirables for a cognitive testing method for assessing rodent models of schizophrenia. A number of tests relevant to schizophrenia research are described which are currently being developed and validated using this method. These tests can be used to study reward learning, memory, perceptual discrimination, object-place associative learning, attention, impulsivity, compulsivity, extinction, simple Pavlovian conditioning, and other constructs. The tests can be deployed using a 'flexible battery' approach to establish a cognitive profile for a particular mouse or rat model. We have found these tests to be capable of detecting not just impairments in function, but enhancements as well, which is essential for testing putative cognitive therapies. New tests are being continuously developed, many of which may prove particularly valuable for schizophrenia research.",
+            "authors": {
+              "abbreviation": "T J Bussey, A Holmes, L Lyon, ..., L M Saksida",
+              "authorList": [
+                {
+                  "ForeName": "T",
+                  "LastName": "Bussey",
+                  "abbrevName": "Bussey TJ",
+                  "email": "tjb1000@cam.ac.uk",
+                  "isCollectiveName": false,
+                  "name": "T J Bussey"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Holmes",
+                  "abbrevName": "Holmes A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A Holmes"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Lyon",
+                  "abbrevName": "Lyon L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Lyon"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Mar",
+                  "abbrevName": "Mar AC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A C Mar"
+                },
+                {
+                  "ForeName": "K",
+                  "LastName": "McAllister",
+                  "abbrevName": "McAllister KA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "K A L McAllister"
+                },
+                {
+                  "ForeName": "J",
+                  "LastName": "Nithianantharajah",
+                  "abbrevName": "Nithianantharajah J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J Nithianantharajah"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Oomen",
+                  "abbrevName": "Oomen CA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "C A Oomen"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Saksida",
+                  "abbrevName": "Saksida LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L M Saksida"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "T",
+                  "LastName": "Bussey",
+                  "email": [
+                    "tjb1000@cam.ac.uk"
+                  ],
+                  "name": "T J Bussey"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuropharm.2011.04.011",
+            "pmid": "21530550",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052060",
+                "value": "Research Support, N.I.H., Intramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D016454",
+                "value": "Review"
+              }
+            ],
+            "reference": "Neuropharmacology 62 2012",
+            "title": "New translational assays for preclinical modelling of cognition in schizophrenia: the touchscreen testing method for mice and rats."
+          }
+        },
+        {
+          "pmid": "21373993",
+          "pubmed": {
+            "ISODate": "2011-12-01T00:00:00.000Z",
+            "abstract": "We introduce Atropos, an ITK-based multivariate n-class open source segmentation algorithm distributed with ANTs ( http://www.picsl.upenn.edu/ANTs). The Bayesian formulation of the segmentation problem is solved using the Expectation Maximization (EM) algorithm with the modeling of the class intensities based on either parametric or non-parametric finite mixtures. Atropos is capable of incorporating spatial prior probability maps (sparse), prior label maps and/or Markov Random Field (MRF) modeling. Atropos has also been efficiently implemented to handle large quantities of possible labelings (in the experimental section, we use up to 69 classes) with a minimal memory footprint. This work describes the technical and implementation aspects of Atropos and evaluates its performance on two different ground-truth datasets. First, we use the BrainWeb dataset from Montreal Neurological Institute to evaluate three-tissue segmentation performance via (1) K-means segmentation without use of template data; (2) MRF segmentation with initialization by prior probability maps derived from a group template; (3) Prior-based segmentation with use of spatial prior probability maps derived from a group template. We also evaluate Atropos performance by using spatial priors to drive a 69-class EM segmentation problem derived from the Hammers atlas from University College London. These evaluation studies, combined with illustrative examples that exercise Atropos options, demonstrate both performance and wide applicability of this new platform-independent open source segmentation tool.",
+            "authors": {
+              "abbreviation": "Brian B Avants, Nicholas J Tustison, Jue Wu, ..., James C Gee",
+              "authorList": [
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Avants",
+                  "abbrevName": "Avants BB",
+                  "email": "stnava@gmail.com",
+                  "isCollectiveName": false,
+                  "name": "Brian B Avants"
+                },
+                {
+                  "ForeName": "Nicholas",
+                  "LastName": "Tustison",
+                  "abbrevName": "Tustison NJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicholas J Tustison"
+                },
+                {
+                  "ForeName": "Jue",
+                  "LastName": "Wu",
+                  "abbrevName": "Wu J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jue Wu"
+                },
+                {
+                  "ForeName": "Philip",
+                  "LastName": "Cook",
+                  "abbrevName": "Cook PA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Philip A Cook"
+                },
+                {
+                  "ForeName": "James",
+                  "LastName": "Gee",
+                  "abbrevName": "Gee JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "James C Gee"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Avants",
+                  "email": [
+                    "stnava@gmail.com"
+                  ],
+                  "name": "Brian B Avants"
+                }
+              ]
+            },
+            "doi": "10.1007/s12021-011-9109-y",
+            "pmid": "21373993",
+            "pubTypes": [
+              {
+                "UI": "D023362",
+                "value": "Evaluation Study"
+              },
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "Neuroinformatics 9 2011",
+            "title": "An open source multivariate framework for n-tissue segmentation with evaluation on public data."
+          }
+        },
+        {
+          "pmid": "21209221",
+          "pubmed": {
+            "ISODate": "2011-01-05T00:00:00.000Z",
+            "abstract": "In humans, mutations in the gene encoding ATRX, a chromatin remodeling protein of the sucrose-nonfermenting 2 family, cause several mental retardation disorders, including α-thalassemia X-linked mental retardation syndrome. We generated ATRX mutant mice lacking exon 2 (ATRX(ΔE2) mice), a mutation that mimics exon 2 mutations seen in human patients and associated with milder forms of retardation. ATRX(ΔE2) mice exhibited abnormal dendritic spine formation in the medial prefrontal cortex (mPFC). Consistent with other mouse models of mental retardation, ATRX(ΔE2) mice exhibited longer and thinner dendritic spines compared with wild-type mice without changes in spine number. Interestingly, aberrant increased calcium/calmodulin-dependent protein kinase II (CaMKII) activity was observed in the mPFC of ATRX(ΔE2) mice. Increased CaMKII autophosphorylation and activity were associated with increased phosphorylation of the Rac1-guanine nucleotide exchange factors (GEFs) T-cell lymphoma invasion and metastasis 1 (Tiam1) and kalirin-7, known substrates of CaMKII. We confirmed increased phosphorylation of p21-activated kinases (PAKs) in mPFC extracts. Furthermore, reduced protein expression and activity of protein phosphatase 1 (PP1) was evident in the mPFC of ATRX(ΔE2) mice. In cultured cortical neurons, PP1 inhibition by okadaic acid increased CaMKII-dependent Tiam1 and kalirin-7 phosphorylation. Together, our data strongly suggest that aberrant CaMKII activation likely mediates abnormal spine formation in the mPFC. Such morphological changes plus elevated Rac1-GEF/PAK signaling seen in ATRX(ΔE2) mice may contribute to mental retardation syndromes seen in human patients.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Hideyuki Beppu, Takaichi Fukuda, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takaichi",
+                  "LastName": "Fukuda",
+                  "abbrevName": "Fukuda T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takaichi Fukuda"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1523/JNEUROSCI.4816-10.2011",
+            "pmid": "21209221",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Neurosci 31 2011",
+            "title": "Aberrant calcium/calmodulin-dependent protein kinase II (CaMKII) activity is associated with abnormal dendritic spine morphology in the ATRX mutant mouse brain."
+          }
+        },
+        {
+          "pmid": "21029860",
+          "pubmed": {
+            "ISODate": "2010-10-29T00:00:00.000Z",
+            "abstract": "ATRX is an X-linked gene of the SWI/SNF family, mutations in which cause syndromal mental retardation and downregulation of α-globin expression. Here we show that ATRX binds to tandem repeat (TR) sequences in both telomeres and euchromatin. Genes associated with these TRs can be dysregulated when ATRX is mutated, and the change in expression is determined by the size of the TR, producing skewed allelic expression. This reveals the characteristics of the affected genes, explains the variable phenotypes seen with identical ATRX mutations, and illustrates a new mechanism underlying variable penetrance. Many of the TRs are G rich and predicted to form non-B DNA structures (including G-quadruplex) in vivo. We show that ATRX binds G-quadruplex structures in vitro, suggesting a mechanism by which ATRX may play a role in various nuclear processes and how this is perturbed when ATRX is mutated.",
+            "authors": {
+              "abbreviation": "Martin J Law, Karen M Lower, Hsiao P J Voon, ..., Richard J Gibbons",
+              "authorList": [
+                {
+                  "ForeName": "Martin",
+                  "LastName": "Law",
+                  "abbrevName": "Law MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Martin J Law"
+                },
+                {
+                  "ForeName": "Karen",
+                  "LastName": "Lower",
+                  "abbrevName": "Lower KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Karen M Lower"
+                },
+                {
+                  "ForeName": "Hsiao",
+                  "LastName": "Voon",
+                  "abbrevName": "Voon HP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hsiao P J Voon"
+                },
+                {
+                  "ForeName": "Jim",
+                  "LastName": "Hughes",
+                  "abbrevName": "Hughes JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jim R Hughes"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Garrick",
+                  "abbrevName": "Garrick D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Garrick"
+                },
+                {
+                  "ForeName": "Vip",
+                  "LastName": "Viprakasit",
+                  "abbrevName": "Viprakasit V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vip Viprakasit"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Mitson",
+                  "abbrevName": "Mitson M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Mitson"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "De Gobbi",
+                  "abbrevName": "De Gobbi M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco De Gobbi"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Marra",
+                  "abbrevName": "Marra M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco Marra"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "Morris",
+                  "abbrevName": "Morris A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew Morris"
+                },
+                {
+                  "ForeName": "Aaron",
+                  "LastName": "Abbott",
+                  "abbrevName": "Abbott A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Aaron Abbott"
+                },
+                {
+                  "ForeName": "Steven",
+                  "LastName": "Wilder",
+                  "abbrevName": "Wilder SP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Steven P Wilder"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Taylor",
+                  "abbrevName": "Taylor S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen Taylor"
+                },
+                {
+                  "ForeName": "Guilherme",
+                  "LastName": "Santos",
+                  "abbrevName": "Santos GM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Guilherme M Santos"
+                },
+                {
+                  "ForeName": "Joe",
+                  "LastName": "Cross",
+                  "abbrevName": "Cross J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Joe Cross"
+                },
+                {
+                  "ForeName": "Helena",
+                  "LastName": "Ayyub",
+                  "abbrevName": "Ayyub H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Helena Ayyub"
+                },
+                {
+                  "ForeName": "Steven",
+                  "LastName": "Jones",
+                  "abbrevName": "Jones S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Steven Jones"
+                },
+                {
+                  "ForeName": "Jiannis",
+                  "LastName": "Ragoussis",
+                  "abbrevName": "Ragoussis J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jiannis Ragoussis"
+                },
+                {
+                  "ForeName": "Daniela",
+                  "LastName": "Rhodes",
+                  "abbrevName": "Rhodes D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Daniela Rhodes"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Dunham",
+                  "abbrevName": "Dunham I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ian Dunham"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas R Higgs"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.cell.2010.09.023",
+            "pmid": "21029860",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell 143 2010",
+            "title": "ATR-X syndrome protein targets tandem repeats and influences allele-specific expression in a size-dependent manner."
+          }
+        },
+        {
+          "pmid": "20651253",
+          "pubmed": {
+            "ISODate": "2010-08-10T00:00:00.000Z",
+            "abstract": "The histone variant H3.3 is implicated in the formation and maintenance of specialized chromatin structure in metazoan cells. H3.3-containing nucleosomes are assembled in a replication-independent manner by means of dedicated chaperone proteins. We previously identified the death domain associated protein (Daxx) and the alpha-thalassemia X-linked mental retardation protein (ATRX) as H3.3-associated proteins. Here, we report that the highly conserved N terminus of Daxx interacts directly with variant-specific residues in the H3.3 core. Recombinant Daxx assembles H3.3/H4 tetramers on DNA templates, and the ATRX-Daxx complex catalyzes the deposition and remodeling of H3.3-containing nucleosomes. We find that the ATRX-Daxx complex is bound to telomeric chromatin, and that both components of this complex are required for H3.3 deposition at telomeres in murine embryonic stem cells (ESCs). These data demonstrate that Daxx functions as an H3.3-specific chaperone and facilitates the deposition of H3.3 at heterochromatin loci in the context of the ATRX-Daxx complex.",
+            "authors": {
+              "abbreviation": "Peter W Lewis, Simon J Elsaesser, Kyung-Min Noh, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Simon",
+                  "LastName": "Elsaesser",
+                  "abbrevName": "Elsaesser SJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Simon J Elsaesser"
+                },
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Sonja",
+                  "LastName": "Stadler",
+                  "abbrevName": "Stadler SC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sonja C Stadler"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1073/pnas.1008850107",
+            "pmid": "20651253",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 107 2010",
+            "title": "Daxx is an H3.3-specific histone chaperone and cooperates with ATRX in replication-independent chromatin assembly at telomeres."
+          }
+        },
+        {
+          "pmid": "20211137",
+          "pubmed": {
+            "ISODate": "2010-03-05T00:00:00.000Z",
+            "abstract": "The incorporation of histone H3 variants has been implicated in the epigenetic memory of cellular state. Using genome editing with zinc-finger nucleases to tag endogenous H3.3, we report genome-wide profiles of H3 variants in mammalian embryonic stem cells and neuronal precursor cells. Genome-wide patterns of H3.3 are dependent on amino acid sequence and change with cellular differentiation at developmentally regulated loci. The H3.3 chaperone Hira is required for H3.3 enrichment at active and repressed genes. Strikingly, Hira is not essential for localization of H3.3 at telomeres and many transcription factor binding sites. Immunoaffinity purification and mass spectrometry reveal that the proteins Atrx and Daxx associate with H3.3 in a Hira-independent manner. Atrx is required for Hira-independent localization of H3.3 at telomeres and for the repression of telomeric RNA. Our data demonstrate that multiple and distinct factors are responsible for H3.3 localization at specific genomic locations in mammalian cells.",
+            "authors": {
+              "abbreviation": "Aaron D Goldberg, Laura A Banaszynski, Kyung-Min Noh, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Aaron",
+                  "LastName": "Goldberg",
+                  "abbrevName": "Goldberg AD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Aaron D Goldberg"
+                },
+                {
+                  "ForeName": "Laura",
+                  "LastName": "Banaszynski",
+                  "abbrevName": "Banaszynski LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Laura A Banaszynski"
+                },
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Simon",
+                  "LastName": "Elsaesser",
+                  "abbrevName": "Elsaesser SJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Simon J Elsaesser"
+                },
+                {
+                  "ForeName": "Sonja",
+                  "LastName": "Stadler",
+                  "abbrevName": "Stadler S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sonja Stadler"
+                },
+                {
+                  "ForeName": "Scott",
+                  "LastName": "Dewell",
+                  "abbrevName": "Dewell S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Scott Dewell"
+                },
+                {
+                  "ForeName": "Martin",
+                  "LastName": "Law",
+                  "abbrevName": "Law M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Martin Law"
+                },
+                {
+                  "ForeName": "Xingyi",
+                  "LastName": "Guo",
+                  "abbrevName": "Guo X",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Xingyi Guo"
+                },
+                {
+                  "ForeName": "Xuan",
+                  "LastName": "Li",
+                  "abbrevName": "Li X",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Xuan Li"
+                },
+                {
+                  "ForeName": "Duancheng",
+                  "LastName": "Wen",
+                  "abbrevName": "Wen D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Duancheng Wen"
+                },
+                {
+                  "ForeName": "Ariane",
+                  "LastName": "Chapgier",
+                  "abbrevName": "Chapgier A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ariane Chapgier"
+                },
+                {
+                  "ForeName": "Russell",
+                  "LastName": "DeKelver",
+                  "abbrevName": "DeKelver RC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Russell C DeKelver"
+                },
+                {
+                  "ForeName": "Jeffrey",
+                  "LastName": "Miller",
+                  "abbrevName": "Miller JC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jeffrey C Miller"
+                },
+                {
+                  "ForeName": "Ya-Li",
+                  "LastName": "Lee",
+                  "abbrevName": "Lee YL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ya-Li Lee"
+                },
+                {
+                  "ForeName": "Elizabeth",
+                  "LastName": "Boydston",
+                  "abbrevName": "Boydston EA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Elizabeth A Boydston"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Holmes",
+                  "abbrevName": "Holmes MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael C Holmes"
+                },
+                {
+                  "ForeName": "Philip",
+                  "LastName": "Gregory",
+                  "abbrevName": "Gregory PD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Philip D Gregory"
+                },
+                {
+                  "ForeName": "John",
+                  "LastName": "Greally",
+                  "abbrevName": "Greally JM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "John M Greally"
+                },
+                {
+                  "ForeName": "Shahin",
+                  "LastName": "Rafii",
+                  "abbrevName": "Rafii S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shahin Rafii"
+                },
+                {
+                  "ForeName": "Chingwen",
+                  "LastName": "Yang",
+                  "abbrevName": "Yang C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chingwen Yang"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Scambler",
+                  "abbrevName": "Scambler PJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter J Scambler"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Garrick",
+                  "abbrevName": "Garrick D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Garrick"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas R Higgs"
+                },
+                {
+                  "ForeName": "Ileana",
+                  "LastName": "Cristea",
+                  "abbrevName": "Cristea IM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ileana M Cristea"
+                },
+                {
+                  "ForeName": "Fyodor",
+                  "LastName": "Urnov",
+                  "abbrevName": "Urnov FD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Fyodor D Urnov"
+                },
+                {
+                  "ForeName": "Deyou",
+                  "LastName": "Zheng",
+                  "abbrevName": "Zheng D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Deyou Zheng"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.cell.2010.01.003",
+            "pmid": "20211137",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell 140 2010",
+            "title": "Distinct factors control histone variant H3.3 localization at specific genomic regions."
+          }
+        },
+        {
+          "pmid": "20159591",
+          "pubmed": {
+            "ISODate": "2010-02-16T00:00:00.000Z",
+            "abstract": "Human developmental disorders caused by chromatin dysfunction often display overlapping clinical manifestations, such as cognitive deficits, but the underlying molecular links are poorly defined. Here, we show that ATRX, MeCP2, and cohesin, chromatin regulators implicated in ATR-X, RTT, and CdLS syndromes, respectively, interact in the brain and colocalize at the H19 imprinting control region (ICR) with preferential binding on the maternal allele. Importantly, we show that ATRX loss of function alters enrichment of cohesin, CTCF, and histone modifications at the H19 ICR, without affecting DNA methylation on the paternal allele. ATRX also affects cohesin, CTCF, and MeCP2 occupancy within the Gtl2/Dlk1 imprinted domain. Finally, we show that loss of ATRX interferes with the postnatal silencing of the maternal H19 gene along with a larger network of imprinted genes. We propose that ATRX, cohesin, and MeCP2 cooperate to silence a subset of imprinted genes in the postnatal mouse brain.",
+            "authors": {
+              "abbreviation": "Kristin D Kernohan, Yan Jiang, Deanna C Tremblay, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Kristin",
+                  "LastName": "Kernohan",
+                  "abbrevName": "Kernohan KD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristin D Kernohan"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Deanna",
+                  "LastName": "Tremblay",
+                  "abbrevName": "Tremblay DC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Deanna C Tremblay"
+                },
+                {
+                  "ForeName": "Anne",
+                  "LastName": "Bonvissuto",
+                  "abbrevName": "Bonvissuto AC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anne C Bonvissuto"
+                },
+                {
+                  "ForeName": "James",
+                  "LastName": "Eubanks",
+                  "abbrevName": "Eubanks JH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "James H Eubanks"
+                },
+                {
+                  "ForeName": "Mellissa",
+                  "LastName": "Mann",
+                  "abbrevName": "Mann MR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Mellissa R W Mann"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.devcel.2009.12.017",
+            "pmid": "20159591",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dev Cell 18 2010",
+            "title": "ATRX partners with cohesin and MeCP2 and contributes to developmental silencing of imprinted genes in the brain."
+          }
+        },
+        {
+          "pmid": "19505943",
+          "pubmed": {
+            "ISODate": "2009-08-15T00:00:00.000Z",
+            "abstract": "SUMMARY: The Sequence Alignment/Map (SAM) format is a generic alignment format for storing read alignments against reference sequences, supporting short and long reads (up to 128 Mbp) produced by different sequencing platforms. It is flexible in style, compact in size, efficient in random access and is the format in which alignments from the 1000 Genomes Project are released. SAMtools implements various utilities for post-processing alignments in the SAM format, such as indexing, variant caller and alignment viewer, and thus provides universal tools for processing read alignments. AVAILABILITY: http://samtools.sourceforge.net.",
+            "authors": {
+              "abbreviation": "Heng Li, Bob Handsaker, Alec Wysoker, ..., 1000 Genome Project Data Processing Subgroup",
+              "authorList": [
+                {
+                  "ForeName": "Heng",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Heng Li"
+                },
+                {
+                  "ForeName": "Bob",
+                  "LastName": "Handsaker",
+                  "abbrevName": "Handsaker B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bob Handsaker"
+                },
+                {
+                  "ForeName": "Alec",
+                  "LastName": "Wysoker",
+                  "abbrevName": "Wysoker A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alec Wysoker"
+                },
+                {
+                  "ForeName": "Tim",
+                  "LastName": "Fennell",
+                  "abbrevName": "Fennell T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tim Fennell"
+                },
+                {
+                  "ForeName": "Jue",
+                  "LastName": "Ruan",
+                  "abbrevName": "Ruan J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jue Ruan"
+                },
+                {
+                  "ForeName": "Nils",
+                  "LastName": "Homer",
+                  "abbrevName": "Homer N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nils Homer"
+                },
+                {
+                  "ForeName": "Gabor",
+                  "LastName": "Marth",
+                  "abbrevName": "Marth G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Gabor Marth"
+                },
+                {
+                  "ForeName": "Goncalo",
+                  "LastName": "Abecasis",
+                  "abbrevName": "Abecasis G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Goncalo Abecasis"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Durbin",
+                  "abbrevName": "Durbin R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard Durbin"
+                },
+                {
+                  "ForeName": null,
+                  "LastName": null,
+                  "abbrevName": "1000 Genome Project Data Processing Subgroup",
+                  "email": null,
+                  "isCollectiveName": true,
+                  "name": "1000 Genome Project Data Processing Subgroup"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/bioinformatics/btp352",
+            "pmid": "19505943",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Bioinformatics 25 2009",
+            "title": "The Sequence Alignment/Map format and SAMtools."
+          }
+        },
+        {
+          "pmid": "19357840",
+          "pubmed": {
+            "ISODate": "2009-07-01T00:00:00.000Z",
+            "abstract": "RATIONALE: Paired-associate learning (PAL), as part of the Cambridge Neuropsychological Test Automated Battery, is able to predict who from an at-risk population will develop Alzheimer's disease. Schizophrenic patients are also impaired on this same task. An automated rodent model of PAL would be extremely beneficial in further research into Alzheimer's disease and schizophrenia. OBJECTIVE: The objective of this study was to develop a PAL task using touchscreen-equipped operant boxes and test its sensitivity to manipulations of the hippocampus, a brain region of interest in both Alzheimer's disease and schizophrenia. MATERIALS AND METHODS: Previous work has shown that spatial and non-spatial memory can be tested in touchscreen-equipped operant boxes. Using this same apparatus, rats were trained on two variants of a PAL task differing only in the nature of the S- (the unrewarded stimuli, a combination of image and location upon the screen). Rats underwent cannulation of the dorsal hippocampus, and after recovery were tested under the influence of intra-hippocampally administered glutamatergic and cholinergic antagonists while performing the PAL task. RESULTS: Impairments were seen after the administration of glutamatergic antagonists, but not cholinergic antagonists, in one of the two versions of PAL. CONCLUSIONS: De-activation of the hippocampus caused impairments in a PAL task. The selective nature of this effect (only one of the two tasks was impaired), suggests the effect is specific to cognition and cannot be attributed to gross impairments (changes in visual learning). The pattern of results suggests that rodent PAL may be suitable as a translational model of PAL in humans.",
+            "authors": {
+              "abbreviation": "J C Talpos, B D Winters, R Dias, ..., T J Bussey",
+              "authorList": [
+                {
+                  "ForeName": "J",
+                  "LastName": "Talpos",
+                  "abbrevName": "Talpos JC",
+                  "email": "j.talpos.01@cantab.net",
+                  "isCollectiveName": false,
+                  "name": "J C Talpos"
+                },
+                {
+                  "ForeName": "B",
+                  "LastName": "Winters",
+                  "abbrevName": "Winters BD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "B D Winters"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Dias",
+                  "abbrevName": "Dias R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Dias"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Saksida",
+                  "abbrevName": "Saksida LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L M Saksida"
+                },
+                {
+                  "ForeName": "T",
+                  "LastName": "Bussey",
+                  "abbrevName": "Bussey TJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "T J Bussey"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "J",
+                  "LastName": "Talpos",
+                  "email": [
+                    "j.talpos.01@cantab.net"
+                  ],
+                  "name": "J C Talpos"
+                }
+              ]
+            },
+            "doi": "10.1007/s00213-009-1526-3",
+            "pmid": "19357840",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Psychopharmacology (Berl) 205 2009",
+            "title": "A novel touchscreen-automated paired-associate learning (PAL) task sensitive to pharmacological manipulation of the hippocampus: a translational rodent model of cognitive impairments in neurodegenerative disease."
+          }
+        },
+        {
+          "pmid": "19218885",
+          "pubmed": {
+            "ISODate": "2009-06-01T00:00:00.000Z",
+            "abstract": "This article reviews the results of 43 studies published since 1966 that provided estimates for the prevalence of pervasive developmental disorders (PDDs), including autistic disorder, Asperger disorder, PDD not otherwise specified, and childhood disintegrative disorder. The prevalence of autistic disorder has increased in recent surveys and current estimates of prevalence are around 20/10,000, whereas the prevalence for PDD not otherwise specified is around 30/10,000 in recent surveys. Prevalence of Asperger disorder is much lower than that for autistic disorder and childhood disintegrative disorder is a very rare disorder with a prevalence of about 2/100,000. Combined all together, recent studies that have examined the whole spectrum of PDDs have consistently provided estimates in the 60-70/10,000 range, making PDD one of the most frequent childhood neurodevelopmental disorders. The meaning of the increase in prevalence in recent decades is reviewed. There is evidence that the broadening of the concept, the expansion of diagnostic criteria, the development of services, and improved awareness of the condition have played a major role in explaining this increase, although it cannot be ruled out that other factors might have also contributed to that trend.",
+            "authors": {
+              "abbreviation": "Eric Fombonne",
+              "authorList": [
+                {
+                  "ForeName": "Eric",
+                  "LastName": "Fombonne",
+                  "abbrevName": "Fombonne E",
+                  "email": "eric.fombonne@mcgill.ca",
+                  "isCollectiveName": false,
+                  "name": "Eric Fombonne"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Eric",
+                  "LastName": "Fombonne",
+                  "email": [
+                    "eric.fombonne@mcgill.ca"
+                  ],
+                  "name": "Eric Fombonne"
+                }
+              ]
+            },
+            "doi": "10.1203/PDR.0b013e31819e7203",
+            "pmid": "19218885",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D016454",
+                "value": "Review"
+              }
+            ],
+            "reference": "Pediatr Res 65 2009",
+            "title": "Epidemiology of pervasive developmental disorders."
+          }
+        },
+        {
+          "pmid": "19020049",
+          "pubmed": {
+            "ISODate": "2008-11-19T00:00:00.000Z",
+            "abstract": "ATRX, a chromatin remodeling protein of the Snf2 family, participates in diverse cellular functions including regulation of gene expression and chromosome alignment during mitosis and meiosis. Mutations in the human gene cause alpha thalassemia mental retardation, X-linked (ATR-X) syndrome, a rare disorder characterized by severe cognitive deficits, microcephaly and epileptic seizures. Conditional inactivation of the Atrx gene in the mouse forebrain leads to neonatal lethality and defective neurogenesis manifested by increased cell death and reduced cellularity in the developing neocortex and hippocampus. Here, we show that Atrx-null forebrains do not generate dentate granule cells due to a reduction in precursor cell number and abnormal migration of differentiating granule cells. In addition, fewer GABA-producing interneurons are generated that migrate from the ventral telencephalon to the cortex and hippocampus. Staining for cleaved caspase 3 demonstrated increased apoptosis in both the hippocampal hem and basal telencephalon concurrent with p53 pathway activation. Elimination of the tumor suppressor protein p53 in double knock-out mice rescued cell death in the embryonic telencephalon but only partially ameliorated the Atrx-null phenotypes at birth. Together, these findings show that ATRX deficiency leads to p53-dependent neuronal apoptosis which is responsible for some but not all of the phenotypic consequences of ATRX deficiency in the forebrain.",
+            "authors": {
+              "abbreviation": "Claudia Seah, Michael A Levy, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Claudia",
+                  "LastName": "Seah",
+                  "abbrevName": "Seah C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Claudia Seah"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Levy",
+                  "abbrevName": "Levy MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael A Levy"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sulayman",
+                  "LastName": "Mokhtarzada",
+                  "abbrevName": "Mokhtarzada S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sulayman Mokhtarzada"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas R Higgs"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1523/JNEUROSCI.4048-08.2008",
+            "pmid": "19020049",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Neurosci 28 2008",
+            "title": "Neuronal death resulting from targeted disruption of the Snf2 protein ATRX is mediated by p53."
+          }
+        },
+        {
+          "pmid": "18778400",
+          "pubmed": {
+            "ISODate": "2009-02-01T00:00:00.000Z",
+            "abstract": "Storage of acetylcholine in synaptic vesicles plays a key role in maintaining cholinergic function. Here we used mice with a targeted mutation in the vesicular acetylcholine transporter (VAChT) gene that reduces transporter expression by 40% to investigate cognitive processing under conditions of VAChT deficiency. Motor skill learning in the rotarod revealed that VAChT mutant mice were slower to learn this task, but once they reached maximum performance they were indistinguishable from wild-type mice. Interestingly, motor skill performance maintenance after 10 days was unaffected in these mutant mice. We also tested whether reduced VAChT levels affected learning in an object recognition memory task. We found that VAChT mutant mice presented a deficit in memory encoding necessary for the temporal order version of the object recognition memory, but showed no alteration in spatial working memory, or spatial memory in general when tested in the Morris water maze test. The memory deficit in object recognition memory observed in VAChT mutant mice could be reversed by cholinesterase inhibitors, suggesting that learning deficits caused by reduced VAChT expression can be ameliorated by restoring ACh levels in the synapse. These data indicate an important role for cholinergic tone in motor learning and object recognition memory.",
+            "authors": {
+              "abbreviation": "B M de Castro, G S Pereira, V Magalhães, ..., M A M Prado",
+              "authorList": [
+                {
+                  "ForeName": "B",
+                  "LastName": "de Castro",
+                  "abbrevName": "de Castro BM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "B M de Castro"
+                },
+                {
+                  "ForeName": "G",
+                  "LastName": "Pereira",
+                  "abbrevName": "Pereira GS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "G S Pereira"
+                },
+                {
+                  "ForeName": "V",
+                  "LastName": "Magalhães",
+                  "abbrevName": "Magalhães V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "V Magalhães"
+                },
+                {
+                  "ForeName": "J",
+                  "LastName": "Rossato",
+                  "abbrevName": "Rossato JI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J I Rossato"
+                },
+                {
+                  "ForeName": "X",
+                  "LastName": "De Jaeger",
+                  "abbrevName": "De Jaeger X",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "X De Jaeger"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Martins-Silva",
+                  "abbrevName": "Martins-Silva C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "C Martins-Silva"
+                },
+                {
+                  "ForeName": "B",
+                  "LastName": "Leles",
+                  "abbrevName": "Leles B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "B Leles"
+                },
+                {
+                  "ForeName": "P",
+                  "LastName": "Lima",
+                  "abbrevName": "Lima P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "P Lima"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Gomez",
+                  "abbrevName": "Gomez MV",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M V Gomez"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Gainetdinov",
+                  "abbrevName": "Gainetdinov RR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R R Gainetdinov"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Caron",
+                  "abbrevName": "Caron MG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M G Caron"
+                },
+                {
+                  "ForeName": "I",
+                  "LastName": "Izquierdo",
+                  "abbrevName": "Izquierdo I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "I Izquierdo"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Cammarota",
+                  "abbrevName": "Cammarota M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Cammarota"
+                },
+                {
+                  "ForeName": "V",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado VF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "V F Prado"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M A M Prado"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1111/j.1601-183X.2008.00439.x",
+            "pmid": "18778400",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Genes Brain Behav 8 2009",
+            "title": "Reduced expression of the vesicular acetylcholine transporter causes learning deficits in mice."
+          }
+        },
+        {
+          "pmid": "18614683",
+          "pubmed": {
+            "ISODate": "2008-07-09T00:00:00.000Z",
+            "abstract": "Methyl-CpG-binding protein 2 (MeCP2) binds methylated DNA and recruits corepressor proteins to modify chromatin and alter gene transcription. Mutations of the MECP2 gene can cause Rett syndrome, whereas subtle reductions of MeCP2 expression may be associated with male-dominated social and neurodevelopmental disorders. We report that transiently decreased amygdala Mecp2 expression during a sensitive period of brain sexual differentiation disrupts the organization of sex differences in juvenile social play behavior. Interestingly, neonatal treatment with Mecp2 small interfering RNA within the developing amygdala reduced juvenile social play behavior in males but not females. Reduced Mecp2 expression did not change juvenile sociability or anxiety-like behavior, suggesting that this disruption is associated with subtle behavioral modification. This suggests that Mecp2 may have an overlooked role in the organization of sexually dimorphic behaviors and that male juvenile behavior is particularly sensitive to Mecp2 disruption during this period of development.",
+            "authors": {
+              "abbreviation": "Joseph R Kurian, Meaghan E Bychowski, Robin M Forbes-Lorman, ..., Anthony P Auger",
+              "authorList": [
+                {
+                  "ForeName": "Joseph",
+                  "LastName": "Kurian",
+                  "abbrevName": "Kurian JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Joseph R Kurian"
+                },
+                {
+                  "ForeName": "Meaghan",
+                  "LastName": "Bychowski",
+                  "abbrevName": "Bychowski ME",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Meaghan E Bychowski"
+                },
+                {
+                  "ForeName": "Robin",
+                  "LastName": "Forbes-Lorman",
+                  "abbrevName": "Forbes-Lorman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Robin M Forbes-Lorman"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Auger",
+                  "abbrevName": "Auger CJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine J Auger"
+                },
+                {
+                  "ForeName": "Anthony",
+                  "LastName": "Auger",
+                  "abbrevName": "Auger AP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Anthony P Auger"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1523/JNEUROSCI.1345-08.2008",
+            "pmid": "18614683",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "J Neurosci 28 2008",
+            "title": "Mecp2 organizes juvenile social behavior in a sex-specific manner."
+          }
+        },
+        {
+          "pmid": "18612068",
+          "pubmed": {
+            "ISODate": "2008-07-01T00:00:00.000Z",
+            "abstract": "The touchscreen testing method for rodents is a computer-automated behavioral testing method that allows computer graphic stimuli to be presented to rodents and the rodents to respond to the computer screen via a nose-poke directly to the stimulus. The advantages of this method are numerous; however, a systematic study of the parameters that affect learning has not yet been conducted. We therefore sought to optimize stimuli and task parameters in this method. We found that when parameters were optimized, Lister Hooded rats could learn rapidly using this method, solving a discrimination of two-dimensional stimuli to a level of 80% within five to six sessions lasting approximately 30 min each. In a final experiment we tested both male and female rats of the albino Sprague-Dawley strain, which are often assumed to have visual abilities far too poor to be useful for studies of visual cognition. The performance of female Sprague-Dawley rats was indistinguishable from that of their male counterparts. Furthermore, performance of male Sprague-Dawley rats was indistinguishable from that of their Lister Hooded counterparts. Finally, Experiment 5 examined the ability of Lister Hooded rats to learn a discrimination between photographic stimuli. Under conditions in which parameters were optimized, rats were remarkably adept at this discrimination. Taken together, these experiments served to optimize the touchscreen method and have demonstrated its usefulness as a high-throughput method for the cognitive testing of rodents.",
+            "authors": {
+              "abbreviation": "Timothy J Bussey, Tina L Padain, Elizabeth A Skillings, ..., Lisa M Saksida",
+              "authorList": [
+                {
+                  "ForeName": "Timothy",
+                  "LastName": "Bussey",
+                  "abbrevName": "Bussey TJ",
+                  "email": "tjb1000@cam.ac.uk",
+                  "isCollectiveName": false,
+                  "name": "Timothy J Bussey"
+                },
+                {
+                  "ForeName": "Tina",
+                  "LastName": "Padain",
+                  "abbrevName": "Padain TL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tina L Padain"
+                },
+                {
+                  "ForeName": "Elizabeth",
+                  "LastName": "Skillings",
+                  "abbrevName": "Skillings EA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Elizabeth A Skillings"
+                },
+                {
+                  "ForeName": "Boyer",
+                  "LastName": "Winters",
+                  "abbrevName": "Winters BD",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Boyer D Winters"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Morton",
+                  "abbrevName": "Morton AJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A Jennifer Morton"
+                },
+                {
+                  "ForeName": "Lisa",
+                  "LastName": "Saksida",
+                  "abbrevName": "Saksida LM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lisa M Saksida"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Timothy",
+                  "LastName": "Bussey",
+                  "email": [
+                    "tjb1000@cam.ac.uk"
+                  ],
+                  "name": "Timothy J Bussey"
+                }
+              ]
+            },
+            "doi": "10.1101/lm.987808",
+            "pmid": "18612068",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Learn Mem 15 2008",
+            "title": "The touchscreen cognitive testing method for rodents: how to get the best out of your rat."
+          }
+        },
+        {
+          "pmid": "18502665",
+          "pubmed": {
+            "ISODate": "2008-08-01T00:00:00.000Z",
+            "abstract": "Detailed anatomical atlases can provide considerable interpretive power in studies of both human and rodent neuroanatomy. Here we describe a three-dimensional atlas of the mouse brain, manually segmented into 62 structures, based on an average of 32 mum isotropic resolution T(2)-weighted, within skull images of forty 12 week old C57Bl/6J mice, scanned on a 7 T scanner. Individual scans were normalized, registered, and averaged into one volume. Structures within the cerebrum, cerebellum, and brainstem were painted on each slice of the average MR image while using simultaneous viewing of the coronal, sagittal and horizontal orientations. The final product, which will be freely available to the research community, provides the most detailed MR-based, three-dimensional neuroanatomical atlas of the whole brain yet created. The atlas is furthermore accompanied by ancillary detailed descriptions of boundaries for each structure and provides high quality neuroanatomical details pertinent to MR studies using mouse models in research.",
+            "authors": {
+              "abbreviation": "A E Dorr, J P Lerch, S Spring, ..., R M Henkelman",
+              "authorList": [
+                {
+                  "ForeName": "A",
+                  "LastName": "Dorr",
+                  "abbrevName": "Dorr AE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A E Dorr"
+                },
+                {
+                  "ForeName": "J",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J P Lerch"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Spring",
+                  "abbrevName": "Spring S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S Spring"
+                },
+                {
+                  "ForeName": "N",
+                  "LastName": "Kabani",
+                  "abbrevName": "Kabani N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "N Kabani"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Henkelman",
+                  "abbrevName": "Henkelman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R M Henkelman"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.neuroimage.2008.03.037",
+            "pmid": "18502665",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Neuroimage 42 2008",
+            "title": "High resolution three-dimensional brain atlas using an average magnetic resonance image of 40 adult C57Bl/6J mice."
+          }
+        },
+        {
+          "pmid": "18434530",
+          "pubmed": {
+            "ISODate": "2008-04-23T00:00:00.000Z",
+            "abstract": "Although X inactivation is thought to balance gene expression between the sexes, some genes escape inactivation, potentially contributing to differences between males and females. Utx (ubiquitously transcribed tetratricopeptide repeat gene on X chromosome) is an escapee gene that encodes a demethylase specific for lysine 27 of histone H3, a mark of repressed chromatin. We found Utx to be expressed higher in females than in males in developing and adult brains and in adult liver. XX mice had a higher level of Utx than XY mice, regardless of whether they had testes or ovaries, indicating that the sexually dimorphic gene expression was a consequence of the sex chromosome complement. Females had significantly higher levels of Utx than males in most brain regions except in the amygdala. The regional expression of the Y-linked paralogue Uty (ubiquitously transcribed tetratricopeptide repeat gene on Y chromosome) was somewhat distinct from that of Utx, specifically in the paraventricular nucleus of the hypothalamus (high Uty) and the amygdala (high Utx), implying that the two paralogues may be differentially regulated. Higher expression of Utx compared with Uty was detected in P19 pluripotent embryonic carcinoma cells as well as in P19-derived neurons. This transcriptional divergence between the two paralogues was associated with high levels of histone H3 lysine 4 dimethylation at the Utx promoter and of histone H4 lysine 16 acetylation throughout the gene body, which suggests that epigenetic mechanisms control differential expression of paralogous genes.",
+            "authors": {
+              "abbreviation": "Jun Xu, Xinxian Deng, Rebecca Watkins, Christine M Disteche",
+              "authorList": [
+                {
+                  "ForeName": "Jun",
+                  "LastName": "Xu",
+                  "abbrevName": "Xu J",
+                  "email": "jun.xu@tufts.edu",
+                  "isCollectiveName": false,
+                  "name": "Jun Xu"
+                },
+                {
+                  "ForeName": "Xinxian",
+                  "LastName": "Deng",
+                  "abbrevName": "Deng X",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Xinxian Deng"
+                },
+                {
+                  "ForeName": "Rebecca",
+                  "LastName": "Watkins",
+                  "abbrevName": "Watkins R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Rebecca Watkins"
+                },
+                {
+                  "ForeName": "Christine",
+                  "LastName": "Disteche",
+                  "abbrevName": "Disteche CM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christine M Disteche"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Jun",
+                  "LastName": "Xu",
+                  "email": [
+                    "jun.xu@tufts.edu"
+                  ],
+                  "name": "Jun Xu"
+                }
+              ]
+            },
+            "doi": "10.1523/JNEUROSCI.5382-07.2008",
+            "pmid": "18434530",
+            "pubTypes": [
+              {
+                "UI": "D003160",
+                "value": "Comparative Study"
+              },
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Neurosci 28 2008",
+            "title": "Sex-specific differences in expression of histone demethylases Utx and Uty in mouse brain and neurons."
+          }
+        },
+        {
+          "pmid": "18409179",
+          "pubmed": {
+            "ISODate": "2008-06-01T00:00:00.000Z",
+            "abstract": "ATRX belongs to the SNF2 family of proteins, many of which have been demonstrated to have chromatin remodeling activity. Constitution mutations in the X-encoded gene give rise to alpha thalassemia mental retardation (ATR-X) syndrome and a variety of related conditions that are often associated with profound developmental delay, facial dysmorphism, genital abnormalities, and alpha thalassemia. Acquired mutations in ATRX are observed in the preleukemic condition alpha thalassemia myelodysplastic syndrome (ATMDS). Mutations in ATRX have been shown to perturb gene expression and DNA methylation. This is a comprehensive report of 127 mutations including 32 reported here for the first time. Missense mutations are shown to cluster in the two main functional domains. The truncating mutations appear to be \"rescued\" to some degree and so it appears likely that most if not all constitutional ATRX mutations are hypomorphs.",
+            "authors": {
+              "abbreviation": "Richard J Gibbons, Takahito Wada, Christopher A Fisher, ..., Joanne Traeger-Synodinos",
+              "authorList": [
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": "richard.gibbons@imm.ox.ac.uk",
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Christopher",
+                  "LastName": "Fisher",
+                  "abbrevName": "Fisher CA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christopher A Fisher"
+                },
+                {
+                  "ForeName": "Nicola",
+                  "LastName": "Malik",
+                  "abbrevName": "Malik N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicola Malik"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Mitson",
+                  "abbrevName": "Mitson MJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew J Mitson"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Steensma",
+                  "abbrevName": "Steensma DP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David P Steensma"
+                },
+                {
+                  "ForeName": "Alan",
+                  "LastName": "Fryer",
+                  "abbrevName": "Fryer A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alan Fryer"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Goudie",
+                  "abbrevName": "Goudie DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David R Goudie"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Krantz",
+                  "abbrevName": "Krantz ID",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ian D Krantz"
+                },
+                {
+                  "ForeName": "Joanne",
+                  "LastName": "Traeger-Synodinos",
+                  "abbrevName": "Traeger-Synodinos J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Joanne Traeger-Synodinos"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "email": [
+                    "richard.gibbons@imm.ox.ac.uk"
+                  ],
+                  "name": "Richard J Gibbons"
+                }
+              ]
+            },
+            "doi": "10.1002/humu.20734",
+            "pmid": "18409179",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              }
+            ],
+            "reference": "Hum Mutat 29 2008",
+            "title": "Mutations in the chromatin-associated protein ATRX."
+          }
+        },
+        {
+          "pmid": "18387826",
+          "pubmed": {
+            "ISODate": "2008-06-01T00:00:00.000Z",
+            "abstract": "A recent study found differences in localised regions of the cortex between the YAC128 mouse model of Huntington's Disease (HD) and wild-type mice. There are, however, few tools to automatically examine shape differences in the cortices of mice. This paper describes an algorithm for automatically measuring cortical thickness across the entire cortex from MRI of fixed mouse brain specimens. An analysis of the variance of the method showed that, on average, a 50 microm (0.05 mm) localised difference in cortical thickness can be measured using MR scans. Applying these methods to 8-month-old YAC128 mouse model mice representing an early stage of HD, we found an increase in cortical thickness in the sensorimotor cortex, and also revealed regions wherein decreasing striatal volume correlated with increasing cortical thickness, indicating a potential compensatory response.",
+            "authors": {
+              "abbreviation": "Jason P Lerch, Jeffrey B Carroll, Adrienne Dorr, ..., R Mark Henkelman",
+              "authorList": [
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": "jason@bic.mni.mcgill.ca",
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Jeffrey",
+                  "LastName": "Carroll",
+                  "abbrevName": "Carroll JB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jeffrey B Carroll"
+                },
+                {
+                  "ForeName": "Adrienne",
+                  "LastName": "Dorr",
+                  "abbrevName": "Dorr A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adrienne Dorr"
+                },
+                {
+                  "ForeName": "Shoshana",
+                  "LastName": "Spring",
+                  "abbrevName": "Spring S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shoshana Spring"
+                },
+                {
+                  "ForeName": "Alan",
+                  "LastName": "Evans",
+                  "abbrevName": "Evans AC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Alan C Evans"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Hayden",
+                  "abbrevName": "Hayden MR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael R Hayden"
+                },
+                {
+                  "ForeName": "John",
+                  "LastName": "Sled",
+                  "abbrevName": "Sled JG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "John G Sled"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Henkelman",
+                  "abbrevName": "Henkelman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Mark Henkelman"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "email": [
+                    "jason@bic.mni.mcgill.ca"
+                  ],
+                  "name": "Jason P Lerch"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuroimage.2008.02.019",
+            "pmid": "18387826",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Neuroimage 41 2008",
+            "title": "Cortical thickness measured from MRI in the YAC128 mouse model of Huntington's disease."
+          }
+        },
+        {
+          "pmid": "18313770",
+          "pubmed": {
+            "ISODate": "2008-06-03T00:00:00.000Z",
+            "abstract": "Subregional analyses of the hippocampus suggest CA1-dependent memory processes rely heavily upon interactions between the CA1 subregion and entorhinal cortex. There is evidence that the direct perforant path (pp) projection to CA1 is selectively modulated by dopamine while having little to no effect on the Schaffer collateral (SC) projection to CA1. The current study takes advantage of this pharmacological dissociation to demonstrate that local infusion of the non-selective dopamine agonist, apomorphine (10, 15 microg), into the CA1 subregion of awake animals produces impairments in working memory at intermediate (5 min), but not short-term (10 s) delays within a delayed non-match-to-place task on a radial arm maze. Sustained impairments were also found in a novel context with similar object-space relationships. Infusion of apomorphine into CA1 is also shown here to produce deficits in spatial, but not non-spatial novelty detection within an object exploration paradigm. In contrast, apomorphine produces no behavioral deficits when infused into the CA3 subregion or overlying cortex. These behavioral studies are supported by previous electrophysiological data that demonstrate local infusion of the same doses of apomorphine significantly modifies evoked responses in the distal dendrites of CA1 following angular bundle stimulation, but produces no significant effects in the proximal dendritic layer following stimulation of the SC. These results support a modulatory role for dopamine in EC-CA1, but not CA3-CA1 circuitry, and suggest the possibility of a fundamental role for EC-CA1 synaptic transmission in terms of detection of spatial novelty, and intermediate-term, but not short-term spatial working memory or object-novelty detection.",
+            "authors": {
+              "abbreviation": "David R Vago, Raymond P Kesner",
+              "authorList": [
+                {
+                  "ForeName": "David",
+                  "LastName": "Vago",
+                  "abbrevName": "Vago DR",
+                  "email": "vago.dave@gmail.com",
+                  "isCollectiveName": false,
+                  "name": "David R Vago"
+                },
+                {
+                  "ForeName": "Raymond",
+                  "LastName": "Kesner",
+                  "abbrevName": "Kesner RP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Raymond P Kesner"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "David",
+                  "LastName": "Vago",
+                  "email": [
+                    "vago.dave@gmail.com"
+                  ],
+                  "name": "David R Vago"
+                }
+              ]
+            },
+            "doi": "10.1016/j.bbr.2008.01.002",
+            "pmid": "18313770",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Behav Brain Res 189 2008",
+            "title": "Disruption of the direct perforant path input to the CA1 subregion of the dorsal hippocampus interferes with spatial working memory and novelty detection."
+          }
+        },
+        {
+          "pmid": "18215625",
+          "pubmed": {
+            "ISODate": "2008-01-24T00:00:00.000Z",
+            "abstract": "Place-specific firing in the hippocampus is determined by path integration-based spatial representations in the grid-cell network of the medial entorhinal cortex. Output from this network is conveyed directly to CA1 of the hippocampus by projections from principal neurons in layer III, but also indirectly by axons from layer II to the dentate gyrus and CA3. The direct pathway is sufficient for spatial firing in CA1, but it is not known whether similar firing can also be supported by the input from CA3. To test this possibility, we made selective lesions in layer III of medial entorhinal cortex by local infusion of the neurotoxin gamma-acetylenic GABA. Firing fields in CA1 became larger and more dispersed after cell loss in layer III, whereas CA3 cells, which receive layer II input, still had sharp firing fields. Thus, the direct projection is necessary for precise spatial firing in the CA1 place cell population.",
+            "authors": {
+              "abbreviation": "Vegard Heimly Brun, Stefan Leutgeb, Hui-Qiu Wu, ..., May-Britt Moser",
+              "authorList": [
+                {
+                  "ForeName": "Vegard",
+                  "LastName": "Brun",
+                  "abbrevName": "Brun VH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vegard Heimly Brun"
+                },
+                {
+                  "ForeName": "Stefan",
+                  "LastName": "Leutgeb",
+                  "abbrevName": "Leutgeb S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stefan Leutgeb"
+                },
+                {
+                  "ForeName": "Hui-Qiu",
+                  "LastName": "Wu",
+                  "abbrevName": "Wu HQ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hui-Qiu Wu"
+                },
+                {
+                  "ForeName": "Robert",
+                  "LastName": "Schwarcz",
+                  "abbrevName": "Schwarcz R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Robert Schwarcz"
+                },
+                {
+                  "ForeName": "Menno",
+                  "LastName": "Witter",
+                  "abbrevName": "Witter MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Menno P Witter"
+                },
+                {
+                  "ForeName": "Edvard",
+                  "LastName": "Moser",
+                  "abbrevName": "Moser EI",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Edvard I Moser"
+                },
+                {
+                  "ForeName": "May-Britt",
+                  "LastName": "Moser",
+                  "abbrevName": "Moser MB",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "May-Britt Moser"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/j.neuron.2007.11.034",
+            "pmid": "18215625",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Neuron 57 2008",
+            "title": "Impaired spatial representation in CA1 after lesion of direct input from entorhinal cortex."
+          }
+        },
+        {
+          "pmid": "17406317",
+          "pubmed": {
+            "ISODate": "2006-01-01T00:00:00.000Z",
+            "abstract": "The Morris water maze (MWM) is a test of spatial learning for rodents that relies on distal cues to navigate from start locations around the perimeter of an open swimming arena to locate a submerged escape platform. Spatial learning is assessed across repeated trials and reference memory is determined by preference for the platform area when the platform is absent. Reversal and shift trials enhance the detection of spatial impairments. Trial-dependent, latent and discrimination learning can be assessed using modifications of the basic protocol. Search-to-platform area determines the degree of reliance on spatial versus non-spatial strategies. Cued trials determine whether performance factors that are unrelated to place learning are present. Escape from water is relatively immune from activity or body mass differences, making it ideal for many experimental models. The MWM has proven to be a robust and reliable test that is strongly correlated with hippocampal synaptic plasticity and NMDA receptor function. We present protocols for performing variants of the MWM test, from which results can be obtained from individual animals in as few as 6 days.",
+            "authors": {
+              "abbreviation": "Charles V Vorhees, Michael T Williams",
+              "authorList": [
+                {
+                  "ForeName": "Charles",
+                  "LastName": "Vorhees",
+                  "abbrevName": "Vorhees CV",
+                  "email": "charles.vorhees@cchmc.org",
+                  "isCollectiveName": false,
+                  "name": "Charles V Vorhees"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Williams",
+                  "abbrevName": "Williams MT",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael T Williams"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Charles",
+                  "LastName": "Vorhees",
+                  "email": [
+                    "charles.vorhees@cchmc.org"
+                  ],
+                  "name": "Charles V Vorhees"
+                }
+              ]
+            },
+            "doi": "10.1038/nprot.2006.116",
+            "pmid": "17406317",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              }
+            ],
+            "reference": "Nat Protoc 1 2006",
+            "title": "Morris water maze: procedures for assessing spatial and related forms of learning and memory."
+          }
+        },
+        {
+          "pmid": "16628246",
+          "pubmed": {
+            "ISODate": "2006-04-01T00:00:00.000Z",
+            "abstract": "ATRX is an X-encoded member of the SNF2 family of ATPase/helicase proteins thought to regulate gene expression by modifying chromatin at target loci. Mutations in ATRX provided the first example of a human genetic disease associated with defects in such proteins. To better understand the role of ATRX in development and the associated abnormalities in the ATR-X (alpha thalassemia mental retardation, X-linked) syndrome, we conditionally inactivated the homolog in mice, Atrx, at the 8- to 16-cell stage of development. The protein, Atrx, was ubiquitously expressed, and male embryos null for Atrx implanted and gastrulated normally but did not survive beyond 9.5 days postcoitus due to a defect in formation of the extraembryonic trophoblast, one of the first terminally differentiated lineages in the developing embryo. Carrier female mice that inherit a maternal null allele should be affected, since the paternal X chromosome is normally inactivated in extraembryonic tissues. Surprisingly, however, some carrier females established a normal placenta and appeared to escape the usual pattern of imprinted X-inactivation in these tissues. Together these findings demonstrate an unexpected, specific, and essential role for Atrx in the development of the murine trophoblast and present an example of escape from imprinted X chromosome inactivation.",
+            "authors": {
+              "abbreviation": "David Garrick, Jackie A Sharpe, Ruth Arkell, ..., Richard J Gibbons",
+              "authorList": [
+                {
+                  "ForeName": "David",
+                  "LastName": "Garrick",
+                  "abbrevName": "Garrick D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Garrick"
+                },
+                {
+                  "ForeName": "Jackie",
+                  "LastName": "Sharpe",
+                  "abbrevName": "Sharpe JA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jackie A Sharpe"
+                },
+                {
+                  "ForeName": "Ruth",
+                  "LastName": "Arkell",
+                  "abbrevName": "Arkell R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ruth Arkell"
+                },
+                {
+                  "ForeName": "Lorraine",
+                  "LastName": "Dobbie",
+                  "abbrevName": "Dobbie L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lorraine Dobbie"
+                },
+                {
+                  "ForeName": "Andrew",
+                  "LastName": "Smith",
+                  "abbrevName": "Smith AJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Andrew J H Smith"
+                },
+                {
+                  "ForeName": "William",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood WG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "William G Wood"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas R Higgs"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1371/journal.pgen.0020058",
+            "pmid": "16628246",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "PLoS Genet 2 2006",
+            "title": "Loss of Atrx affects trophoblast development and the pattern of X-inactivation in extraembryonic tissues."
+          }
+        },
+        {
+          "pmid": "16429444",
+          "pubmed": {
+            "ISODate": "2006-03-01T00:00:00.000Z",
+            "abstract": "We used lipopolysaccharide (LPS) to activate microglia that play an important role in the brain immune system. LPS injected into the rat hippocampus CA1 region activated microglial cells resulting in an increased production of interleukin (IL)-1beta and tumor necrosis factor (TNF)-alpha in the hippocampus during the initial stage of treatment. Immunostaining for IL-1beta was increased at 6 hr after LPS injection. IL-1beta-immunopositive cells were co-localized with immunostaining for CD11b. Subacute treatment with LPS by the same route for 5 days caused long-term activation of microglia and induced learning and memory deficits in animals when examined with a step-through passive avoidance test, but histochemical analysis showed that neuronal cell death was not observed under these experimental conditions. The increased expression of the heme oxygenase-1 (HO-1) gene, an oxidative stress maker, was observed. However, the genetic expression of brain-derived neurotrophic factor (BDNF) and its receptor, TrkB, decreased during the course of LPS treatment. We found decreases in [3H]MK801 binding in the hippocampus CA1 region by LPS-treatment for 5 days. The data shows that glutamatergic transmission was attenuated in the LPS-treated rats. These results suggest that long-term activation of microglia induced by LPS results in a decrease of glutamatergic transmission that leads to learning and memory deficits without neuronal cell death. The physiologic significance of these findings is discussed.",
+            "authors": {
+              "abbreviation": "Sachiko Tanaka, Masatoshi Ide, Toshiomi Shibutani, ..., Takemi Yoshida",
+              "authorList": [
+                {
+                  "ForeName": "Sachiko",
+                  "LastName": "Tanaka",
+                  "abbrevName": "Tanaka S",
+                  "email": "stanaka@pharm.showa-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Sachiko Tanaka"
+                },
+                {
+                  "ForeName": "Masatoshi",
+                  "LastName": "Ide",
+                  "abbrevName": "Ide M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masatoshi Ide"
+                },
+                {
+                  "ForeName": "Toshiomi",
+                  "LastName": "Shibutani",
+                  "abbrevName": "Shibutani T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshiomi Shibutani"
+                },
+                {
+                  "ForeName": "Hirokazu",
+                  "LastName": "Ohtaki",
+                  "abbrevName": "Ohtaki H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hirokazu Ohtaki"
+                },
+                {
+                  "ForeName": "Satoshi",
+                  "LastName": "Numazawa",
+                  "abbrevName": "Numazawa S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Satoshi Numazawa"
+                },
+                {
+                  "ForeName": "Seiji",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Seiji Shioda"
+                },
+                {
+                  "ForeName": "Takemi",
+                  "LastName": "Yoshida",
+                  "abbrevName": "Yoshida T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takemi Yoshida"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Sachiko",
+                  "LastName": "Tanaka",
+                  "email": [
+                    "stanaka@pharm.showa-u.ac.jp"
+                  ],
+                  "name": "Sachiko Tanaka"
+                }
+              ]
+            },
+            "doi": "10.1002/jnr.20752",
+            "pmid": "16429444",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Neurosci Res 83 2006",
+            "title": "Lipopolysaccharide-induced microglial activation induces learning and memory deficits without neuronal cell death in rats."
+          }
+        },
+        {
+          "pmid": "16410543",
+          "pubmed": {
+            "ISODate": "2006-01-12T00:00:00.000Z",
+            "abstract": "Since genetically modified mice have become more common in biomedical research as models of human disease, a need has also grown for efficient and quantitative methods to assess mouse phenotype. One powerful means of phenotyping is characterization of anatomy in mutant vs. normal populations. Anatomical phenotyping requires visualization of structures in situ, quantification of complex shape differences between mouse populations, and detection of subtle or diffuse abnormalities during high-throughput survey work. These aims can be achieved with imaging techniques adapted from clinical radiology, such as magnetic resonance imaging and computed tomography. These imaging technologies provide an excellent nondestructive method for visualization of anatomy in live individuals or specimens. The computer-based analysis of these images then allows thorough anatomical characterizations. We present an automated method for analyzing multiple-image data sets. This method uses image registration to identify corresponding anatomy between control and mutant groups. Within- and between-group shape differences are used to map regions of significantly differing anatomy. These regions are highlighted and represented quantitatively by displacements and volume changes. This methodology is demonstrated for a partially characterized mouse mutation generated by N-ethyl-N-nitrosourea mutagenesis that is a putative model of the human syndrome oculodentodigital dysplasia, caused by point mutations in the gene encoding connexin 43.",
+            "authors": {
+              "abbreviation": "Brian J Nieman, Ann M Flenniken, S Lee Adamson, ..., John G Sled",
+              "authorList": [
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Nieman",
+                  "abbrevName": "Nieman BJ",
+                  "email": "brian.nieman@sw.ca",
+                  "isCollectiveName": false,
+                  "name": "Brian J Nieman"
+                },
+                {
+                  "ForeName": "Ann",
+                  "LastName": "Flenniken",
+                  "abbrevName": "Flenniken AM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ann M Flenniken"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Adamson",
+                  "abbrevName": "Adamson SL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S Lee Adamson"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Henkelman",
+                  "abbrevName": "Henkelman RM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Mark Henkelman"
+                },
+                {
+                  "ForeName": "John",
+                  "LastName": "Sled",
+                  "abbrevName": "Sled JG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "John G Sled"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Brian",
+                  "LastName": "Nieman",
+                  "email": [
+                    "brian.nieman@sw.ca"
+                  ],
+                  "name": "Brian J Nieman"
+                }
+              ]
+            },
+            "doi": "10.1152/physiolgenomics.00217.2005",
+            "pmid": "16410543",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Physiol Genomics 24 2006",
+            "title": "Anatomical phenotyping in the brain and skull of a mutant mouse by magnetic resonance imaging and computed tomography."
+          }
+        },
+        {
+          "pmid": "15668733",
+          "pubmed": {
+            "ISODate": "2005-02-01T00:00:00.000Z",
+            "abstract": "Mutations in genes encoding chromatin-remodeling proteins, such as the ATRX gene, underlie a number of genetic disorders including several X-linked mental retardation syndromes; however, the role of these proteins in normal CNS development is unknown. Here, we used a conditional gene-targeting approach to inactivate Atrx, specifically in the forebrain of mice. Loss of ATRX protein caused widespread hypocellularity in the neocortex and hippocampus and a pronounced reduction in forebrain size. Neuronal \"birthdating\" confirmed that fewer neurons reached the superficial cortical layers, despite normal progenitor cell proliferation. The loss of cortical mass resulted from a 12-fold increase in neuronal apoptosis during early stages of corticogenesis in the mutant animals. Moreover, cortical progenitors isolated from Atrx-null mice undergo enhanced apoptosis upon differentiation. Taken together, our results indicate that ATRX is a critical mediator of cell survival during early neuronal differentiation. Thus, increased neuronal loss may contribute to the severe mental retardation observed in human patients.",
+            "authors": {
+              "abbreviation": "Nathalie G Bérubé, Marie Mangelsdorf, Magdalena Jagla, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Marie",
+                  "LastName": "Mangelsdorf",
+                  "abbrevName": "Mangelsdorf M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marie Mangelsdorf"
+                },
+                {
+                  "ForeName": "Magdalena",
+                  "LastName": "Jagla",
+                  "abbrevName": "Jagla M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Magdalena Jagla"
+                },
+                {
+                  "ForeName": "Jackie",
+                  "LastName": "Vanderluit",
+                  "abbrevName": "Vanderluit J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jackie Vanderluit"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Garrick",
+                  "abbrevName": "Garrick D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David Garrick"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Douglas",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Douglas R Higgs"
+                },
+                {
+                  "ForeName": "Ruth",
+                  "LastName": "Slack",
+                  "abbrevName": "Slack RS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Ruth S Slack"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI22329",
+            "pmid": "15668733",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 115 2005",
+            "title": "The chromatin-remodeling protein ATRX is critical for neuronal survival during corticogenesis."
+          }
+        },
+        {
+          "pmid": "15470431",
+          "pubmed": {
+            "ISODate": "2004-10-07T00:00:00.000Z",
+            "abstract": "A dialogue between the hippocampus and the neocortex is thought to underlie the formation, consolidation and retrieval of episodic memories, although the nature of this cortico-hippocampal communication is poorly understood. Using selective electrolytic lesions in rats, here we examined the role of the direct entorhinal projection (temporoammonic, TA) to the hippocampal area CA1 in short-term (24 hours) and long-term (four weeks) spatial memory in the Morris water maze. When short-term memory was examined, both sham- and TA-lesioned animals showed a significant preference for the target quadrant. When re-tested four weeks later, sham-lesioned animals exhibited long-term memory; in contrast, the TA-lesioned animals no longer showed target quadrant preference. Many long-lasting memories require a process called consolidation, which involves the exchange of information between the cortex and hippocampus. The disruption of long-term memory by the TA lesion could reflect a requirement for TA input during either the acquisition or consolidation of long-term memory. To distinguish between these possibilities, we trained animals, verified their spatial memory 24 hours later, and then subjected trained animals to TA lesions. TA-lesioned animals still exhibited a deficit in long-term memory, indicating a disruption of consolidation. Animals in which the TA lesion was delayed by three weeks, however, showed a significant preference for the target quadrant, indicating that the memory had already been adequately consolidated at the time of the delayed lesion. These results indicate that, after learning, ongoing cortical input conveyed by the TA path is required to consolidate long-term spatial memory.",
+            "authors": {
+              "abbreviation": "Miguel Remondes, Erin M Schuman",
+              "authorList": [
+                {
+                  "ForeName": "Miguel",
+                  "LastName": "Remondes",
+                  "abbrevName": "Remondes M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Miguel Remondes"
+                },
+                {
+                  "ForeName": "Erin",
+                  "LastName": "Schuman",
+                  "abbrevName": "Schuman EM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Erin M Schuman"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/nature02965",
+            "pmid": "15470431",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nature 431 2004",
+            "title": "Role for a cortical input to hippocampal area CA1 in the consolidation of a long-term memory."
+          }
+        },
+        {
+          "pmid": "11906227",
+          "pubmed": {
+            "ISODate": "2002-04-01T00:00:00.000Z",
+            "abstract": "Finding objective and effective thresholds for voxelwise statistics derived from neuroimaging data has been a long-standing problem. With at least one test performed for every voxel in an image, some correction of the thresholds is needed to control the error rates, but standard procedures for multiple hypothesis testing (e.g., Bonferroni) tend to not be sensitive enough to be useful in this context. This paper introduces to the neuroscience literature statistical procedures for controlling the false discovery rate (FDR). Recent theoretical work in statistics suggests that FDR-controlling procedures will be effective for the analysis of neuroimaging data. These procedures operate simultaneously on all voxelwise test statistics to determine which tests should be considered statistically significant. The innovation of the procedures is that they control the expected proportion of the rejected hypotheses that are falsely rejected. We demonstrate this approach using both simulations and functional magnetic resonance imaging data from two simple experiments.",
+            "authors": {
+              "abbreviation": "Christopher R Genovese, Nicole A Lazar, Thomas Nichols",
+              "authorList": [
+                {
+                  "ForeName": "Christopher",
+                  "LastName": "Genovese",
+                  "abbrevName": "Genovese CR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Christopher R Genovese"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Lazar",
+                  "abbrevName": "Lazar NA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole A Lazar"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Nichols",
+                  "abbrevName": "Nichols T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas Nichols"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1006/nimg.2001.1037",
+            "pmid": "11906227",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuroimage 15 2002",
+            "title": "Thresholding of statistical maps in functional neuroimaging using the false discovery rate."
+          }
+        },
+        {
+          "pmid": "11377840",
+          "pubmed": {
+            "ISODate": "2001-01-01T00:00:00.000Z",
+            "abstract": "The extracellular matrix is a complex network of macromolecules including glycoproteins, polysaccharides and proteoglycans. Tenascin-R and chondroitin sulfate proteoglycans are essential components of hippocampal extracellular matrix co-localised in perineuronal nets on interneurons. Mutant mice deficient in expression of tenascin-R showed a two-fold reduction of long-term potentiation induced by theta-burst stimulation of Schaffer collaterals in the stratum radiatum of the CA1 region of the hippocampus, as compared to wild-type mice. The same reduction in potentiation was observed in slices from wild-type mice pretreated for 2h with chondroitinase ABC that completely removed chondroitin sulfates from the extracellular matrix. Treatment of slices from tenascin-R deficient animals with the enzyme did not further reduce potentiation in comparison with untreated slices from these mice, showing an occlusion of effects produced by removal of tenascin-R and chondroitin sulfates. However, the level of potentiation recorded immediately after theta-burst stimulation was significantly higher in wild-type than in tenascin-R deficient mice, whereas chondroitinase ABC had no significant effect on this short-term form of plasticity. Enzymatic treatment also did not affect short-term depression evoked by low-frequency stimulation, whereas this form of synaptic plasticity was reduced in tenascin-R deficient mice. In contrast, long-term depression in CA1 was impaired by digestion of chondroitin sulfates but appeared normal in tenascin-R mutants. Our data demonstrate that tenascin-R and chondroitin sulfate proteoglycans differentially modulate several forms of synaptic plasticity, suggesting that different mechanisms are involved.",
+            "authors": {
+              "abbreviation": "O Bukalo, M Schachner, A Dityatev",
+              "authorList": [
+                {
+                  "ForeName": "O",
+                  "LastName": "Bukalo",
+                  "abbrevName": "Bukalo O",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "O Bukalo"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Schachner",
+                  "abbrevName": "Schachner M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Schachner"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Dityatev",
+                  "abbrevName": "Dityatev A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A Dityatev"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/s0306-4522(01)00082-3",
+            "pmid": "11377840",
+            "pubTypes": [
+              {
+                "UI": "D003160",
+                "value": "Comparative Study"
+              },
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Neuroscience 104 2001",
+            "title": "Modification of extracellular matrix by enzymatic removal of chondroitin sulfate and by lack of tenascin-R differentially affects several forms of synaptic plasticity in the hippocampus."
+          }
+        },
+        {
+          "pmid": "10806096",
+          "pubmed": {
+            "ISODate": "2000-06-01T00:00:00.000Z",
+            "abstract": "Shank proteins make up a new family of scaffold proteins recently identified through their interaction with a variety of membrane and cytoplasmic proteins. Shank polypeptides contain multiple sites for protein-protein interaction, including ankyrin repeats, an SH3 domain, a PDZ domain, a long proline-rich region, and a SAM domain. Binding partners for most of these domains have been identified: for instance, the PDZ domain of Shank proteins interacts with GKAP (a postsynaptic-density protein) as well as several G-protein-coupled receptors. The specific localization of Shank proteins at postsynaptic sites of brain excitatory synapses suggests a role for this family of proteins in the organization of cytoskeletal/ signaling complexes at specialized cell junctions.",
+            "authors": {
+              "abbreviation": "M Sheng, E Kim",
+              "authorList": [
+                {
+                  "ForeName": "M",
+                  "LastName": "Sheng",
+                  "abbrevName": "Sheng M",
+                  "email": "sheng@helix.mgh.harvard.edu",
+                  "isCollectiveName": false,
+                  "name": "M Sheng"
+                },
+                {
+                  "ForeName": "E",
+                  "LastName": "Kim",
+                  "abbrevName": "Kim E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "E Kim"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "M",
+                  "LastName": "Sheng",
+                  "email": [
+                    "sheng@helix.mgh.harvard.edu"
+                  ],
+                  "name": "M Sheng"
+                }
+              ]
+            },
+            "doi": "10.1242/jcs.113.11.1851",
+            "pmid": "10806096",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D016454",
+                "value": "Review"
+              }
+            ],
+            "reference": "J Cell Sci 113 ( Pt 11) 2000",
+            "title": "The Shank family of scaffold proteins."
+          }
+        },
+        {
+          "pmid": "10471508",
+          "pubmed": {
+            "ISODate": "1999-09-01T00:00:00.000Z",
+            "abstract": "The glucocorticoid receptor (Gr, encoded by the gene Grl1) controls transcription of target genes both directly by interaction with DNA regulatory elements and indirectly by cross-talk with other transcription factors. In response to various stimuli, including stress, glucocorticoids coordinate metabolic, endocrine, immune and nervous system responses and ensure an adequate profile of transcription. In the brain, Gr has been proposed to modulate emotional behaviour, cognitive functions and addictive states. Previously, these aspects were not studied in the absence of functional Gr because inactivation of Grl1 in mice causes lethality at birth (F.T., C.K. and G.S., unpublished data). Therefore, we generated tissue-specific mutations of this gene using the Cre/loxP -recombination system. This allowed us to generate viable adult mice with loss of Gr function in selected tissues. Loss of Gr function in the nervous system impairs hypothalamus-pituitary-adrenal (HPA)-axis regulation, resulting in increased glucocorticoid (GC) levels that lead to symptoms reminiscent of those observed in Cushing syndrome. Conditional mutagenesis of Gr in the nervous system provides genetic evidence for the importance of Gr signalling in emotional behaviour because mutant animals show an impaired behavioural response to stress and display reduced anxiety.",
+            "authors": {
+              "abbreviation": "F Tronche, C Kellendonk, O Kretz, ..., G Schütz",
+              "authorList": [
+                {
+                  "ForeName": "F",
+                  "LastName": "Tronche",
+                  "abbrevName": "Tronche F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "F Tronche"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Kellendonk",
+                  "abbrevName": "Kellendonk C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "C Kellendonk"
+                },
+                {
+                  "ForeName": "O",
+                  "LastName": "Kretz",
+                  "abbrevName": "Kretz O",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "O Kretz"
+                },
+                {
+                  "ForeName": "P",
+                  "LastName": "Gass",
+                  "abbrevName": "Gass P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "P Gass"
+                },
+                {
+                  "ForeName": "K",
+                  "LastName": "Anlag",
+                  "abbrevName": "Anlag K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "K Anlag"
+                },
+                {
+                  "ForeName": "P",
+                  "LastName": "Orban",
+                  "abbrevName": "Orban PC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "P C Orban"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Bock",
+                  "abbrevName": "Bock R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Bock"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Klein",
+                  "abbrevName": "Klein R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Klein"
+                },
+                {
+                  "ForeName": "G",
+                  "LastName": "Schütz",
+                  "abbrevName": "Schütz G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "G Schütz"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/12703",
+            "pmid": "10471508",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Genet 23 1999",
+            "title": "Disruption of the glucocorticoid receptor gene in the nervous system results in reduced anxiety."
+          }
+        },
+        {
+          "pmid": "9326931",
+          "pubmed": {
+            "ISODate": "1997-10-01T00:00:00.000Z",
+            "abstract": null,
+            "authors": {
+              "abbreviation": "R J Gibbons, S Bachoo, D J Picketts, ..., D R Higgs",
+              "authorList": [
+                {
+                  "ForeName": "R",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R J Gibbons"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Bachoo",
+                  "abbrevName": "Bachoo S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S Bachoo"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D J Picketts"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Aftimos",
+                  "abbrevName": "Aftimos S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S Aftimos"
+                },
+                {
+                  "ForeName": "B",
+                  "LastName": "Asenbauer",
+                  "abbrevName": "Asenbauer B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "B Asenbauer"
+                },
+                {
+                  "ForeName": "J",
+                  "LastName": "Bergoffen",
+                  "abbrevName": "Bergoffen J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J Bergoffen"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Berry",
+                  "abbrevName": "Berry SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S A Berry"
+                },
+                {
+                  "ForeName": "N",
+                  "LastName": "Dahl",
+                  "abbrevName": "Dahl N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "N Dahl"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Fryer",
+                  "abbrevName": "Fryer A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A Fryer"
+                },
+                {
+                  "ForeName": "K",
+                  "LastName": "Keppler",
+                  "abbrevName": "Keppler K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "K Keppler"
+                },
+                {
+                  "ForeName": "K",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "K Kurosawa"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Levin",
+                  "abbrevName": "Levin ML",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M L Levin"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Masuno",
+                  "abbrevName": "Masuno M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Masuno"
+                },
+                {
+                  "ForeName": "G",
+                  "LastName": "Neri",
+                  "abbrevName": "Neri G",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "G Neri"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Pierpont",
+                  "abbrevName": "Pierpont ME",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M E Pierpont"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Slaney",
+                  "abbrevName": "Slaney SF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S F Slaney"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D R Higgs"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1038/ng1097-146",
+            "pmid": "9326931",
+            "pubTypes": [
+              {
+                "UI": "D016422",
+                "value": "Letter"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Genet 17 1997",
+            "title": "Mutations in transcriptional regulator ATRX establish the functional significance of a PHD-like domain."
+          }
+        },
+        {
+          "pmid": "8980237",
+          "pubmed": {
+            "ISODate": "1996-12-27T00:00:00.000Z",
+            "abstract": "Using the phage P1-derived Cre/loxP recombination system, we have developed a method to create mice in which the deletion (knockout) of virtually any gene of interest is restricted to a subregion or a specific cell type in the brain such as the pyramidal cells of the hippocampal CA1 region. The Cre/loxP recombination-based gene deletion appears to require a certain level of Cre protein expression. The brain subregional restricted gene knockout should allow a more precise analysis of the impact of a gene mutation on animal behaviors.",
+            "authors": {
+              "abbreviation": "J Z Tsien, D F Chen, D Gerber, ..., S Tonegawa",
+              "authorList": [
+                {
+                  "ForeName": "J",
+                  "LastName": "Tsien",
+                  "abbrevName": "Tsien JZ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J Z Tsien"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Chen",
+                  "abbrevName": "Chen DF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D F Chen"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Gerber",
+                  "abbrevName": "Gerber D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D Gerber"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Tom",
+                  "abbrevName": "Tom C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "C Tom"
+                },
+                {
+                  "ForeName": "E",
+                  "LastName": "Mercer",
+                  "abbrevName": "Mercer EH",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "E H Mercer"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Anderson",
+                  "abbrevName": "Anderson DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D J Anderson"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Mayford",
+                  "abbrevName": "Mayford M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Mayford"
+                },
+                {
+                  "ForeName": "E",
+                  "LastName": "Kandel",
+                  "abbrevName": "Kandel ER",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "E R Kandel"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Tonegawa",
+                  "abbrevName": "Tonegawa S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S Tonegawa"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/s0092-8674(00)81826-7",
+            "pmid": "8980237",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013487",
+                "value": "Research Support, U.S. Gov't, P.H.S."
+              }
+            ],
+            "reference": "Cell 87 1996",
+            "title": "Subregion- and cell type-restricted gene knockout in mouse brain."
+          }
+        },
+        {
+          "pmid": "8968741",
+          "pubmed": {
+            "ISODate": "1996-12-01T00:00:00.000Z",
+            "abstract": "It was shown recently that mutations of the ATRX gene give rise to a severe, X-linked form of syndromal mental retardation associated with alpha thalassaemia (ATR-X syndrome). In this study, we have characterised the full-length cDNA and predicted structure of the ATRX protein. Comparative analysis shows that it is an entirely new member of the SNF2 subgroup of a superfamily of proteins with similar ATPase and helicase domains. ATRX probably acts as a regulator of gene expression. Definition of its genomic structure enabled us to identify four novel splicing defects by screening 52 affected individuals. Correlation between these and previously identified mutations with variations in the ATR-X phenotype provides insights into the pathophysiology of this disease and the normal role of the ATRX protein in vivo.",
+            "authors": {
+              "abbreviation": "D J Picketts, D R Higgs, S Bachoo, ..., R J Gibbons",
+              "authorList": [
+                {
+                  "ForeName": "D",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D J Picketts"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D R Higgs"
+                },
+                {
+                  "ForeName": "S",
+                  "LastName": "Bachoo",
+                  "abbrevName": "Bachoo S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "S Bachoo"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Blake",
+                  "abbrevName": "Blake DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D J Blake"
+                },
+                {
+                  "ForeName": "O",
+                  "LastName": "Quarrell",
+                  "abbrevName": "Quarrell OW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "O W Quarrell"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R J Gibbons"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/5.12.1899",
+            "pmid": "8968741",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 5 1996",
+            "title": "ATRX encodes a novel member of the SNF2 family of proteins: mutations point to a common mechanism underlying the ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "8627357",
+          "pubmed": {
+            "ISODate": "1996-05-15T00:00:00.000Z",
+            "abstract": "Memory storage consists of a short-term phase that is independent of new protein synthesis and a long-term phase that requires the synthesis of new proteins and RNA. A cellular representation of these two phases has been demonstrated recently for long-term potentiation (LTP) in both the Schaffer collateral and the mossy fibers of the hippocampus, a structure widely thought to contribute to memory consolidation. By contrast, much less information is available about the medial perforant pathway (MPP), one of the major inputs to the hippocampus. We found that both a short-lasting and a long-lasting potentiation (L-LTP) can be induced in the MPP of rat hippocampal slices by applying repeated tetanization in reduced levels of magnesium. This potentiation was dependent on the activation of NMDA receptors. The early, transient phase of LTP in the MPP did not require either protein or RNA synthesis, and it was independent of protein kinase A activation. By contrast, L-LTP required the synthesis of proteins and RNA, and was selectively blocked by inhibitors of cAMP-dependent protein kinase (PKA). Forskolin, an adenylate cyclase activator, also induced a L-LTP that was attenuated by inhibition of transcription. Our results demonstrate that, like LTP in the Schaffer collateral and mossy fiber pathways, MPP LTP also consists of a late phase that is dependent on protein and RNA synthesis and PKA activity. Thus, cAMP-mediated transcription appears to be a common mechanism for the late form of LTP in all three pathways within the hippocampus.",
+            "authors": {
+              "abbreviation": "P V Nguyen, E R Kandel",
+              "authorList": [
+                {
+                  "ForeName": "P",
+                  "LastName": "Nguyen",
+                  "abbrevName": "Nguyen PV",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "P V Nguyen"
+                },
+                {
+                  "ForeName": "E",
+                  "LastName": "Kandel",
+                  "abbrevName": "Kandel ER",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "E R Kandel"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": null,
+            "pmid": "8627357",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013487",
+                "value": "Research Support, U.S. Gov't, P.H.S."
+              }
+            ],
+            "reference": "J Neurosci 16 1996",
+            "title": "A macromolecular synthesis-dependent late phase of long-term potentiation requiring cAMP in the medial perforant pathway of rat hippocampal slices."
+          }
+        },
+        {
+          "pmid": "8126267",
+          "pubmed": {
+            "ISODate": null,
+            "abstract": "OBJECTIVE: In both diagnostic and research applications, the interpretation of MR images of the human brain is facilitated when different data sets can be compared by visual inspection of equivalent anatomical planes. Quantitative analysis with predefined atlas templates often requires the initial alignment of atlas and image planes. Unfortunately, the axial planes acquired during separate scanning sessions are often different in their relative position and orientation, and these slices are not coplanar with those in the atlas. We have developed a completely automatic method to register a given volumetric data set with Talairach stereotaxic coordinate system. MATERIALS AND METHODS: The registration method is based on multi-scale, three-dimensional (3D) cross-correlation with an average (n > 300) MR brain image volume aligned with the Talariach stereotaxic space. Once the data set is re-sampled by the transformation recovered by the algorithm, atlas slices can be directly superimposed on the corresponding slices of the re-sampled volume. the use of such a standardized space also allows the direct comparison, voxel to voxel, of two or more data sets brought into stereotaxic space. RESULTS: With use of a two-tailed Student t test for paired samples, there was no significant difference in the transformation parameters recovered by the automatic algorithm when compared with two manual landmark-based methods (p > 0.1 for all parameters except y-scale, where p > 0.05). Using root-mean-square difference between normalized voxel intensities as an unbiased measure of registration, we show that when estimated and averaged over 60 volumetric MR images in standard space, this measure was 30% lower for the automatic technique than the manual method, indicating better registrations. Likewise, the automatic method showed a 57% reduction in standard deviation, implying a more stable technique. The algorithm is able to recover the transformation even when data are missing from the top or bottom of the volume. CONCLUSION: We present a fully automatic registration method to map volumetric data into stereotaxic space that yields results comparable with those of manually based techniques. The method requires no manual identification of points or contours and therefore does not suffer the drawbacks involved in user intervention such as reproducibility and interobserver variability.",
+            "authors": {
+              "abbreviation": "D L Collins, P Neelin, T M Peters, A C Evans",
+              "authorList": [
+                {
+                  "ForeName": "D",
+                  "LastName": "Collins",
+                  "abbrevName": "Collins DL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D L Collins"
+                },
+                {
+                  "ForeName": "P",
+                  "LastName": "Neelin",
+                  "abbrevName": "Neelin P",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "P Neelin"
+                },
+                {
+                  "ForeName": "T",
+                  "LastName": "Peters",
+                  "abbrevName": "Peters TM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "T M Peters"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Evans",
+                  "abbrevName": "Evans AC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A C Evans"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": null,
+            "pmid": "8126267",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Comput Assist Tomogr 18",
+            "title": "Automatic 3D intersubject registration of MR volumetric data in standardized Talairach space."
+          }
+        },
+        {
+          "pmid": "7697714",
+          "pubmed": {
+            "ISODate": "1995-03-24T00:00:00.000Z",
+            "abstract": "The ATR-X syndrome is an X-linked disorder comprising severe psychomotor retardation, characteristic facial features, genital abnormalities, and alpha-thalassemia. We have shown that ATR-X results from diverse mutations of XH2, a member of a subgroup of the helicase superfamily that includes proteins involved in a wide range of cellular functions, including DNA recombination and repair (RAD16, RAD54, and ERCC6) and regulation of transcription (SW12/SNF2, MOT1, and brahma). The complex ATR-X phenotype suggests that XH2, when mutated, down-regulates expression of several genes, including the alpha-globin genes, indicating that it could be a global transcriptional regulator. In addition to its role in the ATR-X syndrome, XH2 may be a good candidate for other forms of X-linked mental retardation mapping to Xq13.",
+            "authors": {
+              "abbreviation": "R J Gibbons, D J Picketts, L Villard, D R Higgs",
+              "authorList": [
+                {
+                  "ForeName": "R",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R J Gibbons"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D J Picketts"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Villard",
+                  "abbrevName": "Villard L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Villard"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D R Higgs"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1016/0092-8674(95)90287-2",
+            "pmid": "7697714",
+            "pubTypes": [
+              {
+                "UI": "D003160",
+                "value": "Comparative Study"
+              },
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell 80 1995",
+            "title": "Mutations in a putative global transcriptional regulator cause X-linked mental retardation with alpha-thalassemia (ATR-X syndrome)."
+          }
+        },
+        {
+          "pmid": "3382917",
+          "pubmed": {
+            "ISODate": "1988-06-01T00:00:00.000Z",
+            "abstract": "Groups of patients with dementia of Alzheimer type (DAT) and idiopathic Parkinson's disease, together with age and IQ-matched normal controls, were compared on several computerized tests of visuospatial memory and learning. Two different groups of parkinsonian patients were studied: (1) a newly diagnosed group, early in the course of the disease, not receiving medication (NMED) PD) and (2) a group later in the course of the disease, receiving medication (MED PD). The DAT and MED PD group were significantly impaired in both spatial and visual pattern recognition memory. The DAT group exhibited a delay-dependent deficit (over 0-16 s) in a delayed matching-to-sample procedure, but were not impaired at simultaneous-matching-to-sample. By contrast, the MED PD group showed delay-independent deficits in the delayed matching-to-sample test and both the MED PD and the NMED PD group were also significantly impaired in simultaneous matching. In a form of delayed response test, the subjects were required first to memorize and then to learn the locations of several abstract visual stimuli which varied progressively in number from 1 to 8. The DAT group were severely impaired in this conditional associative learning task. A significant proportion of patients, but none of the controls, in the NMED and MED PD group also failed the test at the levels of 6 or 8 items. There was a significant correlation between the performance on the first trial, memory score in the delayed response task and indices of clinical disability and disease duration in the patients with Parkinson's disease. The results are discussed in terms of the utility of the comparison between DAT and PD in characterizing the nature of the cognitive deficits in these conditions and their relation to those findings from animal neuropsychology which use comparable paradigms.",
+            "authors": {
+              "abbreviation": "B J Sahakian, R G Morris, J L Evenden, ..., T W Robbins",
+              "authorList": [
+                {
+                  "ForeName": "B",
+                  "LastName": "Sahakian",
+                  "abbrevName": "Sahakian BJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "B J Sahakian"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Morris",
+                  "abbrevName": "Morris RG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R G Morris"
+                },
+                {
+                  "ForeName": "J",
+                  "LastName": "Evenden",
+                  "abbrevName": "Evenden JL",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "J L Evenden"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Heald",
+                  "abbrevName": "Heald A",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A Heald"
+                },
+                {
+                  "ForeName": "R",
+                  "LastName": "Levy",
+                  "abbrevName": "Levy R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R Levy"
+                },
+                {
+                  "ForeName": "M",
+                  "LastName": "Philpot",
+                  "abbrevName": "Philpot M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "M Philpot"
+                },
+                {
+                  "ForeName": "T",
+                  "LastName": "Robbins",
+                  "abbrevName": "Robbins TW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "T W Robbins"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/brain/111.3.695",
+            "pmid": "3382917",
+            "pubTypes": [
+              {
+                "UI": "D003160",
+                "value": "Comparative Study"
+              },
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Brain 111 ( Pt 3) 1988",
+            "title": "A comparative study of visuospatial memory and learning in Alzheimer-type dementia and Parkinson's disease."
+          }
+        },
+        {
+          "pmid": "1613552",
+          "pubmed": {
+            "ISODate": "1992-07-01T00:00:00.000Z",
+            "abstract": "It has long been hypothesized that changes in dendritic spine structure may modify the physiological properties of synapses located on them. Due to their small size, large number, and highly variable shapes, standard light microscopy of Golgi impregnations and electron microscopy (EM) of single thin sections have not proved adequate to identify most spines in a sample or to quantify their structural dimensions and composition. Here we describe a new approach, the series sample, that was developed to classify by shape and subcellular composition all of the spines and synapses in a sample of neuropil by viewing them through serial EM sections. Spines in each class are then randomly selected for serial reconstruction and measurement in three dimensions. This approach was used to assess whether structural changes in hippocampal CA1 spines could contribute to the enhanced synaptic transmission and the greater endurance of long-term potentiation (LTP) that occur with maturation. Our results show a near doubling in the total density of synapses in the neuropil and along reconstructed dendrites between postnatal day 15 (PND 15) and adult ages. However, this doubling does not occur uniformly across all spine and synapse morphologies. Thin spines, mushroom spines containing perforated postsynaptic densities (PSDs) and spine apparatuses, and branched spines increase by about four-fold in density between PND 15 and adult ages. In contrast, stubby spines decrease by more than half and no change occurs in mushroom spines with macular PSDs or in dendritic shaft synapses. The stubby spines that remain are smaller in adults than at PND 15 and the mushroom spines are larger, while no change occurs in the three-dimensional structure of thin spines. Only a few spine necks at either age are constricted or long enough to attenuate charge transfer; therefore, the doubling in synapses should mediate the enhancement of synaptic transmission that occurs with maturation. In addition, LTP is not likely to be mediated by widening of spine necks at either age. However, the constricted spine necks could serve to concentrate specific molecules at activated synapses, thereby enhancing the specificity and endurance of LTP with maturation. These results demonstrate that the new series sample method combined with three-dimensional reconstruction reveals quantitative changes in the frequency and structure of spines and synapses that are not discernable by other methods and are likely to have dramatic effects on synaptic physiology and plasticity.",
+            "authors": {
+              "abbreviation": "K M Harris, F E Jensen, B Tsao",
+              "authorList": [
+                {
+                  "ForeName": "K",
+                  "LastName": "Harris",
+                  "abbrevName": "Harris KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "K M Harris"
+                },
+                {
+                  "ForeName": "F",
+                  "LastName": "Jensen",
+                  "abbrevName": "Jensen FE",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "F E Jensen"
+                },
+                {
+                  "ForeName": "B",
+                  "LastName": "Tsao",
+                  "abbrevName": "Tsao B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "B Tsao"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": null,
+            "pmid": "1613552",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013487",
+                "value": "Research Support, U.S. Gov't, P.H.S."
+              }
+            ],
+            "reference": "J Neurosci 12 1992",
+            "title": "Three-dimensional structure of dendritic spines and synapses in rat hippocampus (CA1) at postnatal day 15 and adult ages: implications for the maturation of synaptic physiology and long-term potentiation."
+          }
+        },
+        {
+          "pmid": "1415255",
+          "pubmed": {
+            "ISODate": "1992-11-01T00:00:00.000Z",
+            "abstract": "We have examined seven pedigrees that include individuals with a recently described X-linked form of severe mental retardation associated with alpha-thalassemia (ATR-X syndrome). Using hematologic and molecular approaches, we have shown that intellectually normal female carriers of this syndrome may be identified by the presence of rare cells containing HbH inclusions in their peripheral blood and by an extremely skewed pattern of X inactivation seen in cells from a variety of tissues. Linkage analysis has localized the ATR-X locus to an interval of approximately 11 cM between the loci DXS106 and DXYS1X (Xq12-q21.31), with a peak LOD score of 5.4 (recombination fraction of 0) at DXS72. These findings provide the basis for genetic counseling, assessment of carrier risk, and prenatal diagnosis of the ATR-X syndrome. Furthermore, they represent an important step in developing strategies to understand how the mutant ATR-X allele causes mental handicap, dysmorphism, and down-regulation of the alpha-globin genes.",
+            "authors": {
+              "abbreviation": "R J Gibbons, G K Suthers, A O Wilkie, ..., D R Higgs",
+              "authorList": [
+                {
+                  "ForeName": "R",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "R J Gibbons"
+                },
+                {
+                  "ForeName": "G",
+                  "LastName": "Suthers",
+                  "abbrevName": "Suthers GK",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "G K Suthers"
+                },
+                {
+                  "ForeName": "A",
+                  "LastName": "Wilkie",
+                  "abbrevName": "Wilkie AO",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "A O Wilkie"
+                },
+                {
+                  "ForeName": "V",
+                  "LastName": "Buckle",
+                  "abbrevName": "Buckle VJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "V J Buckle"
+                },
+                {
+                  "ForeName": "D",
+                  "LastName": "Higgs",
+                  "abbrevName": "Higgs DR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "D R Higgs"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": null,
+            "pmid": "1415255",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Am J Hum Genet 51 1992",
+            "title": "X-linked alpha-thalassemia/mental retardation (ATR-X) syndrome: localization to Xq12-q21.31 by X inactivation and linkage analysis."
+          }
+        }
+      ],
+      "relatedPapers": [
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        },
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "status": "public",
+      "tweet": null,
+      "verified": true
+    }
+  ],
+  "element": [
+    {
+      "_creationTimestamp": "2020-09-29T13:48:50.743Z",
+      "_newestOpId": "bbb93a32-9345-488e-a04d-94f97bee0043",
+      "_ops": [],
+      "association": {
+        "charge": null,
+        "combinedOrganismIndex": 0,
+        "dbName": "ChEBI",
+        "dbPrefix": "CHEBI",
+        "dbXrefs": [
+          {
+            "db": "MGI",
+            "id": "MGI:95977"
+          }
+        ],
+        "defaultOrganismIndex": 0,
+        "distance": 0,
+        "esScore": 11.06899,
+        "formulae": [],
+        "id": "85045",
+        "mass": null,
+        "monoisotopicMass": null,
+        "name": "H3K27Me3",
+        "nameDistance": 0,
+        "namespace": "chebi",
+        "organism": "10090",
+        "organismIndex": 0,
+        "organismName": "Mus musculus",
+        "overallDistance": 0,
+        "shortSynonyms": [],
+        "synonyms": [],
+        "type": "chemical"
+      },
+      "completed": true,
+      "description": "",
+      "id": "39ed6d4b-0ef1-4ea8-b1e2-823aef3e6363",
+      "liveId": "a3892063-3009-44a6-b95d-4b6d4fda054d",
+      "lock": null,
+      "locked": false,
+      "name": "H3K27me3",
+      "position": {
+        "x": 237.9746835443037,
+        "y": 52.658227848101255
+      },
+      "relatedPapers": [
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "type": "chemical"
+    },
+    {
+      "_creationTimestamp": "2020-09-29T13:47:58.167Z",
+      "_newestOpId": "128ea2b1-a502-4b47-82bb-9c8ba75f1b03",
+      "_ops": [],
+      "association": {
+        "combinedOrganismIndex": 0,
+        "dbName": "NCBI Gene",
+        "dbPrefix": "ncbigene",
+        "dbXrefs": [
+          {
+            "db": "MGI",
+            "id": "MGI:2676822"
+          },
+          {
+            "db": "Ensembl",
+            "id": "ENSMUSG00000065569"
+          },
+          {
+            "db": "miRBase",
+            "id": "MI0000163"
+          }
+        ],
+        "defaultOrganismIndex": 2,
+        "distance": 0,
+        "esScore": 11.06899,
+        "id": "387155",
+        "name": "Mir137",
+        "nameDistance": 0,
+        "namespace": "ncbi",
+        "organism": "10090",
+        "organismIndex": 0,
+        "organismName": "Mus musculus",
+        "overallDistance": 0,
+        "shortSynonyms": [
+          "Mirn137",
+          "mir-137",
+          "mmu-mir-137",
+          "microRNA 137"
+        ],
+        "synonyms": [
+          "Mirn137",
+          "mir-137",
+          "mmu-mir-137",
+          "microRNA 137"
+        ],
+        "type": "ggp"
+      },
+      "completed": true,
+      "description": "",
+      "id": "6efd818a-b71f-4618-bd73-08232cdc63d8",
+      "liveId": "ff6c17ae-f716-4b8f-a12e-11ad75307b65",
+      "lock": null,
+      "locked": false,
+      "name": "miR137",
+      "position": {
+        "x": 328.1012658227847,
+        "y": 81.51898734177216
+      },
+      "relatedPapers": [
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "type": "ggp"
+    },
+    {
+      "_creationTimestamp": "2020-09-29T13:49:40.207Z",
+      "_newestOpId": "d954432a-0f2c-4340-b9e2-d8729ac799fd",
+      "_ops": [],
+      "association": "transcription-translation",
+      "completed": true,
+      "description": "",
+      "entries": [
+        {
+          "group": null,
+          "id": "74715bf7-c1da-420f-923a-1f37983cf184"
+        },
+        {
+          "group": "negative",
+          "id": "6efd818a-b71f-4618-bd73-08232cdc63d8"
+        }
+      ],
+      "id": "e0f02139-fc9e-4463-8ac6-8632630323a9",
+      "liveId": "186f2571-6dec-4b2e-a588-e8b324b2a0ad",
+      "lock": null,
+      "locked": false,
+      "name": "",
+      "novel": true,
+      "position": {
+        "x": -41.51898734177231,
+        "y": 28.35443037974682
+      },
+      "relatedPapers": [
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        },
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "type": "transcription-translation"
+    },
+    {
+      "_creationTimestamp": "2020-09-29T13:49:48.815Z",
+      "_newestOpId": "949a6647-b2ea-4708-b55b-101822bf2a71",
+      "_ops": [],
+      "association": "transcription-translation",
+      "completed": true,
+      "description": "",
+      "entries": [
+        {
+          "group": null,
+          "id": "39ed6d4b-0ef1-4ea8-b1e2-823aef3e6363"
+        },
+        {
+          "group": "negative",
+          "id": "6efd818a-b71f-4618-bd73-08232cdc63d8"
+        }
+      ],
+      "id": "9004e33a-f2ab-4ab2-b95f-3ed48ee36391",
+      "liveId": "09809a42-5f50-4488-8e4d-2e55710d3894",
+      "lock": null,
+      "locked": false,
+      "name": "",
+      "novel": true,
+      "position": {
+        "x": -46.582278481012814,
+        "y": 28.35443037974682
+      },
+      "relatedPapers": [
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        },
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "type": "transcription-translation"
+    },
+    {
+      "_creationTimestamp": "2020-09-29T13:47:27.542Z",
+      "_newestOpId": "333f517b-a8e3-45fe-aae5-388f75831fe1",
+      "_ops": [],
+      "association": {
+        "combinedOrganismIndex": 2,
+        "dbName": "NCBI Gene",
+        "dbPrefix": "ncbigene",
+        "dbXrefs": [
+          {
+            "db": "MGI",
+            "id": "MGI:103067"
+          },
+          {
+            "db": "Ensembl",
+            "id": "ENSMUSG00000031229"
+          }
+        ],
+        "defaultOrganismIndex": 2,
+        "distance": 0,
+        "esScore": 10.227753,
+        "id": "22589",
+        "name": "Atrx",
+        "nameDistance": 0,
+        "namespace": "ncbi",
+        "organism": "10090",
+        "organismIndex": 0,
+        "organismName": "Mus musculus",
+        "overallDistance": 200000,
+        "shortSynonyms": [
+          "4833408C14Rik",
+          "AI447451",
+          "ATR2",
+          "DXHXS6677E",
+          "HP1-BP38",
+          "MRXS3",
+          "ATRX, chromatin remodeler",
+          "ATP-dependent helicase ATRX",
+          "transcriptional regulator ATRX",
+          "heterochromatin protein 2"
+        ],
+        "synonyms": [
+          "4833408C14Rik",
+          "AI447451",
+          "ATR2",
+          "DXHXS6677E",
+          "HP1-BP38",
+          "Hp1bp2",
+          "Hp1bp38",
+          "MRXS3",
+          "RAD54L",
+          "Rad54",
+          "XH2",
+          "Xnp",
+          "ZNF-HX",
+          "transcriptional regulator ATRX",
+          "ATP-dependent helicase ATRX",
+          "HP1 alpha-interacting protein",
+          "X-linked nuclear protein",
+          "alpha thalassemia/mental retardation syndrome X-linked homolog",
+          "heterochromatin protein 2",
+          "ATRX, chromatin remodeler"
+        ],
+        "type": "protein"
+      },
+      "completed": true,
+      "description": "",
+      "id": "74715bf7-c1da-420f-923a-1f37983cf184",
+      "liveId": "a644b727-1bf2-48f8-906a-3f281827446e",
+      "lock": null,
+      "locked": false,
+      "name": "ATRX",
+      "position": {
+        "x": 149.873417721519,
+        "y": 83.03797468354429
+      },
+      "relatedPapers": [
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        },
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "type": "protein"
+    },
+    {
+      "_creationTimestamp": "2020-09-29T13:49:57.767Z",
+      "_newestOpId": "e398baab-3e98-49ba-a247-234e7504012c",
+      "_ops": [],
+      "association": "interaction",
+      "completed": true,
+      "description": "",
+      "entries": [
+        {
+          "group": null,
+          "id": "74715bf7-c1da-420f-923a-1f37983cf184"
+        },
+        {
+          "group": "unsigned",
+          "id": "39ed6d4b-0ef1-4ea8-b1e2-823aef3e6363"
+        }
+      ],
+      "id": "109b5c89-5eee-482e-8986-d8ae6f23d319",
+      "liveId": "17b3367a-2e90-47e3-91e0-d75d85f3e90c",
+      "lock": null,
+      "locked": false,
+      "name": "",
+      "novel": true,
+      "position": {
+        "x": -41.51898734177231,
+        "y": 28.35443037974682
+      },
+      "relatedPapers": [
+        {
+          "pmid": "28173139",
+          "pubmed": {
+            "ISODate": "2016-11-01T00:00:00.000Z",
+            "abstract": "ATRX is a chromatin remodeling protein that is mutated in several intellectual disability disorders including alpha-thalassemia/mental retardation, X-linked (ATR-X) syndrome. We previously reported the prevalence of ophthalmological defects in ATR-X syndrome patients, and accordingly we find morphological and functional visual abnormalities in a mouse model harboring a mutation occurring in ATR-X patients. The visual system abnormalities observed in these mice parallels the Atrx-null retinal phenotype characterized by interneuron defects and selective loss of amacrine and horizontal cells. The mechanisms that underlie selective neuronal vulnerability and neurodegeneration in the central nervous system upon Atrx mutation or deletion are unknown. To interrogate the cellular specificity of Atrx for its retinal neuroprotective functions, we employed a combination of temporal and lineage-restricted conditional ablation strategies to generate five different conditional knockout mouse models, and subsequently identified a non-cell-autonomous requirement for Atrx in bipolar cells for inhibitory interneuron survival in the retina. Atrx-deficient retinal bipolar cells exhibit functional, structural and molecular alterations consistent with impairments in neuronal activity and connectivity. Gene expression changes in the Atrx-null retina indicate defective synaptic structure and neuronal circuitry, suggest excitotoxic mechanisms of neurodegeneration, and demonstrate that common targets of ATRX in the forebrain and retina may contribute to similar neuropathological processes underlying cognitive impairment and visual dysfunction in ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Pamela S Lagali, Chantal F Medina, Brandon Y H Zhao, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Pamela",
+                  "LastName": "Lagali",
+                  "abbrevName": "Lagali PS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Pamela S Lagali"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Brandon",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao BY",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Brandon Y H Zhao"
+                },
+                {
+                  "ForeName": "Keqin",
+                  "LastName": "Yan",
+                  "abbrevName": "Yan K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Keqin Yan"
+                },
+                {
+                  "ForeName": "Adam",
+                  "LastName": "Baker",
+                  "abbrevName": "Baker AN",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Adam N Baker"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland SG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart G Coupland"
+                },
+                {
+                  "ForeName": "Catherine",
+                  "LastName": "Tsilfidis",
+                  "abbrevName": "Tsilfidis C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Catherine Tsilfidis"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddw306",
+            "pmid": "28173139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 25 2016",
+            "title": "Retinal interneuron survival requires non-cell-autonomous Atrx activity."
+          }
+        },
+        {
+          "pmid": "20865721",
+          "pubmed": {
+            "ISODate": "2011-06-01T00:00:00.000Z",
+            "abstract": "Mutations of the ATRX gene, which encodes an ATP-dependent chromatin-remodeling factor, were identified in patients with α-thalassemia X-linked mental retardation (ATR-X) syndrome. There is a milder variant of ATR-X syndrome caused by mutations in the Exon 2 of the gene. To examine the impact of the Exon 2 mutation on neuronal development, we generated ATRX mutant (ATRX(ΔE2)) mice. Truncated ATRX protein was produced from the ATRX(ΔE2) mutant allele with reduced expression level. The ATRX(ΔE2) mice survived and reproduced normally. There was no significant difference in Morris water maze test between wild-type and ATRX(ΔE2) mice. In a contextual fear conditioning test, however, total freezing time was decreased in ATRX(ΔE2) mice compared to wild-type mice, suggesting that ATRX(ΔE2) mice have impaired contextual fear memory. ATRX(ΔE2) mice showed significantly reduced long-term potentiation in the hippocampal CA1 region evoked by high-frequency stimulation. Moreover, autophosphorylation of calcium-calmodulin-dependent kinase II (αCaMKII) and phosphorylation of glutamate receptor, ionotropic, AMPA 1 (GluR1) were decreased in the hippocampi of the ATRX(ΔE2) mice compared to wild-type mice. These findings suggest that ATRX(ΔE2) mice may have fear-associated learning impairment with the dysfunction of αCaMKII and GluR1. The ATRX(ΔE2) mice would be useful tools to investigate the role of the chromatin-remodeling factor in the pathogenesis of abnormal behaviors and learning impairment.",
+            "authors": {
+              "abbreviation": "Tatsuya Nogami, Hideyuki Beppu, Takashi Tokoro, ..., Isao Kitajima",
+              "authorList": [
+                {
+                  "ForeName": "Tatsuya",
+                  "LastName": "Nogami",
+                  "abbrevName": "Nogami T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Tatsuya Nogami"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Beppu",
+                  "abbrevName": "Beppu H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Beppu"
+                },
+                {
+                  "ForeName": "Takashi",
+                  "LastName": "Tokoro",
+                  "abbrevName": "Tokoro T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takashi Tokoro"
+                },
+                {
+                  "ForeName": "Shigeki",
+                  "LastName": "Moriguchi",
+                  "abbrevName": "Moriguchi S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Shigeki Moriguchi"
+                },
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                },
+                {
+                  "ForeName": "Toshihisa",
+                  "LastName": "Ohtsuka",
+                  "abbrevName": "Ohtsuka T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Toshihisa Ohtsuka"
+                },
+                {
+                  "ForeName": "Yoko",
+                  "LastName": "Ishii",
+                  "abbrevName": "Ishii Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yoko Ishii"
+                },
+                {
+                  "ForeName": "Masakiyo",
+                  "LastName": "Sasahara",
+                  "abbrevName": "Sasahara M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Masakiyo Sasahara"
+                },
+                {
+                  "ForeName": "Yutaka",
+                  "LastName": "Shimada",
+                  "abbrevName": "Shimada Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yutaka Shimada"
+                },
+                {
+                  "ForeName": "Hisao",
+                  "LastName": "Nishijo",
+                  "abbrevName": "Nishijo H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hisao Nishijo"
+                },
+                {
+                  "ForeName": "En",
+                  "LastName": "Li",
+                  "abbrevName": "Li E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "En Li"
+                },
+                {
+                  "ForeName": "Isao",
+                  "LastName": "Kitajima",
+                  "abbrevName": "Kitajima I",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Isao Kitajima"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.20782",
+            "pmid": "20865721",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 21 2011",
+            "title": "Reduced expression of the ATRX gene, a chromatin-remodeling factor, causes hippocampal dysfunction in mice."
+          }
+        },
+        {
+          "pmid": "31813652",
+          "pubmed": {
+            "ISODate": "2020-02-05T00:00:00.000Z",
+            "abstract": "Variants in the ANK3 gene encoding ankyrin-G are associated with neurodevelopmental disorders, including intellectual disability, autism, schizophrenia, and bipolar disorder. However, no upstream regulators of ankyrin-G at synapses are known. Here, we show that ankyrin-G interacts with Usp9X, a neurodevelopmental-disorder-associated deubiquitinase (DUB). Usp9X phosphorylation enhances their interaction, decreases ankyrin-G polyubiquitination, and stabilizes ankyrin-G to maintain dendritic spine development. In forebrain-specific Usp9X knockout mice (Usp9X-/Y), ankyrin-G as well as multiple ankyrin-repeat domain (ANKRD)-containing proteins are transiently reduced at 2 but recovered at 12 weeks postnatally. However, reduced cortical spine density in knockouts persists into adulthood. Usp9X-/Y mice display increase of ankyrin-G ubiquitination and aggregation and hyperactivity. USP9X mutations in patients with intellectual disability and autism ablate its catalytic activity or ankyrin-G interaction. Our data reveal a DUB-dependent mechanism of ANKRD protein homeostasis, the impairment of which only transiently affects ANKRD protein levels but leads to persistent neuronal, behavioral, and clinical abnormalities.",
+            "authors": {
+              "abbreviation": "Sehyoun Yoon, Euan Parnell, Maria Kasherman, ..., Peter Penzes",
+              "authorList": [
+                {
+                  "ForeName": "Sehyoun",
+                  "LastName": "Yoon",
+                  "abbrevName": "Yoon S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sehyoun Yoon"
+                },
+                {
+                  "ForeName": "Euan",
+                  "LastName": "Parnell",
+                  "abbrevName": "Parnell E",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Euan Parnell"
+                },
+                {
+                  "ForeName": "Maria",
+                  "LastName": "Kasherman",
+                  "abbrevName": "Kasherman M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Maria Kasherman"
+                },
+                {
+                  "ForeName": "Marc",
+                  "LastName": "Forrest",
+                  "abbrevName": "Forrest MP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marc P Forrest"
+                },
+                {
+                  "ForeName": "Kristoffer",
+                  "LastName": "Myczek",
+                  "abbrevName": "Myczek K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kristoffer Myczek"
+                },
+                {
+                  "ForeName": "Susitha",
+                  "LastName": "Premarathne",
+                  "abbrevName": "Premarathne S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Susitha Premarathne"
+                },
+                {
+                  "ForeName": "Michelle",
+                  "LastName": "Sanchez Vega",
+                  "abbrevName": "Sanchez Vega MC",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michelle C Sanchez Vega"
+                },
+                {
+                  "ForeName": "Michael",
+                  "LastName": "Piper",
+                  "abbrevName": "Piper M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Michael Piper"
+                },
+                {
+                  "ForeName": "Thomas",
+                  "LastName": "Burne",
+                  "abbrevName": "Burne THJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Thomas H J Burne"
+                },
+                {
+                  "ForeName": "Lachlan",
+                  "LastName": "Jolly",
+                  "abbrevName": "Jolly LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lachlan A Jolly"
+                },
+                {
+                  "ForeName": "Stephen",
+                  "LastName": "Wood",
+                  "abbrevName": "Wood SA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stephen A Wood"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "abbrevName": "Penzes P",
+                  "email": "p-penzes@northwestern.edu",
+                  "isCollectiveName": false,
+                  "name": "Peter Penzes"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Penzes",
+                  "email": [
+                    "p-penzes@northwestern.edu"
+                  ],
+                  "name": "Peter Penzes"
+                }
+              ]
+            },
+            "doi": "10.1016/j.neuron.2019.11.003",
+            "pmid": "31813652",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              },
+              {
+                "UI": "D013486",
+                "value": "Research Support, U.S. Gov't, Non-P.H.S."
+              }
+            ],
+            "reference": "Neuron 105 2020",
+            "title": "Usp9X Controls Ankyrin-Repeat Domain Protein Homeostasis during Dendritic Spine Development."
+          }
+        },
+        {
+          "pmid": "32610139",
+          "pubmed": {
+            "ISODate": "2020-06-30T00:00:00.000Z",
+            "abstract": "ATRX gene mutations have been identified in syndromic and non-syndromic intellectual disabilities in humans. ATRX is known to maintain genomic stability in neuroprogenitor cells, but its function in differentiated neurons and memory processes remains largely unresolved. Here, we show that the deletion of neuronal Atrx in mice leads to distinct hippocampal structural defects, fewer presynaptic vesicles, and an enlarged postsynaptic area at CA1 apical dendrite-axon junctions. We identify male-specific impairments in long-term contextual memory and in synaptic gene expression, linked to altered miR-137 levels. We show that ATRX directly binds to the miR-137 locus and that the enrichment of the suppressive histone mark H3K27me3 is significantly reduced upon the loss of ATRX. We conclude that the ablation of ATRX in excitatory forebrain neurons leads to sexually dimorphic effects on miR-137 expression and on spatial memory, identifying a potential therapeutic target for neurological defects caused by ATRX dysfunction.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Vanessa Dumeaux, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Vanessa",
+                  "LastName": "Dumeaux",
+                  "abbrevName": "Dumeaux V",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Vanessa Dumeaux"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Sarfraz",
+                  "LastName": "Shafiq",
+                  "abbrevName": "Shafiq S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Sarfraz Shafiq"
+                },
+                {
+                  "ForeName": "Luana",
+                  "LastName": "Langlois",
+                  "abbrevName": "Langlois L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Luana Langlois"
+                },
+                {
+                  "ForeName": "Jacob",
+                  "LastName": "Ellegood",
+                  "abbrevName": "Ellegood J",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jacob Ellegood"
+                },
+                {
+                  "ForeName": "Lily",
+                  "LastName": "Qiu",
+                  "abbrevName": "Qiu LR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lily R Qiu"
+                },
+                {
+                  "ForeName": "Jason",
+                  "LastName": "Lerch",
+                  "abbrevName": "Lerch JP",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jason P Lerch"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1016/j.celrep.2020.107838",
+            "pmid": "32610139",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Cell Rep 31 2020",
+            "title": "Atrx Deletion in Neurons Leads to Sexually Dimorphic Dysregulation of miR-137 and Spatial Learning and Memory Deficits."
+          }
+        },
+        {
+          "pmid": "25538301",
+          "pubmed": {
+            "ISODate": "2015-06-02T00:00:00.000Z",
+            "abstract": "ATRX (the alpha thalassemia/mental retardation syndrome X-linked protein) is a member of the switch2/sucrose nonfermentable2 (SWI2/SNF2) family of chromatin-remodeling proteins and primarily functions at heterochromatic loci via its recognition of \"repressive\" histone modifications [e.g., histone H3 lysine 9 tri-methylation (H3K9me3)]. Despite significant roles for ATRX during normal neural development, as well as its relationship to human disease, ATRX function in the central nervous system is not well understood. Here, we describe ATRX's ability to recognize an activity-dependent combinatorial histone modification, histone H3 lysine 9 tri-methylation/serine 10 phosphorylation (H3K9me3S10ph), in postmitotic neurons. In neurons, this \"methyl/phos\" switch occurs exclusively after periods of stimulation and is highly enriched at heterochromatic repeats associated with centromeres. Using a multifaceted approach, we reveal that H3K9me3S10ph-bound Atrx represses noncoding transcription of centromeric minor satellite sequences during instances of heightened activity. Our results indicate an essential interaction between ATRX and a previously uncharacterized histone modification in the central nervous system and suggest a potential role for abnormal repetitive element transcription in pathological states manifested by ATRX dysfunction. ",
+            "authors": {
+              "abbreviation": "Kyung-Min Noh, Ian Maze, Dan Zhao, ..., C David Allis",
+              "authorList": [
+                {
+                  "ForeName": "Kyung-Min",
+                  "LastName": "Noh",
+                  "abbrevName": "Noh KM",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kyung-Min Noh"
+                },
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "abbrevName": "Maze I",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Dan",
+                  "LastName": "Zhao",
+                  "abbrevName": "Zhao D",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Dan Zhao"
+                },
+                {
+                  "ForeName": "Bin",
+                  "LastName": "Xiang",
+                  "abbrevName": "Xiang B",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Bin Xiang"
+                },
+                {
+                  "ForeName": "Wendy",
+                  "LastName": "Wenderski",
+                  "abbrevName": "Wenderski W",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Wendy Wenderski"
+                },
+                {
+                  "ForeName": "Peter",
+                  "LastName": "Lewis",
+                  "abbrevName": "Lewis PW",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Peter W Lewis"
+                },
+                {
+                  "ForeName": "Li",
+                  "LastName": "Shen",
+                  "abbrevName": "Shen L",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Li Shen"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "abbrevName": "Li H",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "abbrevName": "Allis CD",
+                  "email": "alliscd@rockefeller.edu",
+                  "isCollectiveName": false,
+                  "name": "C David Allis"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Ian",
+                  "LastName": "Maze",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Ian Maze"
+                },
+                {
+                  "ForeName": "Haitao",
+                  "LastName": "Li",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "Haitao Li"
+                },
+                {
+                  "ForeName": "C",
+                  "LastName": "Allis",
+                  "email": [
+                    "alliscd@rockefeller.edu",
+                    "lht@tsinghua.edu.cn"
+                  ],
+                  "name": "C David Allis"
+                }
+              ]
+            },
+            "doi": "10.1073/pnas.1411258112",
+            "pmid": "25538301",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D052061",
+                "value": "Research Support, N.I.H., Extramural"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Proc Natl Acad Sci U S A 112 2015",
+            "title": "ATRX tolerates activity-dependent histone H3 methyl/phos switching to maintain repetitive element silencing in neurons."
+          }
+        },
+        {
+          "pmid": "28093507",
+          "pubmed": {
+            "ISODate": "2017-02-01T00:00:00.000Z",
+            "abstract": "The rapid modulation of chromatin organization is thought to play a crucial role in cognitive processes such as memory consolidation. This is supported in part by the dysregulation of many chromatin-remodelling proteins in neurodevelopmental and psychiatric disorders. A key example is ATRX, an X-linked gene commonly mutated in individuals with syndromic and nonsyndromic intellectual disability. The consequences of Atrx inactivation for learning and memory have been difficult to evaluate because of the early lethality of hemizygous-null animals. In this study, we evaluated the outcome of brain-specific Atrx deletion in heterozygous female mice. These mice exhibit a mosaic pattern of ATRX protein expression in the central nervous system attributable to the location of the gene on the X chromosome. Although the hemizygous male mice die soon after birth, heterozygous females survive to adulthood. Body growth is stunted in these animals, and they have low circulating concentrations of insulin growth factor 1. In addition, they are impaired in spatial, contextual fear and novel object recognition memory. Our findings demonstrate that mosaic loss of ATRX expression in the central nervous system leads to endocrine defects and decreased body size and has a negative impact on learning and memory.",
+            "authors": {
+              "abbreviation": "Renee J Tamming, Jennifer R Siu, Yan Jiang, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Siu",
+                  "abbrevName": "Siu JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer R Siu"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Marco",
+                  "LastName": "Prado",
+                  "abbrevName": "Prado MA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Marco A M Prado"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": "nberube@uwo.ca",
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "email": [
+                    "nberube@uwo.ca"
+                  ],
+                  "name": "Nathalie G Bérubé"
+                }
+              ]
+            },
+            "doi": "10.1242/dmm.027482",
+            "pmid": "28093507",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Dis Model Mech 10 2017",
+            "title": "Mosaic expression of Atrx in the mouse central nervous system causes memory deficits."
+          }
+        },
+        {
+          "pmid": "23563309",
+          "pubmed": {
+            "ISODate": "2013-05-01T00:00:00.000Z",
+            "abstract": "Human ATRX mutations are associated with cognitive deficits, developmental abnormalities, and cancer. We show that the Atrx-null embryonic mouse brain accumulates replicative damage at telomeres and pericentromeric heterochromatin, which is exacerbated by loss of p53 and linked to ATM activation. ATRX-deficient neuroprogenitors exhibited higher incidence of telomere fusions and increased sensitivity to replication stress-inducing drugs. Treatment of Atrx-null neuroprogenitors with the G-quadruplex (G4) ligand telomestatin increased DNA damage, indicating that ATRX likely aids in the replication of telomeric G4-DNA structures. Unexpectedly, mutant mice displayed reduced growth, shortened life span, lordokyphosis, cataracts, heart enlargement, and hypoglycemia, as well as reduction of mineral bone density, trabecular bone content, and subcutaneous fat. We show that a subset of these defects can be attributed to loss of ATRX in the embryonic anterior pituitary that resulted in low circulating levels of thyroxine and IGF-1. Our findings suggest that loss of ATRX increases DNA damage locally in the forebrain and anterior pituitary and causes tissue attrition and other systemic defects similar to those seen in aging.",
+            "authors": {
+              "abbreviation": "L Ashley Watson, Lauren A Solomon, Jennifer Ruizhe Li, ..., Nathalie G Bérubé",
+              "authorList": [
+                {
+                  "ForeName": "L",
+                  "LastName": "Watson",
+                  "abbrevName": "Watson LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Ashley Watson"
+                },
+                {
+                  "ForeName": "Lauren",
+                  "LastName": "Solomon",
+                  "abbrevName": "Solomon LA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Lauren A Solomon"
+                },
+                {
+                  "ForeName": "Jennifer",
+                  "LastName": "Li",
+                  "abbrevName": "Li JR",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Jennifer Ruizhe Li"
+                },
+                {
+                  "ForeName": "Yan",
+                  "LastName": "Jiang",
+                  "abbrevName": "Jiang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yan Jiang"
+                },
+                {
+                  "ForeName": "Matthew",
+                  "LastName": "Edwards",
+                  "abbrevName": "Edwards M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Matthew Edwards"
+                },
+                {
+                  "ForeName": "Kazuo",
+                  "LastName": "Shin-ya",
+                  "abbrevName": "Shin-ya K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kazuo Shin-ya"
+                },
+                {
+                  "ForeName": "Frank",
+                  "LastName": "Beier",
+                  "abbrevName": "Beier F",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Frank Beier"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1172/JCI65634",
+            "pmid": "23563309",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "J Clin Invest 123 2013",
+            "title": "Atrx deficiency induces telomere dysfunction, endocrine defects, and reduced life span."
+          }
+        },
+        {
+          "pmid": "29785027",
+          "pubmed": {
+            "ISODate": "2018-06-01T00:00:00.000Z",
+            "abstract": "Alpha-thalassemia X-linked intellectual disability (ATR-X) syndrome is caused by mutations in ATRX, which encodes a chromatin-remodeling protein. Genome-wide analyses in mouse and human cells indicate that ATRX tends to bind to G-rich sequences with a high potential to form G-quadruplexes. Here, we report that Atrx mutation induces aberrant upregulation of Xlr3b expression in the mouse brain, an outcome associated with neuronal pathogenesis displayed by ATR-X model mice. We show that ATRX normally binds to G-quadruplexes in CpG islands of the imprinted Xlr3b gene, regulating its expression by recruiting DNA methyltransferases. Xlr3b binds to dendritic mRNAs, and its overexpression inhibits dendritic transport of the mRNA encoding CaMKII-α, promoting synaptic dysfunction. Notably, treatment with 5-ALA, which is converted into G-quadruplex-binding metabolites, reduces RNA polymerase II recruitment and represses Xlr3b transcription in ATR-X model mice. 5-ALA treatment also rescues decreased synaptic plasticity and cognitive deficits seen in ATR-X model mice. Our findings suggest a potential therapeutic strategy to target G-quadruplexes and decrease cognitive impairment associated with ATR-X syndrome.",
+            "authors": {
+              "abbreviation": "Norifumi Shioda, Yasushi Yabuki, Kouya Yamaguchi, ..., Kohji Fukunaga",
+              "authorList": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "abbrevName": "Shioda N",
+                  "email": "shioda@gifu-pu.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Yasushi",
+                  "LastName": "Yabuki",
+                  "abbrevName": "Yabuki Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yasushi Yabuki"
+                },
+                {
+                  "ForeName": "Kouya",
+                  "LastName": "Yamaguchi",
+                  "abbrevName": "Yamaguchi K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kouya Yamaguchi"
+                },
+                {
+                  "ForeName": "Misaki",
+                  "LastName": "Onozato",
+                  "abbrevName": "Onozato M",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Misaki Onozato"
+                },
+                {
+                  "ForeName": "Yue",
+                  "LastName": "Li",
+                  "abbrevName": "Li Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yue Li"
+                },
+                {
+                  "ForeName": "Kenji",
+                  "LastName": "Kurosawa",
+                  "abbrevName": "Kurosawa K",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Kenji Kurosawa"
+                },
+                {
+                  "ForeName": "Hideyuki",
+                  "LastName": "Tanabe",
+                  "abbrevName": "Tanabe H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hideyuki Tanabe"
+                },
+                {
+                  "ForeName": "Nobuhiko",
+                  "LastName": "Okamoto",
+                  "abbrevName": "Okamoto N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nobuhiko Okamoto"
+                },
+                {
+                  "ForeName": "Takumi",
+                  "LastName": "Era",
+                  "abbrevName": "Era T",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Takumi Era"
+                },
+                {
+                  "ForeName": "Hiroshi",
+                  "LastName": "Sugiyama",
+                  "abbrevName": "Sugiyama H",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Hiroshi Sugiyama"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "abbrevName": "Wada T",
+                  "email": "wadataka@kuhp.kyoto-u.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "abbrevName": "Fukunaga K",
+                  "email": "kfukunaga@m.tohoku.ac.jp",
+                  "isCollectiveName": false,
+                  "name": "Kohji Fukunaga"
+                }
+              ],
+              "contacts": [
+                {
+                  "ForeName": "Norifumi",
+                  "LastName": "Shioda",
+                  "email": [
+                    "shioda@gifu-pu.ac.jp"
+                  ],
+                  "name": "Norifumi Shioda"
+                },
+                {
+                  "ForeName": "Takahito",
+                  "LastName": "Wada",
+                  "email": [
+                    "wadataka@kuhp.kyoto-u.ac.jp"
+                  ],
+                  "name": "Takahito Wada"
+                },
+                {
+                  "ForeName": "Kohji",
+                  "LastName": "Fukunaga",
+                  "email": [
+                    "kfukunaga@m.tohoku.ac.jp"
+                  ],
+                  "name": "Kohji Fukunaga"
+                }
+              ]
+            },
+            "doi": "10.1038/s41591-018-0018-6",
+            "pmid": "29785027",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Nat Med 24 2018",
+            "title": "Targeting G-quadruplex DNA as cognitive function therapy for ATR-X syndrome."
+          }
+        },
+        {
+          "pmid": "31713968",
+          "pubmed": {
+            "ISODate": "2020-06-01T00:00:00.000Z",
+            "abstract": "α-Thalassemia X-linked intellectual disability (ATR-X) syndrome is a neurodevelopmental disorder caused by mutations in the ATRX gene that encodes a SNF2-type chromatin-remodeling protein. The ATRX protein regulates chromatin structure and gene expression in the developing mouse brain and early inactivation leads to DNA replication stress, extensive cell death, and microcephaly. However, the outcome of Atrx loss of function postnatally in neurons is less well understood. We recently reported that conditional inactivation of Atrx in postnatal forebrain excitatory neurons (ATRX-cKO) causes deficits in long-term hippocampus-dependent spatial memory. Thus, we hypothesized that ATRX-cKO mice will display impaired hippocampal synaptic transmission and plasticity. In the present study, evoked field potentials and current source density analysis were recorded from a multichannel electrode in male, urethane-anesthetized mice. Three major excitatory synapses, the Schaffer collaterals to basal dendrites and proximal apical dendrites, and the temporoammonic path to distal apical dendrites on hippocampal CA1 pyramidal cells were assessed by their baseline synaptic transmission, including paired-pulse facilitation (PPF) at 50-ms interpulse interval, and by their long-term potentiation (LTP) induced by theta-frequency burst stimulation. Baseline single-pulse excitatory response at each synapse did not differ between ATRX-cKO and control mice, but baseline PPF was reduced at the CA1 basal dendritic synapse in ATRX-cKO mice. While basal dendritic LTP of the first-pulse excitatory response was not affected in ATRX-cKO mice, proximal and distal apical dendritic LTP were marginally and significantly reduced, respectively. These results suggest that ATRX is required in excitatory neurons of the forebrain to achieve normal hippocampal LTP and PPF at the CA1 apical and basal dendritic synapses, respectively. Such alterations in hippocampal synaptic transmission and plasticity could explain the long-term spatial memory deficits in ATRX-cKO mice and provide insight into the physiological mechanisms underlying intellectual disability in ATR-X syndrome patients.",
+            "authors": {
+              "abbreviation": "Radu Gugustea, Renee J Tamming, Nicole Martin-Kenny, ..., L Stan Leung",
+              "authorList": [
+                {
+                  "ForeName": "Radu",
+                  "LastName": "Gugustea",
+                  "abbrevName": "Gugustea R",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Radu Gugustea"
+                },
+                {
+                  "ForeName": "Renee",
+                  "LastName": "Tamming",
+                  "abbrevName": "Tamming RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Renee J Tamming"
+                },
+                {
+                  "ForeName": "Nicole",
+                  "LastName": "Martin-Kenny",
+                  "abbrevName": "Martin-Kenny N",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nicole Martin-Kenny"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "L",
+                  "LastName": "Leung",
+                  "abbrevName": "Leung LS",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "L Stan Leung"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1002/hipo.23174",
+            "pmid": "31713968",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hippocampus 30 2020",
+            "title": "Inactivation of ATRX in forebrain excitatory neurons affects hippocampal synaptic plasticity."
+          }
+        },
+        {
+          "pmid": "19088125",
+          "pubmed": {
+            "ISODate": "2009-03-01T00:00:00.000Z",
+            "abstract": "ATRX is an SWI/SNF-like chromatin remodeling protein that is mutated in several X-linked mental retardation syndromes, including the ATR-X syndrome. In mice, Atrx expression is widespread and attempts to understand its function in brain development are hampered by the lethality associated with ubiquitous or forebrain-restricted ablation of this gene. One way to circumvent this problem is to study its function in a region of the brain that is dispensable for long-term survival of the organism. The retina is a well-characterized tractable model of CNS development and in our review of 202 ATR-X syndrome patients, we found ocular defects present in approximately 25% of the cases, suggesting that studying Atrx in this tissue will provide insight into function. We report that Atrx is expressed in the neuroprogenitor pool in embryonic retina and in all cell types of the mature retina with the exception of rod photoreceptors. Conditional inactivation of Atrx in the retina during embryogenesis ultimately results in a loss of only two types of neurons, amacrine and horizontal cells. We show that this defect does not arise from a failure to specify these cells but rather a defect in interneuron differentiation and survival post-natally. The timing of cell loss is concomitant with light-dependent changes in synaptic organization in the retina and with a change in Atrx subnuclear localization within these interneurons. Moreover, these interneuron defects are associated with functional deficits as demonstrated by reduced b-wave amplitudes upon electroretinogram analysis. These results implicate a role for Atrx in interneuron survival and differentiation.",
+            "authors": {
+              "abbreviation": "Chantal F Medina, Chantal Mazerolle, Yaping Wang, ..., David J Picketts",
+              "authorList": [
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Medina",
+                  "abbrevName": "Medina CF",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal F Medina"
+                },
+                {
+                  "ForeName": "Chantal",
+                  "LastName": "Mazerolle",
+                  "abbrevName": "Mazerolle C",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Chantal Mazerolle"
+                },
+                {
+                  "ForeName": "Yaping",
+                  "LastName": "Wang",
+                  "abbrevName": "Wang Y",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Yaping Wang"
+                },
+                {
+                  "ForeName": "Nathalie",
+                  "LastName": "Bérubé",
+                  "abbrevName": "Bérubé NG",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Nathalie G Bérubé"
+                },
+                {
+                  "ForeName": "Stuart",
+                  "LastName": "Coupland",
+                  "abbrevName": "Coupland S",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Stuart Coupland"
+                },
+                {
+                  "ForeName": "Richard",
+                  "LastName": "Gibbons",
+                  "abbrevName": "Gibbons RJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Richard J Gibbons"
+                },
+                {
+                  "ForeName": "Valerie",
+                  "LastName": "Wallace",
+                  "abbrevName": "Wallace VA",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "Valerie A Wallace"
+                },
+                {
+                  "ForeName": "David",
+                  "LastName": "Picketts",
+                  "abbrevName": "Picketts DJ",
+                  "email": null,
+                  "isCollectiveName": false,
+                  "name": "David J Picketts"
+                }
+              ],
+              "contacts": []
+            },
+            "doi": "10.1093/hmg/ddn424",
+            "pmid": "19088125",
+            "pubTypes": [
+              {
+                "UI": "D016428",
+                "value": "Journal Article"
+              },
+              {
+                "UI": "D013485",
+                "value": "Research Support, Non-U.S. Gov't"
+              }
+            ],
+            "reference": "Hum Mol Genet 18 2009",
+            "title": "Altered visual function and interneuron survival in Atrx knockout mice: inference for the human syndrome."
+          }
+        }
+      ],
+      "secret": "read-only",
+      "type": "interaction"
+    }
+  ]
+}


### PR DESCRIPTION
#1166 

Investigating some documents that appear to have unconnected/orphaned nodes in Neo4j.

The following docs seem to have unconnected nodes by user's choice:
`62163587-4030-4cae-98b8-9594a402abb1`
`69cdff5d-cf3c-4e9c-9d5e-cede9a334ed8`
`6bb89ee8-266b-400d-b03a-46268c7cb8cf`
`6392a454-089e-42b6-9afb-aa78059bc5b8`

This document has 3 nodes, all connected, yet appeared to be unconnected in Neo4j:
`a6b4351d-b474-49d9-bc3d-f044513d5a0c`

However, upon adding it to the test suite, it appears to have made the necessary edges as desired. 
It is possible that this document is not problematic, and that the script I wrote to generate the doc ids
belonging to the orphaned nodes had some error.

Will investigate further.

