### PR TITLE
Use positional argument 'maxAge' for cache

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -1460,9 +1460,9 @@ http.get('/(:id).png', function( req, res, next ){
   const fillCache = async doc => {
     const img = await getDocumentImageBufferRatedLimited(doc);
     const cache = { img };
-    const ttl = calcTtl(doc);
+    const maxAge = calcTtl(doc);
 
-    imageCache.set(id, cache, {ttl});
+    imageCache.set(id, cache, maxAge);
 
     return cache;
   };


### PR DESCRIPTION
To set an expiration time for a key/value in lru-cache, use the positional argument `maxAge`. 

Problem was I was viewing the most updated API docs (9.1) rather than our [installed version (4.1.1)](https://github.com/isaacs/node-lru-cache/releases/tag/v4.1.1)

Refs: https://github.com/PathwayCommons/factoid/issues/1151#issuecomment-1503363300

Relevant sections of 4.1.1 Docs:

> ## Options
> ...
> * `maxAge` Maximum age in ms.  Items are not pro-actively pruned out
  as they age, but if you try to get an item that is too old, it'll
  drop it and return undefined instead of giving it to you.
>
> ## API
>
> * `set(key, value, maxAge)`
