### PR TITLE
Support FamPlex family members

### DIFF
--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -207,13 +207,14 @@ class Entity extends Element {
     let name = this.name() || '';
     let xref = this.getBiopaxXref( omitDbXref );
     let orgId = _.get( this.association(), ['organism'] );
+    let memberXrefs = _.get( this.association(), ['memberXrefs'], null );
     let organism = null;
 
     if ( orgId ) {
       organism = { id: orgId, db: 'taxonomy' };
     }
 
-    let entity = { type, name, xref, organism };
+    let entity = { type, name, xref, organism, memberXrefs };
 
     if ( type == ENTITY_TYPE.COMPLEX ) {
       entity.components = this.participants().map( p => p.toBiopaxTemplate( omitDbXref ) );


### PR DESCRIPTION
Protein originating from Famplex are supported out of the box. This is backwards compatible with grounding search and factoid converters.

Updates:
- add the grounding record attribute `memberXref` to the BioPAX template so family members can be included in BioPAX, if desired (required downstream update). This is not required.
- refactored the INDRA search template to be more generic.