### PR TITLE
Famplex: Named complex

### DIFF
--- a/src/client/components/element-info/entity-assoc-display.js
+++ b/src/client/components/element-info/entity-assoc-display.js
@@ -7,6 +7,11 @@ const { IDENTIFIERS_ORG_ID_BASE_URL } = require('../../../config');
 
 let protein = (m, searchTerms, includeOrganism = true) => {
   return [
+    m.summary ?
+    h('div.entity-info-section', [
+      h('span.entity-info-title', 'Summary'),
+      h('span', m.summary)
+    ]): null,
     includeOrganism ? h('div.entity-info-section', [
       h('span.entity-info-title', 'Organism'),
       h('span', m.organismName)
@@ -36,6 +41,7 @@ let protein = (m, searchTerms, includeOrganism = true) => {
 let ggp = protein;
 let dna = protein;
 let rna = protein;
+let namedComplex = protein;
 
 let chemical = (m, searchTerms) => {
   return [
@@ -96,6 +102,6 @@ let modification = (mod, onEdit) => h('div.entity-info-section.entity-info-mod-s
   ])
 ]);
 
-export const assocDisp = { ggp, dna, rna, protein, modification, chemical, complex, link };
+export const assocDisp = { ggp, dna, rna, protein, modification, chemical, complex, link, namedComplex };
 
 export default assocDisp;

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -365,10 +365,10 @@ class EntityInfo extends DataComponent {
     let doc = p.document;
     let children = [];
 
-    const citation = doc.citation();
-    const { pmid } = citation;
+    // const citation = doc.citation();
+    // const { pmid } = citation;
 
-    const hasPubmedMetadata = pmid != null;
+    // const hasPubmedMetadata = pmid != null;
 
     let Loader = ({ loading = true }) => h('div.entity-info-matches-loading' + (loading ? '.entity-info-matches-loading-active' : ''), [
       loading ? h('i.icon.icon-spinner') : h('i.material-icons', 'remove')
@@ -612,7 +612,7 @@ class EntityInfo extends DataComponent {
         if( isComplex(s.element.type()) ){
           const entityNames = s.element.participants().map(ppt => ppt.name());
           children.push( h('div.entity-info-assoc', targetFromAssoc({ type, name, entityNames }, true )) );
-          
+
           if (hasRelatedPapers) {
             children.push( h('div.entity-info-reld-papers-title', `Recommended articles`) );
 

--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -365,11 +365,6 @@ class EntityInfo extends DataComponent {
     let doc = p.document;
     let children = [];
 
-    // const citation = doc.citation();
-    // const { pmid } = citation;
-
-    // const hasPubmedMetadata = pmid != null;
-
     let Loader = ({ loading = true }) => h('div.entity-info-matches-loading' + (loading ? '.entity-info-matches-loading-active' : ''), [
       loading ? h('i.icon.icon-spinner') : h('i.material-icons', 'remove')
     ]);

--- a/src/model/element/entity-type.js
+++ b/src/model/element/entity-type.js
@@ -7,7 +7,8 @@ const ENTITY_TYPE = Object.freeze({
   RNA: 'rna',
   PROTEIN: 'protein',
   CHEMICAL: 'chemical',
-  COMPLEX: 'complex'
+  COMPLEX: 'complex',
+  NAMED_COMPLEX: 'namedComplex'
 });
 
 const NCBI_GENE_TYPE = Object.freeze({

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -220,7 +220,9 @@ class Entity extends Element {
       entity.components = this.participants().map( p => p.toBiopaxTemplate( omitDbXref ) );
 
     } else if ( type == ENTITY_TYPE.NAMED_COMPLEX ) {
-      // `namedComplex` shall be defined directly, e.g. UnificationXref
+      // `namedComplex` has no components, defined directly, e.g. UnificationXref
+      entity.type = ENTITY_TYPE.COMPLEX;
+      entity.components = [];
       let componentXrefs = _.get( this.association(), ['componentXrefs'], null );
       if(componentXrefs) entity.componentXrefs = componentXrefs;
 

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -220,9 +220,8 @@ class Entity extends Element {
       entity.components = this.participants().map( p => p.toBiopaxTemplate( omitDbXref ) );
 
     } else if ( type == ENTITY_TYPE.NAMED_COMPLEX ) {
-      // `namedComplex` has no components, defined directly, e.g. UnificationXref
+      // `namedComplex` defined directly, e.g. UnificationXref
       entity.type = ENTITY_TYPE.COMPLEX;
-      entity.components = [];
       let componentXrefs = _.get( this.association(), ['componentXrefs'], null );
       if(componentXrefs) entity.componentXrefs = componentXrefs;
 

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -207,17 +207,27 @@ class Entity extends Element {
     let name = this.name() || '';
     let xref = this.getBiopaxXref( omitDbXref );
     let orgId = _.get( this.association(), ['organism'] );
-    let memberXrefs = _.get( this.association(), ['memberXrefs'], null );
     let organism = null;
 
     if ( orgId ) {
       organism = { id: orgId, db: 'taxonomy' };
     }
 
-    let entity = { type, name, xref, organism, memberXrefs };
+    let entity = { type, name, xref, organism };
 
     if ( type == ENTITY_TYPE.COMPLEX ) {
+      // `complex` shall be defined by components
       entity.components = this.participants().map( p => p.toBiopaxTemplate( omitDbXref ) );
+
+    } else if ( type == ENTITY_TYPE.NAMED_COMPLEX ) {
+      // `namedComplex` shall be defined directly, e.g. UnificationXref
+      let componentXrefs = _.get( this.association(), ['componentXrefs'], null );
+      if(componentXrefs) entity.componentXrefs = componentXrefs;
+
+    } else {
+      // restricted to subclasses of physical entity
+      let memberXrefs = _.get( this.association(), ['memberXrefs'], null );
+      if(memberXrefs) entity.memberXrefs = memberXrefs;
     }
 
     return entity;


### PR DESCRIPTION
Support the entity type `namedComplex`, which represent FamPlex entities with components. In the curation tool, entity information for named complexes resembles existing (compound node) complexes and do not display a reconfigurable type or organism. Instead, a user must simply select another record. 

Representative examples:

<img width="430" alt="Screen Shot 2023-06-19 at 4 00 25 PM" src="https://github.com/PathwayCommons/factoid/assets/4706307/ac1d4332-5f0d-4ea4-ad77-60e2b9f264eb">
<img width="430" alt="Screen Shot 2023-06-19 at 4 04 32 PM" src="https://github.com/PathwayCommons/factoid/assets/4706307/df10e686-b3f6-4c28-96cb-157d1317a602">

- More items to consider 
  - [x] **gene/Famplex clashes, refinement**
  - [x] search template
  - [x] BioPAX/SBGN template
  - [x] factoid-converters
  - [x] neo4j mapping
  
Refs #1181, https://github.com/PathwayCommons/grounding-search/issues/130, https://github.com/PathwayCommons/grounding-search/pull/141