### PR TITLE
Explorer Info panel: Show info when article DOI (no PMID)

### DIFF
--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -72,13 +72,13 @@ export class InfoPanel extends Component {
     const retractedPubType = _.find( citation.pubTypes, ['UI', 'D016441'] );
     const retractFlag = retractedPubType ? h('span.editor-info-flag.super-salient-button.danger', retractedPubType.value) : null;
 
-    const hasPubmedMetadata = pmid != null;
+    const hasArticleMetadata = pmid != null || doi != null;
 
     return h('div.editor-info-panel', [
       h('div.editor-info-flags', [ retractFlag ]),
-      
+
       h('div.editor-info-title', title),
-      
+
       h('div.editor-info-authors', _.flatten(authorProfiles.map((a, i) => {
         let orcid = findOrcidIdentifier( a.orcid ); // Backwards compatible with URI
         if ( orcid ) {
@@ -94,12 +94,12 @@ export class InfoPanel extends Component {
           i !== authorProfiles.length - 1 ? h('span.editor-info-author-spacer', ', ') : null
         ];
       }))),
-      
+
       h(Credits, { controller, bus, document }),
 
-      hasPubmedMetadata ? h('div.editor-info-links', [
+      hasArticleMetadata ? h('div.editor-info-links', [
         h( doi ? 'a.editor-info-link.plain-link': 'div.editor-info-link', doi ? { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }: {}, reference),
-        h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed'),
+        pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${ doi ?  doi : ( "\u0022" + title + "\u0022") }` }, 'Google Scholar')
       ]) : null,
 
@@ -114,7 +114,7 @@ export class InfoPanel extends Component {
         ])
       ]) : null,
 
-      !hasPubmedMetadata && !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
+      !hasArticleMetadata && !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
     ]);
   }
 }


### PR DESCRIPTION
This is a required, backwards compatible update to accept preprints with DOI but which may not have a PMID (yet).

Updating https://github.com/PathwayCommons/factoid/commit/b37e604e82e46cf110dcad3d94449d49c6eb5d99 so that Explorer shows article information when any article ID is present. Below, a rigged example with article having DOI but no PMID.

<img width="450" alt="Screenshot 2023-07-27 at 10 53 09 AM" src="https://github.com/PathwayCommons/factoid/assets/4706307/92e8ee3c-0234-44a0-955f-506e4818b682">


In support of #961 