### PR TITLE
CrossRef API wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Services:
 - `ORCID_BASE_URL` : url for [ORCID](https://orcid.org/) website
 - `ORCID_PUBLIC_API_BASE_URL` : url for version of [ORCID](https://orcid.org/) public API
 - `NO_ABSTRACT_HANDLING` : labels directing how to sort documents missing query text. 'text' (default): autogenerate text from templates; 'date': sort by date and ignore text.
+- `CROSSREF_API_BASE_URL` : url for [Crossref Unified Resource API](https://api.crossref.org/)
 
 Links:
 

--- a/src/config.js
+++ b/src/config.js
@@ -75,6 +75,7 @@ export const INDRA_ENGLISH_ASSEMBLER_URL = env('INDRA_ENGLISH_ASSEMBLER_URL', 'h
 export const SEMANTIC_SEARCH_BASE_URL = env('SEMANTIC_SEARCH_BASE_URL', 'https://main.semanticsearch.baderlab.org/');
 export const ORCID_BASE_URL = env('ORCID_BASE_URL', 'https://orcid.org/');
 export const ORCID_PUBLIC_API_BASE_URL = env('ORCID_PUBLIC_API_BASE_URL', 'https://pub.orcid.org/v3.0/');
+export const CROSSREF_API_BASE_URL = env('CROSSREF_API_BASE_URL', 'https://api.crossref.org/');
 
 // Links
 export const UNIPROT_LINK_BASE_URL = env('UNIPROT_LINK_BASE_URL', 'http://www.uniprot.org/uniprot/');

--- a/src/server/routes/api/document/crossref/api.js
+++ b/src/server/routes/api/document/crossref/api.js
@@ -1,0 +1,85 @@
+import _ from 'lodash';
+import queryString from 'query-string';
+import fetch from 'node-fetch';
+
+import { CROSSREF_API_BASE_URL, EMAIL_ADDRESS_INFO, BASE_URL } from '../../../../../config.js';
+import { checkHTTPStatus } from '../../../../../util/index.js';
+
+const WORKS_URL = CROSSREF_API_BASE_URL + 'works';
+
+const toJson = response => response.json();
+const checkResultStatus = json => {
+  const status = _.get( json, ['status'] );
+  const isOK = status === 'ok';
+  if( isOK ){
+    return json;
+  } else {
+    const message = _.get( json, ['message'] );
+    throw new Error(`${message}`);
+  }
+};
+
+/**
+ * search
+ *
+ * Query the CrossRef web service API for matching Work.
+ * [See docs]{@link https://api.crossref.org/swagger-ui/index.html#/Works/get_works}
+ *
+ * @param { String } q The query term
+ * @param { Object } opts Search options
+ * @returns { Object } result The search results
+ * @returns { Array } result.searchHits A list of matching records
+ * @returns { Number } result.count The number of searchHits
+ */
+const search = (q, opts) => {
+  const DEFAULT_WORKS_PARAMS = {
+    'query.bibliographic': undefined, //query field for: citation look up, includes titles, authors, ISSNs and publication years
+    'rows': 5
+  };
+  const formatSearchHits = json => {
+    const searchHits =  _.get( json, ['message', 'items'] );
+    const count = searchHits.length;
+    return { searchHits, count };
+  };
+  const params = _.assign( {}, DEFAULT_WORKS_PARAMS, { 'query.bibliographic': q }, opts );
+  const url = WORKS_URL + '?' + queryString.stringify( params );
+  const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version} (${BASE_URL}; mailto:${EMAIL_ADDRESS_INFO})`;
+  return fetch( url, {
+    method: 'GET',
+    headers: {
+      'User-Agent': userAgent
+    }
+  })
+  .then( checkHTTPStatus )
+  .then( toJson )
+  .then( checkResultStatus )
+  .then( formatSearchHits );
+};
+
+
+/**
+ * get
+ *
+ * Retrieve Work from CrossRef web service API.
+ * [See docs]{@link https://api.crossref.org/swagger-ui/index.html#/Works/get_works__doi_}
+ *
+ * @param { String } doi The object DOI
+ * @returns { Object } The matching record
+ */
+const get = doi => {
+  const formatGetResponse = json => _.get( json, ['message'] );
+  const url = WORKS_URL + `/${doi}`;
+  const userAgent = `${process.env.npm_package_name}/${process.env.npm_package_version} (${BASE_URL}; mailto:${EMAIL_ADDRESS_INFO})`;
+  return fetch( url, {
+    method: 'GET',
+    headers: {
+      'User-Agent': userAgent
+    }
+  })
+  .then( checkHTTPStatus )
+  .then( toJson )
+  .then( checkResultStatus )
+  .then( formatGetResponse );
+};
+
+export { search, get };

--- a/src/server/routes/api/document/crossref/index.js
+++ b/src/server/routes/api/document/crossref/index.js
@@ -1,0 +1,1 @@
+export * from './api.js';


### PR DESCRIPTION
`search` and `get` (by DOI) a 'Work' (types include journal-article, preprint) from the [Crossref Unified Resource API](https://api.crossref.org/swagger-ui/index.html).

Notes:
  - Add user agent to get into 'polite' pool
  - searches aimed at 'citation look up, includes titles, authors, ISSNs and publication years'

Refs #961 