### PR TITLE
Add PublicationTypeList to default Pubmed article template.

### DIFF
--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -274,7 +274,8 @@ const createPubmedArticle = ({ articleTitle = null, journalName = null, publicat
             },
             Volume: null
           }
-        }
+        },
+        PublicationTypeList: []
       },
       ChemicalList: [],
       InvestigatorList: [],


### PR DESCRIPTION
Add a default PublicationTypeList field in template - this explicitly indicates if an article is a Journal Article, Review, Preprint etc.

Refs #961