### PR TITLE
Filling and updating Document Article metadata

### DIFF
--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -78,7 +78,7 @@ const findPreprint = async paperId => {
   ]);
   const isPreprint = ({ type, subtype }) => VALID_SUBTYPES.has( subtype ) && VALID_TYPES.has( type );
   const isRecognizedPublisher = ({ publisher }) => VALID_PUBLISHERS.has( publisher );
-  const isSupported = w => isPreprint( w ) && isRecognizedPublisher( w );
+  const isSupported = w => !_.isUndefined( w ) && isPreprint( w ) && isRecognizedPublisher( w );
   const paperId2Type = paperId => {
     // 99.3% of CrossRef DOIs (https://www.crossref.org/blog/dois-and-matching-regular-expressions/)
     let IdType = ID_TYPE.TERM;

--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -4,6 +4,7 @@ import logger from '../../../../logger';
 import { search, get } from './api.js';
 import { toPubMedArticle } from './map';
 import { isDoi } from '../../../../../util';
+import { ArticleIDError } from '../../../../../util/pubmed';
 
 const ID_TYPE = Object.freeze({
   DOI: 'doi',
@@ -106,12 +107,12 @@ const findPreprint = async paperId => {
     if( isSupported( m ) ){
       return toPubMedArticle( m );
     } else {
-      throw new Error(`Unable to find a CrossRef preprint for '${paperId}`);
+      throw new ArticleIDError( `Unrecognized paperId '${paperId}'`, paperId );
     }
 
   } catch( err ) {
     logger.error( `${err.name}: ${err.message}` );
-    throw new Error( `Unrecognized paperId '${paperId}'`, paperId );
+    throw err;
   }
 };
 

--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import logger from '../../../../logger';
 
 import { search, get } from './api.js';
+import { toPubMedArticle } from './map';
 
 const ID_TYPE = Object.freeze({
   DOI: 'doi',
@@ -103,7 +104,7 @@ const findPreprint = async paperId => {
     m = match( paperId, IdType, hits );
 
     if( isSupported( m ) ){
-      return m;
+      return toPubMedArticle( m );
     } else {
       throw new Error(`Unable to find a CrossRef preprint for '${paperId}`);
     }

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -99,12 +99,12 @@ const getPubmedArticle = async paperId => {
       if( PubmedArticle ){
         return PubmedArticle;
       } else {
-        throw new Error(`Unable to retrieve a PubmedArticle for '${paperId}`);
+        throw new ArticleIDError( `Unrecognized paperId '${paperId}'`, paperId );
       }
 
     } catch( err ) {
       logger.error( `${err.name}: ${err.message}` );
-      throw new ArticleIDError( `Unrecognized paperId '${paperId}'`, paperId );
+      throw err;
     }
   }
 };


### PR DESCRIPTION
Modifying the function that initially fills and updates article metadata from source to include:
  - Preprints
    - via [CrossRef Unified Resource API](https://api.crossref.org/swagger-ui/index.html)
      - Publishers supported
        - 'Cold Spring Harbor Laboratory'
          - bioRxiv and medRxiv 
        - 'eLife Sciences Publications, Ltd'
        - 'Research Square Platform LLC' (Nature)
  - Update
    - Uses an existing PubMed ID, DOI or the author supplied title as a default to refresh

**Table** Test cases evaluated (as of Oct 11, 2023)
|Update|Case                                              |PMID|DOI|Identifier                                                                                                 |Data Source|Reference                                         |Pass                     |
|------|--------------------------------------------------|----|---|-----------------------------------------------------------------------------------------------------------|-----------|--------------------------------------------------|-------------------------|
|N     |Unrecognized/spam/network error                   |N   |N  |paperId: "asdasdasd"                                                                                       |Default    |-                                                 |Y                        |
|N     |Published (No preprint)                           |N   |N  |paperId: "SENP1-Sirt3 Signaling Controls Mitochondrial Protein Acetylation and Metabolism"                 |PubMed     |https://pubmed.ncbi.nlm.nih.gov/31302001/         |Y                        |
|N     |Preprint (No publication)                         |N   |N  |paperId: "Epigenetic Reprogramming of Tissue-Specific Transcription Promotes Metastasis"                   |CrossRef   |https://www.biorxiv.org/content/10.1101/131102v1  |Y                        |
|N     |Published after preprint                          |N   |N  |paperId: "Laminin α1 orchestrates VEGFA functions in the ecosystem of colorectal carcinoma"                |PubMed     |https://pubmed.ncbi.nlm.nih.gov/29907957/         |Y                        |
|N     |Preprint (eLife) after preprint (bioRxiv + PubMed)|N   |N  |paperId: "Tmem263 deletion disrupts the GH/IGF-1 axis and causes dwarfism and impairs skeletal acquisition"|CrossRef   |https://elifesciences.org/reviewed-preprints/90949|Y                        |
|N     |Preprint (eLife) before preprint (Research Sq.)   |N   |N  |paperId: "RNA-binding deficient TDP-43 drives cognitive decline in a mouse model of TDP-43 proteinopathy"  |CrossRef   |https://elifesciences.org/reviewed-preprints/85921|Works by accident (top 5)|
|Y     |Unrecognized/spam/network error                   |N   |N  |paperId: "asdasdasd"                                                                                       |Default    |-                                                 |Y                        |
|Y     |Published (No preprint)                           |Y   |Y  |pmid: "31302001"                                                                                           |PubMed     |https://pubmed.ncbi.nlm.nih.gov/31302001/         |Y                        |
|Y     |Preprint (No publication)                         |N   |Y  |doi: "10.1101/131102"                                                                                      |CrossRef   |https://www.biorxiv.org/content/10.1101/131102v1  |Y                        |
|Y     |Published after preprint                          |Y   |Y  |pmid: "29907957"                                                                                           |PubMed     |https://pubmed.ncbi.nlm.nih.gov/29907957/         |Y                        |
|Y     |Preprint (eLife) after preprint (bioRxiv + PubMed)|N   |Y  |doi: "10.7554/elife.90949"                                                                                 |CrossRef   |https://elifesciences.org/reviewed-preprints/90949|Y                        |
|Y     |Preprint (eLife) before preprint (Research Sq.)   |N   |Y  |doi: "10.7554/elife.85921.2"                                                                               |CrossRef   |https://elifesciences.org/reviewed-preprints/85921|Works by accident (top 5)|


Refs #1201 #961