### PR TITLE
Extract string tests for items that resemble DOIs and PMIDs

### DIFF
--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import logger from '../../../../logger';
 
 import { search, get } from './api.js';
+import { isDoi } from '../../../../../util';
 
 const ID_TYPE = Object.freeze({
   DOI: 'doi',
@@ -69,9 +70,8 @@ const find = async paperId => {
 
   const paperId2Type = paperId => {
     // 99.3% of CrossRef DOIs (https://www.crossref.org/blog/dois-and-matching-regular-expressions/)
-    const doiRegex = /^10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i;
     let IdType = ID_TYPE.TERM;
-    const isDoiLike = doiRegex.test( paperId );
+    const isDoiLike = isDoi( paperId );
     if( isDoiLike ) IdType = ID_TYPE.DOI;
     return IdType;
   };

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -7,6 +7,7 @@ import { ArticleIDError, getPubmedCitation } from '../../../../../util/pubmed';
 import {
   DEMO_ID
 } from '../../../../../config';
+import { isDigits, isDoi } from '../../../../../util';
 
 const ID_TYPE = Object.freeze({
   DOI: 'doi',
@@ -20,13 +21,9 @@ const pubTypeToExclude = [
 ];
 
 const paperId2Type = paperId => {
-  // 99.3% of CrossRef DOIs (https://www.crossref.org/blog/dois-and-matching-regular-expressions/)
-  const doiRegex = /^10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i;
-  const digitsRegex = /^[0-9.]+$/;
-
   let IdType = ID_TYPE.TITLE;
-  const isUidLike = digitsRegex.test( paperId );
-  const isDoiLike = doiRegex.test( paperId );
+  const isUidLike = isDigits( paperId );
+  const isDoiLike = isDoi( paperId );
 
   if( isDoiLike ) {
     IdType = ID_TYPE.DOI;

--- a/src/util/is.js
+++ b/src/util/is.js
@@ -9,4 +9,15 @@ function isServer(){
   return !isClient();
 }
 
-export { isClient, isServer };
+function isDoi( str ){
+  // 99.3% of CrossRef DOIs (https://www.crossref.org/blog/dois-and-matching-regular-expressions/)
+  const doiRegex = /^10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i;
+  return doiRegex.test( str );
+}
+
+function isDigits( str ){
+  const digitsRegex = /^[0-9.]+$/;
+  return  digitsRegex.test( str );
+}
+
+export { isClient, isServer, isDoi, isDigits };


### PR DESCRIPTION
Checking for a DOI-like string comes up more often, especially when extracting from plain text fields.