### PR TITLE
Zero-input route to new, blank Document

### DIFF
--- a/src/client/components/request-form.js
+++ b/src/client/components/request-form.js
@@ -40,10 +40,10 @@ class RequestForm extends Component {
 
       if(titleEl){
         focusDomElement(titleEl);
-      } 
+      }
     }, 50);
 
-    this.onCloseCTA = () => this.reset();
+    this.onCloseCTA = () => {};
     this.onOpenCTA = () => this.focusTitle();
   }
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -696,19 +696,28 @@ const generateSitemap = () => {
  * as the POST /api/document/ route.
  */
 const blankDocumentJson = () => {
-  const id = undefined;
   const secret = uuid();
-  const provided = {};
-  const article = createPubmedArticle({});
-  const handleDocCreation = ({ docDb, eleDb }) => createDoc({ docDb, eleDb, id, secret, provided });
-  const setStatus = doc => tryPromise( () => doc.initiate() ).then( () => doc );
-  const fillBlankArticle = doc => tryPromise( () => doc.article( article ) ).then( () => doc );
+  const handleDocCreation = ({ docDb, eleDb }) => {
+    const id = undefined;
+    const provided = {};
+    return createDoc({ docDb, eleDb, id, secret, provided });
+  };
+  const setStatus = doc => doc.initiate().then( () => doc );
+  const stubArticle = doc => {
+    const article = createPubmedArticle({});
+    return doc.article( article ).then( () => doc );
+  };
+  const stubCorrespondence = doc => {
+    const error = new EmailError('Blank email');
+    return doc.issues({ authorEmail: { error, message: error.message } }).then( () => doc );
+  };
 
   return tryPromise( () => createSecret({ secret }) )
     .then( loadTables )
     .then( handleDocCreation )
-    .then( fillBlankArticle )
     .then( setStatus )
+    .then( stubArticle )
+    .then( stubCorrespondence )
     .then( getDocJson );
 };
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -692,6 +692,27 @@ const generateSitemap = () => {
 };
 
 /**
+ * Create a new, blank document JSON representation, with the same format and caveats
+ * as the POST /api/document/ route.
+ */
+const blankDocumentJson = () => {
+  const id = undefined;
+  const secret = uuid();
+  const provided = {};
+  const article = createPubmedArticle({});
+  const handleDocCreation = ({ docDb, eleDb }) => createDoc({ docDb, eleDb, id, secret, provided });
+  const setStatus = doc => tryPromise( () => doc.initiate() ).then( () => doc );
+  const fillBlankArticle = doc => tryPromise( () => doc.article( article ) ).then( () => doc );
+
+  return tryPromise( () => createSecret({ secret }) )
+    .then( loadTables )
+    .then( handleDocCreation )
+    .then( fillBlankArticle )
+    .then( setStatus )
+    .then( getDocJson );
+};
+
+/**
  * @swagger
  *
  * /api/document/zip:
@@ -2569,7 +2590,7 @@ const getRelatedPapersForNetwork = async doc => {
 };
 
 export default http;
-export { getDocumentJson,
+export { getDocumentJson, blankDocumentJson,
   loadTables, loadDoc, fillDocArticle, updateRelatedPapers,
   fillDocAuthorProfiles,
   generateSitemap,

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -702,14 +702,21 @@ const blankDocumentJson = () => {
     const provided = {};
     return createDoc({ docDb, eleDb, id, secret, provided });
   };
-  const setStatus = doc => doc.initiate().then( () => doc );
-  const stubArticle = doc => {
-    const article = createPubmedArticle({});
-    return doc.article( article ).then( () => doc );
+  const setStatus = async doc => {
+    await doc.initiate();
+    return doc;
   };
-  const stubCorrespondence = doc => {
+  const stubArticle = async doc => {
+    const article = createPubmedArticle({});
+    const error = new ArticleIDError('Blank paperId');
+    await doc.article( article );
+    await doc.issues({ paperId: { error, message: error.message } });
+    return doc;
+  };
+  const stubCorrespondence = async doc => {
     const error = new EmailError('Blank email');
-    return doc.issues({ authorEmail: { error, message: error.message } }).then( () => doc );
+    await doc.issues({ authorEmail: { error, message: error.message } });
+    return doc;
   };
 
   return tryPromise( () => createSecret({ secret }) )

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { generateSitemap, getDocumentJson } from './api/document';
+import { generateSitemap, getDocumentJson, blankDocumentJson } from './api/document';
 import { TWITTER_ACCOUNT_NAME, BASE_URL, EMAIL_ADDRESS_INFO, NODE_ENV, GTM_ID } from '../../config';
 
 const http = express.Router();
@@ -18,9 +18,16 @@ const getDocumentPage = function(req, res) {
   );
 };
 
+const newDocumentPage = function(req, res) {
+  ( blankDocumentJson()
+    .then( doc => res.redirect( 302, doc.privateUrl ))
+    .catch( () => res.render( '404', { EMAIL_ADDRESS_INFO } ) )
+  );
+};
+
 http.get('/robots.txt', function( req, res ) {
   res.set('Content-Type', 'text/plain');
-  const text = `User-agent: *\nAllow: /\n\nSitemap: ${BASE_URL}/sitemap.xml`;
+  const text = `User-agent: *\nAllow: /\nDisallow: /document/new\n\nSitemap: ${BASE_URL}/sitemap.xml`;
   res.send( text );
 });
 
@@ -31,6 +38,7 @@ http.get('/sitemap.xml', function( req, res, next ) {
     .catch( next );
 });
 
+http.get('/document/new', newDocumentPage);
 http.get('/document/:id/:secret', getDocumentPage);
 http.get('/document/:id', getDocumentPage);
 


### PR DESCRIPTION
Created a new route `/document/new` that will create a new, blank Document with article and correspondence information stubbed out (so it is flagged as missing in admin). Updated robots.txt to get this route disallowed.

**Case: No author information provided**
<img src="https://github.com/PathwayCommons/factoid/assets/4706307/4cdc1dac-990c-4cc0-92d1-2f4dba5a81cb" height="350px"/>

**Case: Author information provided**
<img src="https://github.com/PathwayCommons/factoid/assets/4706307/6150a177-4b36-41bf-b75b-3501ba03778b" height="350px"/>

**Admin view**
<img width="949" alt="Screenshot 2023-11-27 at 4 06 59 PM" src="https://github.com/PathwayCommons/factoid/assets/4706307/41b727f1-0076-440e-a96f-f9352e8400c6">


Refs #1056