### PR TITLE
Explorer view: Handling preprints

### DIFF
--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -72,7 +72,8 @@ export class InfoPanel extends Component {
     const retractedPubType = _.find( citation.pubTypes, ['UI', 'D016441'] );
     const retractFlag = retractedPubType ? h('span.editor-info-flag.super-salient-button.danger', retractedPubType.value) : null;
 
-    const hasArticleMetadata = pmid != null || doi != null;
+    const hasArticleId = pmid != null || doi != null;
+    const hasRelatedPapers = !_.isEmpty( document.relatedPapers() );
 
     return h('div.editor-info-panel', [
       h('div.editor-info-flags', [ retractFlag ]),
@@ -97,24 +98,23 @@ export class InfoPanel extends Component {
 
       h(Credits, { controller, bus, document }),
 
-      hasArticleMetadata ? h('div.editor-info-links', [
-        h( doi ? 'a.editor-info-link.plain-link': 'div.editor-info-link', doi ? { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }: {}, reference),
-        pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
-        h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${ doi ?  doi : ( "\u0022" + title + "\u0022") }` }, 'Google Scholar')
-      ]) : null,
-
-      abstract ? h('div.editor-info-main-sections', [
-        h('div.editor-info-abstract-section.editor-info-main-section', [
-          h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),
-          h('div.editor-info-abstract-content', abstract ? abstract : document.toText() )
+      hasArticleId ? [
+        h('div.editor-info-links', [
+          h( doi ? 'a.editor-info-link.plain-link': 'div.editor-info-link', doi ? { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }: {}, reference),
+          pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
+          h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${ doi ?  doi : ( "\u0022" + title + "\u0022") }` }, 'Google Scholar')
         ]),
-        h('div.editor-info-related-papers-section.editor-info-main-section', [
-          h('div.editor-info-section-title', 'Recommended articles'),
-          h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
+        h('div.editor-info-main-sections', [
+          abstract ? h('div.editor-info-abstract-section.editor-info-main-section', [
+            h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),
+            h('div.editor-info-abstract-content', abstract ? abstract : document.toText() )
+          ]) : null,
+          hasRelatedPapers ? h('div.editor-info-related-papers-section.editor-info-main-section', [
+            h('div.editor-info-section-title', 'Recommended articles'),
+            h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
+          ]) : null
         ])
-      ]) : null,
-
-      !hasArticleMetadata && !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
+      ] : !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
     ]);
   }
 }

--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -98,23 +98,23 @@ export class InfoPanel extends Component {
 
       h(Credits, { controller, bus, document }),
 
-      hasArticleId ? [
-        h('div.editor-info-links', [
-          h( doi ? 'a.editor-info-link.plain-link': 'div.editor-info-link', doi ? { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }: {}, reference),
-          pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
-          h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${ doi ?  doi : ( "\u0022" + title + "\u0022") }` }, 'Google Scholar')
-        ]),
-        h('div.editor-info-main-sections', [
-          abstract ? h('div.editor-info-abstract-section.editor-info-main-section', [
-            h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),
-            h('div.editor-info-abstract-content', abstract ? abstract : document.toText() )
-          ]) : null,
-          hasRelatedPapers ? h('div.editor-info-related-papers-section.editor-info-main-section', [
-            h('div.editor-info-section-title', 'Recommended articles'),
-            h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
-          ]) : null
-        ])
-      ] : !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
+      h('div.editor-info-links', [
+        reference ? h( doi ? 'a.editor-info-link.plain-link': 'div.editor-info-link', doi ? { target: '_blank', href: `${DOI_LINK_BASE_URL}${doi}` }: {}, reference) : null,
+        pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
+        h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${( "\u0022" + title + "\u0022") }`}, 'Google Scholar')
+      ]),
+      h('div.editor-info-main-sections', [
+        abstract ? h('div.editor-info-abstract-section.editor-info-main-section', [
+          h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),
+          h('div.editor-info-abstract-content', abstract ? abstract : document.toText() )
+        ]) : null,
+        hasRelatedPapers ? h('div.editor-info-related-papers-section.editor-info-main-section', [
+          h('div.editor-info-section-title', 'Recommended articles'),
+          h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
+        ]) : null
+      ]),
+
+      !hasArticleId && !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
     ]);
   }
 }

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -435,12 +435,12 @@
   }
 
   .editor-info-abstract-section {
-    width: 50%;
+    min-width: 50%;
     box-sizing: border-box;
     padding-right: 2em;
   }
 
-  .editor-info-related-papers-section {
+  /* .editor-info-related-papers-section {
     flex: 1 1;
-  }
+  } */
 }


### PR DESCRIPTION
Short term fix for Explorer, specifically for preprints;
- Since the related papers system is tied to the use of PMIDs, preprints will simply ignore them on the main 'document' page.
- Google Scholar link uses title as query (instead of DOI)  to cover edge case where some preprint DOIs aren't indexed 

### Case: Preprint
<img src="https://github.com/PathwayCommons/factoid/assets/4706307/853a353e-d6b0-4f09-9c4c-a37facef2714" width="500px" />

### Case: No article found
<img src="https://github.com/PathwayCommons/factoid/assets/4706307/5dab68af-f977-4a1b-94f5-c34b16e99615" width="500px" /> 

### Case: No abstract
<img src="https://github.com/PathwayCommons/factoid/assets/4706307/64dd6b06-d33b-4e84-a065-4f6254b1c7d1" width="500px" /> 

Refs #1215