### PR TITLE
Hide uninformative 'submitted/public' admin icon.

### DIFF
--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -320,9 +320,9 @@ class DocumentManagementDocumentComponent extends React.Component {
             h( 'i.material-icons.hide-by-default.invalid', {
               className: makeClassList({ 'show': hasIssues( doc ) })
             }, 'warning' ),
-            h( 'i.material-icons.hide-by-default.complete', {
-              className: makeClassList({ 'show': doc.submitted() || doc.isPublic() })
-            }, 'check_circle' ),
+            // h( 'i.material-icons.hide-by-default.complete', {
+            //   className: makeClassList({ 'show': doc.submitted() || doc.isPublic() })
+            // }, 'check_circle' ),
             h( 'i.material-icons.hide-by-default.mute', {
               className: makeClassList({ 'show': doc.trashed() })
             }, 'delete' )


### PR DESCRIPTION
A document with. a check (public/submitted) is redundant. 