### PR TITLE
Support Crossref "relations"

### DIFF
--- a/src/server/routes/api/document/crossref/map.js
+++ b/src/server/routes/api/document/crossref/map.js
@@ -184,15 +184,15 @@ const getCommentsCorrectionsList = record => {
   ]);
   const { relation } = record;
   if( relation ){
-    for (let key of Object.keys(relation)) {
-      if( CRRELATION_REFTYPE_MAP.has( key ) ){
-        const refType = CRRELATION_REFTYPE_MAP.get( key );
-        const entries = relation[key];
-        for (let entry of entries) {
-          const { id, 'id-type': idType } = entry;
+    for (let crRelationType of Object.keys(relation)) {
+      if( CRRELATION_REFTYPE_MAP.has( crRelationType ) ){
+        const RefType = CRRELATION_REFTYPE_MAP.get( crRelationType );
+        const relations = relation[crRelationType];
+        for (let rel of relations) {
+          const { id, 'id-type': idType } = rel;
           if( CRRELATION_IDTYPES.has( idType ) ){
             const CommentsCorrections = {
-              RefType: refType,
+              RefType,
               PMID: null,
               DOI: null,
               RefSource: ''

--- a/src/server/routes/api/document/crossref/map.js
+++ b/src/server/routes/api/document/crossref/map.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { format } from 'date-fns';
-import { createPubmedArticle } from '../../../../../util/pubmed';
+import { COMMENTSCORRECTIONS_REFTYPE, createPubmedArticle } from '../../../../../util/pubmed';
 
 /**
  * getAbstract
@@ -169,6 +169,50 @@ const getPublicationTypeList = record => {
   return PublicationTypeList;
 };
 
+const getCommentsCorrectionsList = record => {
+  const CommentsCorrectionsList = [];
+  const CRRELATION_REFTYPE_MAP = new Map([
+    ['is-preprint-of', COMMENTSCORRECTIONS_REFTYPE.UpdateIn],
+    ['has-preprint', COMMENTSCORRECTIONS_REFTYPE.UpdateOf],
+    ['is-comment-on', COMMENTSCORRECTIONS_REFTYPE.CommentOn],
+    ['has-comment',  COMMENTSCORRECTIONS_REFTYPE.CommentIn],
+    ['isSupplementedBy',  COMMENTSCORRECTIONS_REFTYPE.AssociatedDataset]
+  ]);
+  const CRRELATION_IDTYPES = new Set([
+    'doi',
+    'pmid'
+  ]);
+  const { relation } = record;
+  if( relation ){
+    for (let key of Object.keys(relation)) {
+      if( CRRELATION_REFTYPE_MAP.has( key ) ){
+        const refType = CRRELATION_REFTYPE_MAP.get( key );
+        const entries = relation[key];
+        for (let entry of entries) {
+          const { id, 'id-type': idType } = entry;
+          if( CRRELATION_IDTYPES.has( idType ) ){
+            const CommentsCorrections = {
+              RefType: refType,
+              PMID: null,
+              DOI: null,
+              RefSource: ''
+            };
+            if( idType === 'doi' ){
+              _.set(CommentsCorrections, 'DOI', id);
+              _.set(CommentsCorrections, 'RefSource', `doi: ${id}`);
+            } else if( idType === 'pmid' ){
+              _.set(CommentsCorrections, 'PMID', id);
+              _.set(CommentsCorrections, 'RefSource', `pmid: ${id}`);
+            }
+            CommentsCorrectionsList.push(CommentsCorrections);
+          }
+        }
+      }
+    }
+  }
+  return CommentsCorrectionsList;
+};
+
 const getMedlineCitation = record => {
   const { abstract, title, author } = record;
   const Abstract = getAbstract( abstract );
@@ -176,7 +220,8 @@ const getMedlineCitation = record => {
   const AuthorList = asAuthorList( author );
   const Journal = getJournal( record );
   const PublicationTypeList = getPublicationTypeList( record );
-  const MedlineCitation = { Article: { Abstract, ArticleTitle, AuthorList, Journal, PublicationTypeList } };
+  const CommentsCorrectionsList = getCommentsCorrectionsList( record );
+  const MedlineCitation = { Article: { Abstract, ArticleTitle, AuthorList, Journal, PublicationTypeList }, CommentsCorrectionsList };
   return MedlineCitation;
 };
 

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -305,4 +305,27 @@ class ArticleIDError extends Error {
   }
 }
 
-export { getPubmedCitation, createPubmedArticle, ArticleIDError, findOrcidIdentifier };
+const COMMENTSCORRECTIONS_REFTYPE = Object.freeze({
+  AssociatedDataset: 'AssociatedDataset',
+  AssociatedPublication: 'AssociatedPublication',
+  CommentOn: 'CommentOn',
+  CommentIn: 'CommentIn',
+  ErratumIn: 'ErratumIn',
+  ErratumFor: 'ErratumFor',
+  ExpressionOfConcernIn: 'ExpressionOfConcernIn',
+  ExpressionOfConcernFor: 'ExpressionOfConcernFor',
+  RepublishedFrom: 'RepublishedFrom',
+  RepublishedIn: 'RepublishedIn',
+  RetractionOf: 'RetractionOf',
+  RetractionIn: 'RetractionIn',
+  UpdateIn: 'UpdateIn',
+  UpdateOf: 'UpdateOf',
+  SummaryForPatientsIn: 'SummaryForPatientsIn',
+  OriginalReportIn: 'OriginalReportIn',
+  ReprintOf: 'ReprintOf',
+  ReprintIn: 'ReprintIn',
+  Cites: 'Cites'
+});
+
+
+export { getPubmedCitation, createPubmedArticle, ArticleIDError, findOrcidIdentifier, COMMENTSCORRECTIONS_REFTYPE };

--- a/test/crossRef/10.7554_elife.86689.3.json
+++ b/test/crossRef/10.7554_elife.86689.3.json
@@ -1,0 +1,331 @@
+{
+  "indexed": {
+    "date-parts": [
+      [
+        2024,
+        3,
+        4
+      ]
+    ],
+    "date-time": "2024-03-04T21:37:09Z",
+    "timestamp": 1709588229648
+  },
+  "posted": {
+    "date-parts": [
+      [
+        2023,
+        8,
+        25
+      ]
+    ]
+  },
+  "group-title": "elife",
+  "reference-count": 0,
+  "publisher": "eLife Sciences Publications, Ltd",
+  "license": [
+    {
+      "start": {
+        "date-parts": [
+          [
+            2023,
+            8,
+            25
+          ]
+        ],
+        "date-time": "2023-08-25T00:00:00Z",
+        "timestamp": 1692921600000
+      },
+      "content-version": "unspecified",
+      "delay-in-days": 0,
+      "URL": "http:\/\/creativecommons.org\/licenses\/by\/4.0\/"
+    }
+  ],
+  "content-domain": {
+    "domain": [],
+    "crossmark-restriction": false
+  },
+  "short-container-title": [],
+  "abstract": "<jats:p>The primary cilium plays important roles in regulating cell differentiation, signal transduction, and tissue organization. Dysfunction of the primary cilium can lead to ciliopathies and cancer. The formation and organization of the primary cilium are highly associated with cell polarity proteins, such as the apical polarity protein CRB3. However, the molecular mechanisms by which CRB3 regulates ciliogenesis and the location of CRB3 remain unknown. Here, we show that CRB3, as a navigator, regulates vesicle trafficking in γ-TuRC assembly during ciliogenesis and cilium-related Hh and Wnt signaling pathways in tumorigenesis. Crb3 knockout mice display severe defects of the primary cilium in the mammary ductal lumen and renal tubule, while mammary epithelial-specific Crb3 knockout mice exhibit the promotion of ductal epithelial hyperplasia and tumorigenesis. CRB3 is essential for lumen formation and ciliary assembly in the mammary epithelium. We demonstrate that CRB3 localizes to the basal body and that CRB3 trafficking is mediated by Rab11-positive endosomes. Significantly, CRB3 interacts with Rab11 to navigate GCP6\/Rab11 trafficking vesicles to CEP290, resulting in intact γ-TuRC assembly. In addition, CRB3-depleted cells are unresponsive to the activation of the Hh signaling pathway, while CRB3 regulates the Wnt signaling pathway. Therefore, our studies reveal the molecular mechanisms by which CRB3 recognizes Rab11-positive endosomes to facilitate ciliogenesis, and regulates cilium-related signaling pathways in tumorigenesis.<\/jats:p>",
+  "DOI": "10.7554\/elife.86689.3",
+  "type": "posted-content",
+  "created": {
+    "date-parts": [
+      [
+        2023,
+        8,
+        25
+      ]
+    ],
+    "date-time": "2023-08-25T11:05:14Z",
+    "timestamp": 1692961514000
+  },
+  "source": "Crossref",
+  "is-referenced-by-count": 0,
+  "title": [
+    "CRB3 navigates Rab11 trafficking vesicles to promote γTuRC assembly during ciliogenesis"
+  ],
+  "prefix": "10.7554",
+  "author": [
+    {
+      "given": "Bo",
+      "family": "Wang",
+      "sequence": "first",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Zheyong",
+      "family": "Liang",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Department of Cardiovascular Surgery, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Tan",
+      "family": "tan",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Precision Medicine, Affiliated to The First People’s Hospital of Chenzhou, University of South China, Chenzhou 423000, Hunan, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Miao",
+      "family": "Zhang",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Yina",
+      "family": "Jiang",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Department of Pathology, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Yangyang",
+      "family": "Shang",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Xiaoqian",
+      "family": "Gao",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Shaoran",
+      "family": "Song",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Ruiqi",
+      "family": "Wang",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "He",
+      "family": "Chen",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Jie",
+      "family": "Liu",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Juan",
+      "family": "Li",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Yu",
+      "family": "Ren",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Department of Breast Surgery, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    },
+    {
+      "given": "Peijun",
+      "family": "Liu",
+      "sequence": "additional",
+      "affiliation": [
+        {
+          "name": "Center for Translational Medicine, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        },
+        {
+          "name": "Key Laboratory for Tumor Precision Medicine of Shaanxi Province, the First Affiliated Hospital of Xi’an Jiaotong University, Xi’an 710061, Shaanxi, P.R. China"
+        }
+      ]
+    }
+  ],
+  "member": "4374",
+  "container-title": [],
+  "original-title": [],
+  "deposited": {
+    "date-parts": [
+      [
+        2023,
+        8,
+        25
+      ]
+    ],
+    "date-time": "2023-08-25T11:05:14Z",
+    "timestamp": 1692961514000
+  },
+  "score": 1,
+  "resource": {
+    "primary": {
+      "URL": "https:\/\/elifesciences.org\/reviewed-preprints\/86689v3"
+    }
+  },
+  "subtitle": [],
+  "short-title": [],
+  "issued": {
+    "date-parts": [
+      [
+        2023,
+        8,
+        25
+      ]
+    ]
+  },
+  "references-count": 0,
+  "URL": "http:\/\/dx.doi.org\/10.7554\/elife.86689.3",
+  "relation": {
+    "has-version": [
+      {
+        "id-type": "doi",
+        "id": "10.7554\/eLife.86689.2",
+        "asserted-by": "subject"
+      },
+      {
+        "id-type": "doi",
+        "id": "10.7554\/eLife.86689.4",
+        "asserted-by": "object"
+      }
+    ],
+    "is-version-of": [
+      {
+        "id-type": "doi",
+        "id": "10.1101\/2023.02.15.528649",
+        "asserted-by": "subject"
+      }
+    ],
+    "has-review": [
+      {
+        "id-type": "doi",
+        "id": "10.7554\/eLife.86689.3.sa2",
+        "asserted-by": "object"
+      },
+      {
+        "id-type": "doi",
+        "id": "10.7554\/eLife.86689.3.sa1",
+        "asserted-by": "object"
+      },
+      {
+        "id-type": "doi",
+        "id": "10.7554\/eLife.86689.3.sa0",
+        "asserted-by": "object"
+      }
+    ],
+    "is-preprint-of": [
+      {
+        "id-type": "doi",
+        "id": "10.7554\/eLife.86689.4",
+        "asserted-by": "object"
+      }
+    ]
+  },
+  "published": {
+    "date-parts": [
+      [
+        2023,
+        8,
+        25
+      ]
+    ]
+  },
+  "subtype": "preprint"
+}

--- a/test/crossref/map.js
+++ b/test/crossref/map.js
@@ -9,6 +9,7 @@ import work_doi_4 from './10.1101_2022.09.28.22280453.json';
 import work_doi_5 from './10.1016_j.molcel.2019.06.008.json';
 import work_doi_6 from './10.7554_eLife.68292.json';
 import work_doi_7 from './10.3030_101067344.json';
+import work_doi_8 from './10.7554_elife.86689.3.json';
 
 describe('map', function(){
 
@@ -97,6 +98,32 @@ describe('map', function(){
 
         }); // PublicationTypeList
 
+        describe('CommentsCorrectionsList', () => {
+
+          describe('RefType: UpdateIn', () => {
+            const RefType = 'UpdateIn';
+            const { MedlineCitation: { CommentsCorrectionsList } } = toPubMedArticle( work_doi_8 );
+
+            it('Should contain a CommentsCorrectionsList with an element', () => {
+              expect( CommentsCorrectionsList.length ).to.not.equal( 0 );
+            });
+
+            it('Should have a CommentsCorrections with attributes: RefType, RefSource, DOI', () => {
+              const commentsCorrections = _.find(CommentsCorrectionsList, ['RefType', RefType ]);
+              expect( commentsCorrections ).to.have.property( 'DOI' );
+              expect( commentsCorrections ).to.have.property( 'RefType' );
+              expect( commentsCorrections ).to.have.property( 'RefSource' );
+            });
+
+            it('Should have a CommentsCorrections with DOI-based values: RefSource, DOI', () => {
+              const commentsCorrections = _.find(CommentsCorrectionsList, ['RefType', RefType ]);
+              expect( commentsCorrections.DOI ).to.match(/^10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i);
+              expect( commentsCorrections.RefSource ).to.match(/^doi: 10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i);
+            });
+          });
+
+        }); // CommentsCorrectionsList
+
       }); // Article
 
     }); // type: posted-content, subtype: preprint
@@ -170,7 +197,7 @@ describe('map', function(){
       describe('article 2', () => {
 
         describe('MedlineCitation > Article', () => {
-          const { MedlineCitation: { Article } } = toPubMedArticle( work_doi_6 );
+          const { MedlineCitation: { Article, CommentsCorrectionsList } } = toPubMedArticle( work_doi_6 );
 
           describe('Text fields (ArticleTitle, Abstract)', () => {
             it('Should correctly map Abstract and ArticleTitle', () => {
@@ -231,6 +258,31 @@ describe('map', function(){
             });
 
           }); // PublicationTypeList
+
+          describe('CommentsCorrectionsList', () => {
+
+            describe('RefType: UpdateOf', () => {
+              const RefType = 'UpdateOf';
+
+              it('Should contain a CommentsCorrectionsList with an element', () => {
+                expect( CommentsCorrectionsList.length ).to.not.equal( 0 );
+              });
+
+              it('Should have a CommentsCorrections with attributes: RefType, RefSource, DOI', () => {
+                const commentsCorrections = _.find(CommentsCorrectionsList, ['RefType', RefType ]);
+                expect( commentsCorrections ).to.have.property( 'DOI' );
+                expect( commentsCorrections ).to.have.property( 'RefType' );
+                expect( commentsCorrections ).to.have.property( 'RefSource' );
+              });
+
+              it('Should have a CommentsCorrections with DOI-based values: RefSource, DOI', () => {
+                const commentsCorrections = _.find(CommentsCorrectionsList, ['RefType', RefType ]);
+                expect( commentsCorrections.DOI ).to.match(/^10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i);
+                expect( commentsCorrections.RefSource ).to.match(/^doi: 10\.\d{4,9}\/[-._;()/:A-Z0-9]+$/i);
+              });
+            });
+
+          }); // CommentsCorrectionsList
 
         }); // article 2
 


### PR DESCRIPTION
Crossref support for capturing information on a subset of [intra- and inter-work relationships](https://www.crossref.org/documentation/schema-library/markup-guide-metadata-segments/relationships/) when they provide either a PMID or DOI:

-  'is-preprint-of': Preprint referencing a publication
-  'has-preprint': Publication referencing a preprint
- other: 'is-comment-on', 'has-comment', 'isSupplementedBy'
  - selected because they have a reasonable mapping to [PubMed schema](https://www.nlm.nih.gov/bsd/mms/medlineelements.html#cc)

Refs https://github.com/PathwayCommons/factoid/issues/1203#issuecomment-2064055418