### PR TITLE
Show links relation papers in the Explorer

### DIFF
--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -105,9 +105,6 @@ export class InfoPanel extends Component {
         pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${( "\u0022" + title + "\u0022") }`}, 'Google Scholar')
       ]),
-      hasRelations ?
-        h('div.editor-info-links.relations', relations.map( ({ reference, url }) => h('a.editor-info-link.plain-link', { target: '_blank', href: url }, reference ) ) ) :
-        null,
       h('div.editor-info-main-sections', [
         abstract ? h('div.editor-info-abstract-section.editor-info-main-section', [
           h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),
@@ -118,6 +115,13 @@ export class InfoPanel extends Component {
           h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
         ]) : null
       ]),
+      hasRelations ?
+        h('div.editor-info-relations', relations.map( ({ type, links }) => [
+          h('div.editor-info-relation', [
+            h('h4.editor-info-relation-type', type),
+            h('div.editor-info-links', links.map( ({ url, reference }) => h('a.editor-info-link.plain-link', { target: '_blank', href: url }, reference ) ) )
+          ])
+        ])): null,
 
       !hasArticleId && !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
     ]);

--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -67,13 +67,15 @@ export class InfoPanel extends Component {
     const citation = document.citation();
     // authorProfiles may not be existing for the older documents
     const authorProfiles = document.authorProfiles() || citation.authors.authorList;
-    const { pmid, title = 'Untitled article', reference, doi, abstract } = citation;
+    const { pmid, title = 'Untitled article', reference, doi, abstract, relations } = citation;
 
     const retractedPubType = _.find( citation.pubTypes, ['UI', 'D016441'] );
     const retractFlag = retractedPubType ? h('span.editor-info-flag.super-salient-button.danger', retractedPubType.value) : null;
 
     const hasArticleId = pmid != null || doi != null;
     const hasRelatedPapers = !_.isEmpty( document.relatedPapers() );
+
+    const hasRelations = !_.isEmpty( relations );
 
     return h('div.editor-info-panel', [
       h('div.editor-info-flags', [ retractFlag ]),
@@ -103,6 +105,9 @@ export class InfoPanel extends Component {
         pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${( "\u0022" + title + "\u0022") }`}, 'Google Scholar')
       ]),
+      hasRelations ?
+        h('div.editor-info-links.relations', relations.map( ({ reference, url }) => h('a.editor-info-link.plain-link', { target: '_blank', href: url }, reference ) ) ) :
+        null,
       h('div.editor-info-main-sections', [
         abstract ? h('div.editor-info-abstract-section.editor-info-main-section', [
           h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),

--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -105,6 +105,13 @@ export class InfoPanel extends Component {
         pmid ? h('a.editor-info-link.plain-link', { target: '_blank', href: `${PUBMED_LINK_BASE_URL}${pmid}` }, 'PubMed') : null,
         h('a.editor-info-link.plain-link', { target: '_blank', href: `${GOOGLE_SCHOLAR_BASE_URL}${( "\u0022" + title + "\u0022") }`}, 'Google Scholar')
       ]),
+      hasRelations ?
+        h('div.editor-info-relations', relations.map( ({ type, links }, i) => [
+          h('div.editor-info-relation', { key: i.toString() }, [
+            h('span.editor-info-relation-type', `${type} `),
+            h('span.editor-info-links', links.map( ({ url, reference }, j ) =>  h('a.editor-info-link.plain-link', { key: j.toString(), target: '_blank', href: url }, reference ) ) )
+          ])
+        ])): null,
       h('div.editor-info-main-sections', [
         abstract ? h('div.editor-info-abstract-section.editor-info-main-section', [
           h('div.editor-info-section-title', abstract ? 'Abstract': 'Summary'),
@@ -115,13 +122,6 @@ export class InfoPanel extends Component {
           h('div.editor-info-related-papers', [ h(RelatedPapers, { document, source: document }) ])
         ]) : null
       ]),
-      hasRelations ?
-        h('div.editor-info-relations', relations.map( ({ type, links }) => [
-          h('div.editor-info-relation', [
-            h('h4.editor-info-relation-type', type),
-            h('div.editor-info-links', links.map( ({ url, reference }) => h('a.editor-info-link.plain-link', { target: '_blank', href: url }, reference ) ) )
-          ])
-        ])): null,
 
       !hasArticleId && !document.editable() ? h('div.editor-coming-soon-placeholder', `Biofactoid is looking for more information about this article from PubMed and pathway databases.  This information will appear here as soon as it is available.`) : null
     ]);

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -317,6 +317,14 @@
   line-height: 1.4;
 }
 
+.editor-info-relations .editor-info-links {
+  margin: 0.5em 0;
+}
+
+.editor-info-relation-type {
+  margin: 1em 0 0.25em;
+}
+
 .editor-info-author-spacer {
   margin-right: 0.333em;
 }

--- a/src/styles/editor/editor.css
+++ b/src/styles/editor/editor.css
@@ -317,12 +317,16 @@
   line-height: 1.4;
 }
 
-.editor-info-relations .editor-info-links {
-  margin: 0.5em 0;
+.editor-info-relations {
+  margin-bottom: 0.8em;
+}
+
+.editor-info-relation {
+  margin: 0.25em 0;
 }
 
 .editor-info-relation-type {
-  margin: 1em 0 0.25em;
+  font-style: italic;
 }
 
 .editor-info-author-spacer {

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -1,7 +1,30 @@
 import _ from 'lodash';
 import { parse as dateParse } from 'date-fns';
+import { DOI_LINK_BASE_URL, PUBMED_LINK_BASE_URL } from '../config';
 
 const NUM_AUTHORS_SHOWING = 4;
+
+const COMMENTSCORRECTIONS_REFTYPE = Object.freeze({
+  AssociatedDataset: 'AssociatedDataset',
+  AssociatedPublication: 'AssociatedPublication',
+  CommentOn: 'CommentOn',
+  CommentIn: 'CommentIn',
+  ErratumIn: 'ErratumIn',
+  ErratumFor: 'ErratumFor',
+  ExpressionOfConcernIn: 'ExpressionOfConcernIn',
+  ExpressionOfConcernFor: 'ExpressionOfConcernFor',
+  RepublishedFrom: 'RepublishedFrom',
+  RepublishedIn: 'RepublishedIn',
+  RetractionOf: 'RetractionOf',
+  RetractionIn: 'RetractionIn',
+  UpdateIn: 'UpdateIn',
+  UpdateOf: 'UpdateOf',
+  SummaryForPatientsIn: 'SummaryForPatientsIn',
+  OriginalReportIn: 'OriginalReportIn',
+  ReprintOf: 'ReprintOf',
+  ReprintIn: 'ReprintIn',
+  Cites: 'Cites'
+});
 
 /**
  * getAuthorName
@@ -209,6 +232,31 @@ const getReferenceString = Journal => {
 
 const getArticleId = ( PubmedArticle, IdType ) => _.get( _.find( _.get( PubmedArticle, ['PubmedData', 'ArticleIdList'], [] ), [ 'IdType', IdType ] ), 'id', null );
 
+const getRelations = PubmedArticle => {
+  const REFTYPE_2_REF = new Map([
+    [COMMENTSCORRECTIONS_REFTYPE.UpdateIn, 'Update in'],
+    [COMMENTSCORRECTIONS_REFTYPE.UpdateOf, 'Update of']
+  ]);
+  const raw = _.get( PubmedArticle, [ 'MedlineCitation', 'CommentsCorrectionsList' ], [] );
+  const relations = raw.map( ({ RefType, PMID, RefSource, DOI }) => {
+    const hasPMID = !_.isNil( PMID );
+    const hasDOI = !_.isNil( DOI );
+    const hasRelation = REFTYPE_2_REF.has( RefType ) && ( hasPMID || hasDOI );
+    if ( !hasRelation ) return null;
+
+    let url, reference;
+    reference = `${REFTYPE_2_REF.get(RefType)} ${RefSource}`;
+    if( hasPMID ){
+      url = `${PUBMED_LINK_BASE_URL}${PMID}`;
+    } else if( DOI ){
+      url = `${DOI_LINK_BASE_URL}${DOI}`;
+    }
+    return ({ reference, url });
+  });
+
+  return _.compact( relations );
+};
+
 /**
  * getPubmedCitation
  *
@@ -238,7 +286,7 @@ const getPubmedCitation = PubmedArticle => {
   const doi = getArticleId( PubmedArticle, 'doi' );
   const pubTypes = _.get( Article, 'PublicationTypeList' ); //required
   const { ISODate } = getPubDate( _.get( Article, ['Journal', 'JournalIssue'] ) );
-  const relations = _.get( PubmedArticle, [ 'MedlineCitation', 'CommentsCorrectionsList'], [] );
+  const relations = getRelations( PubmedArticle );
 
   return { title, authors, reference, abstract, pmid, doi, pubTypes, ISODate, relations };
 };
@@ -304,28 +352,5 @@ class ArticleIDError extends Error {
     this.name = 'ArticleIDError';
   }
 }
-
-const COMMENTSCORRECTIONS_REFTYPE = Object.freeze({
-  AssociatedDataset: 'AssociatedDataset',
-  AssociatedPublication: 'AssociatedPublication',
-  CommentOn: 'CommentOn',
-  CommentIn: 'CommentIn',
-  ErratumIn: 'ErratumIn',
-  ErratumFor: 'ErratumFor',
-  ExpressionOfConcernIn: 'ExpressionOfConcernIn',
-  ExpressionOfConcernFor: 'ExpressionOfConcernFor',
-  RepublishedFrom: 'RepublishedFrom',
-  RepublishedIn: 'RepublishedIn',
-  RetractionOf: 'RetractionOf',
-  RetractionIn: 'RetractionIn',
-  UpdateIn: 'UpdateIn',
-  UpdateOf: 'UpdateOf',
-  SummaryForPatientsIn: 'SummaryForPatientsIn',
-  OriginalReportIn: 'OriginalReportIn',
-  ReprintOf: 'ReprintOf',
-  ReprintIn: 'ReprintIn',
-  Cites: 'Cites'
-});
-
 
 export { getPubmedCitation, createPubmedArticle, ArticleIDError, findOrcidIdentifier, COMMENTSCORRECTIONS_REFTYPE };

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import { parse as dateParse } from 'date-fns';
 import { DOI_LINK_BASE_URL, PUBMED_LINK_BASE_URL } from '../config';
-import { fromCamelCase } from './strings';
+import { fromCamelCase, onlyCapitalizeFirst } from './strings';
 
 const NUM_AUTHORS_SHOWING = 4;
 
@@ -246,7 +246,7 @@ const getRelations = PubmedArticle => {
   const raw = _.get( PubmedArticle, [ 'MedlineCitation', 'CommentsCorrectionsList' ], [] );
   const groups = _.groupBy( raw, 'RefType' );
   const relations = _.toPairs( groups ).map( ( [ RefType, CommentsCorrectionsList ] ) => {
-    const type = fromCamelCase( RefType );
+    const type = onlyCapitalizeFirst( fromCamelCase( RefType ) );
     const links = CommentsCorrectionsList.map( commentsCorrections2Link );
     return ({ type, links });
   });

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -30,4 +30,8 @@ const stripFinalPeriod = text => {
   return text;
 };
 
-export { stringDistanceMetric, longestCommonPrefixLength, truncateString, stripFinalPeriod };
+const fromCamelCase = str => {
+  return str.replace(/([a-z])([A-Z])/g, '$1 $2');
+};
+
+export { stringDistanceMetric, longestCommonPrefixLength, truncateString, stripFinalPeriod, fromCamelCase };

--- a/src/util/strings.js
+++ b/src/util/strings.js
@@ -34,4 +34,8 @@ const fromCamelCase = str => {
   return str.replace(/([a-z])([A-Z])/g, '$1 $2');
 };
 
-export { stringDistanceMetric, longestCommonPrefixLength, truncateString, stripFinalPeriod, fromCamelCase };
+const onlyCapitalizeFirst = str => {
+  return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
+};
+
+export { stringDistanceMetric, longestCommonPrefixLength, truncateString, stripFinalPeriod, fromCamelCase, onlyCapitalizeFirst };


### PR DESCRIPTION
Display any and all relations (aka PubMed CommentsCorrections) in the Explorer.

 ### Example 1: A preprint with an associated publication

<img width="500" alt="Screenshot 2024-04-24 at 3 51 40 PM" src="https://github.com/PathwayCommons/factoid/assets/4706307/e721212a-0276-452d-a507-45976177e32f">

 ### Example 2: A publication with an associated preprint

<img width="500" alt="Screenshot 2024-04-24 at 3 52 48 PM" src="https://github.com/PathwayCommons/factoid/assets/4706307/34fd3fdd-56a7-4fb0-9f81-ddb0d1b484f1">

 ### Example 3: A publication with an extreme number of relations

<img width="500" alt="Screenshot 2024-04-24 at 3 54 26 PM" src="https://github.com/PathwayCommons/factoid/assets/4706307/44cfe147-1e6b-4be3-89aa-c6a4be14be9c">

Refs #1203