### PR TITLE
More informative logging

### DIFF
--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -111,12 +111,18 @@ const findPreprint = async paperId => {
     }
 
   } catch( err ) {
-    logger.error( `crossref.findPreprint threw ${err.name}: ${err.message}` );
     if( err instanceof HTTPStatusError ){
       const { response } = err;
       const { url, headers } = response;
+      logger.error( `crossref.findPreprint threw ${err.name}: ${err.message}` );
       logger.error( `fetch URL: ${url}` );
       logger.error( headers.raw() );
+
+    } else if( err instanceof ArticleIDError ){
+      logger.info( `crossref.findPreprint threw ${err.name}: ${err.message}` );
+
+    } else {
+      logger.error( `crossref.findPreprint threw ${err.name}: ${err.message}` );
     }
     throw err;
   }

--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -119,7 +119,7 @@ const findPreprint = async paperId => {
       logger.error( headers.raw() );
 
     } else if( err instanceof ArticleIDError ){
-      logger.info( `crossref.findPreprint threw ${err.name}: ${err.message}` );
+      logger.debug( `crossref.findPreprint threw ${err.name}: ${err.message}` );
 
     } else {
       logger.error( `crossref.findPreprint threw ${err.name}: ${err.message}` );

--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -3,7 +3,7 @@ import logger from '../../../../logger';
 
 import { search, get } from './api.js';
 import { toPubMedArticle } from './map';
-import { isDoi } from '../../../../../util';
+import { HTTPStatusError, isDoi } from '../../../../../util';
 import { ArticleIDError } from '../../../../../util/pubmed';
 
 const ID_TYPE = Object.freeze({
@@ -111,7 +111,13 @@ const findPreprint = async paperId => {
     }
 
   } catch( err ) {
-    logger.error( `${err.name}: ${err.message}` );
+    logger.error( `crossref.findPreprint threw ${err.name}: ${err.message}` );
+    if( err instanceof HTTPStatusError ){
+      const { response } = err;
+      const { url, headers } = response;
+      logger.error( `fetch URL: ${url}` );
+      logger.error( headers.raw() );
+    }
     throw err;
   }
 };

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -112,7 +112,7 @@ const getPubmedArticle = async paperId => {
         logger.error( headers.raw() );
 
       } else if( err instanceof ArticleIDError ){
-        logger.info( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
+        logger.debug( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
 
       } else {
         logger.error( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -7,7 +7,7 @@ import { ArticleIDError, getPubmedCitation } from '../../../../../util/pubmed';
 import {
   DEMO_ID
 } from '../../../../../config';
-import { isDigits, isDoi } from '../../../../../util';
+import { HTTPStatusError, isDigits, isDoi } from '../../../../../util';
 
 const ID_TYPE = Object.freeze({
   DOI: 'doi',
@@ -93,6 +93,7 @@ const getPubmedArticle = async paperId => {
     try {
       const IdType = paperId2Type( paperId );
       const fieldOpts = IdType === ID_TYPE.TITLE ? { field: ID_TYPE.TITLE } : {};
+      // TODO - this should fetch when PMID-like, search otherwise
       const { searchHits } = await searchPubmed( paperId, fieldOpts );
       const PubmedArticle = await findMatchingPubmedArticle( paperId, IdType, searchHits );
 
@@ -103,7 +104,13 @@ const getPubmedArticle = async paperId => {
       }
 
     } catch( err ) {
-      logger.error( `${err.name}: ${err.message}` );
+      logger.error( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
+      if( err instanceof HTTPStatusError ){
+        const { response } = err;
+        const { url, headers } = response;
+        logger.error( `fetch URL: ${url}` );
+        logger.error( headers.raw() );
+      }
       throw err;
     }
   }

--- a/src/server/routes/api/document/pubmed/index.js
+++ b/src/server/routes/api/document/pubmed/index.js
@@ -104,12 +104,18 @@ const getPubmedArticle = async paperId => {
       }
 
     } catch( err ) {
-      logger.error( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
       if( err instanceof HTTPStatusError ){
         const { response } = err;
         const { url, headers } = response;
+        logger.error( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
         logger.error( `fetch URL: ${url}` );
         logger.error( headers.raw() );
+
+      } else if( err instanceof ArticleIDError ){
+        logger.info( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
+
+      } else {
+        logger.error( `pubmed.getPubmedArticle threw ${err.name}: ${err.message}` );
       }
       throw err;
     }

--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -117,18 +117,16 @@ const trashDocs = async () => {
 /**
  * Update Document data
  */
-let hasUpdated = false;
 const update = async () => {
   logger.debug('update check');
-  // logger.debug(`timer.delay: ${timer.delay}`);
-  // logger.debug(`timer.last: ${timer.last}`);
-  // if ( !timer.hasElapsed() ) return;
-  if( hasUpdated ) return;
+  logger.debug(`timer.delay: ${timer.delay}`);
+  logger.debug(`timer.last: ${timer.last}`);
+  if ( !timer.hasElapsed() ) return;
+
   try {
     logger.debug('firing an update');
     await updateArticle();
     await trashDocs();
-    hasUpdated = true;
   } catch ( err ) {
     logger.error(`Error in Document update ${err}`);
   } finally {

--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -117,16 +117,18 @@ const trashDocs = async () => {
 /**
  * Update Document data
  */
+let hasUpdated = false;
 const update = async () => {
   logger.debug('update check');
-  logger.debug(`timer.delay: ${timer.delay}`);
-  logger.debug(`timer.last: ${timer.last}`);
-  if ( !timer.hasElapsed() ) return;
-
+  // logger.debug(`timer.delay: ${timer.delay}`);
+  // logger.debug(`timer.last: ${timer.last}`);
+  // if ( !timer.hasElapsed() ) return;
+  if( hasUpdated ) return;
   try {
     logger.debug('firing an update');
     await updateArticle();
     await trashDocs();
+    hasUpdated = true;
   } catch ( err ) {
     logger.error(`Error in Document update ${err}`);
   } finally {

--- a/src/util/fetch.js
+++ b/src/util/fetch.js
@@ -4,11 +4,12 @@
  * Class representing a Fetch Response error
  */
 class HTTPStatusError extends Error {
-  constructor( message, status, statusText ) {
+  constructor( message, status, statusText, response ) {
     super( message );
     this.status = status;
     this.statusText = statusText;
     this.name = 'HTTPStatusError';
+    this.response = response;
   }
 }
 
@@ -24,7 +25,7 @@ class HTTPStatusError extends Error {
 const checkHTTPStatus = response => {
   const { statusText, status, ok } = response;
   if ( !ok ) {
-    throw new HTTPStatusError( `${statusText} (${status})`, status, statusText );
+    throw new HTTPStatusError( `${statusText} (${status})`, status, statusText, response );
   }
   return response;
 };


### PR DESCRIPTION
Logging changes so we don't lose the ability to identify useful info:

- Identify the exact source and type of Error being thrown, namely the PubMed and Crossref resources
- Differentiate between debug and info-level items more appropriately (e.g. HTTP 429 is important)
- For HTTPStatusError, provide access to the fetch response, so we can track headers being sent back (e.g. HTTP 429)

Refs #1251 