### PR TITLE
Create a default uid for queries to semantic search

### DIFF
--- a/src/server/routes/api/document/indra.js
+++ b/src/server/routes/api/document/indra.js
@@ -205,7 +205,8 @@ const getDocuments = ( templates, queryDoc ) => {
         return { semanticScores, articles };
       }
 
-      let { abstract: queryText, pmid: queryUid = uuid() } = queryDoc.citation();
+      let { abstract: queryText, pmid } = queryDoc.citation();
+      let queryUid = pmid || "0"; // semantic search: uid is parsed to Integer
 
       if ( queryText == null ) {
         queryText = handleNoQueryAbastract( queryDoc );


### PR DESCRIPTION
The `query` sent to semantic search should be a  PMID and, when none exists, a dummy string. Semantic search doesn't care what the query uid is (as long as it is an interger-like string), it uses the query text only.

Refs #1263