### PR TITLE
Associated paper (e.g. published version etc) may not have a link 

### DIFF
--- a/src/client/components/editor/info-panel.js
+++ b/src/client/components/editor/info-panel.js
@@ -109,7 +109,7 @@ export class InfoPanel extends Component {
         h('div.editor-info-relations', relations.map( ({ type, links }, i) => [
           h('div.editor-info-relation', { key: i.toString() }, [
             h('span.editor-info-relation-type', `${type} `),
-            h('span.editor-info-links', links.map( ({ url, reference }, j ) =>  h('a.editor-info-link.plain-link', { key: j.toString(), target: '_blank', href: url }, reference ) ) )
+            h('span.editor-info-links', links.map( ({ url, reference }, j ) =>  h( url ? 'a.editor-info-link.plain-link' : 'span',  url ? { key: j.toString(), target: '_blank', href: url }: {}, reference ) ) )
           ])
         ])): null,
       h('div.editor-info-main-sections', [

--- a/src/util/pubmed.js
+++ b/src/util/pubmed.js
@@ -238,9 +238,13 @@ const getRelations = PubmedArticle => {
   const commentsCorrections2Link = ({ RefSource, PMID, DOI }) => {
     const hasPMID = !_.isNil( PMID );
     const hasDOI = !_.isNil( DOI );
-    if( !hasPMID && !hasDOI ) return null;
     const reference = formatRefSource( RefSource );
-    const url = hasPMID ? `${PUBMED_LINK_BASE_URL}${PMID}` : `${DOI_LINK_BASE_URL}${DOI}`;
+    let url = null;
+    if( hasPMID ) {
+      url = `${PUBMED_LINK_BASE_URL}${PMID}`;
+     } else if( hasDOI ){
+      url = `${DOI_LINK_BASE_URL}${DOI}`;
+    }
     return ({ reference, url });
   };
   const raw = _.get( PubmedArticle, [ 'MedlineCitation', 'CommentsCorrectionsList' ], [] );


### PR DESCRIPTION
A paper relation link may have null URL.

Refs #1273.