### PR TITLE
Tweaks to filling the article metadata

### DIFF
--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -334,50 +334,38 @@ class DocumentManagementDocumentComponent extends React.Component {
 
     // Article
     const getDocumentArticle = doc => {
-      let items = null;
-      if( hasIssue( doc, 'paperId' ) ){
-        const { paperId: paperIdIssue } = doc.issues();
-        const paperId = _.get( doc.provided(), 'paperId' );
-        items = [
+      const { authors: { contacts, abbreviation }, title, reference, pmid, doi } = doc.citation();
+      const contactList = _.isArray( contacts ) && contacts.map( contact => `${contact.email} <${contact.name}>` ).join(', ');
+      const { paperId } = doc.provided();
+
+      let items =  [
+          h( 'strong', [
+            pmid ? h( 'a.plain-link.section-item-emphasize', { href: PUBMED_LINK_BASE_URL + pmid, target: '_blank' }, title ) : title
+          ]),
+          abbreviation && reference ? h('small.mute', `${abbreviation}. ${reference}` ) : null,
+          doi ? h( 'small.mute', [
+            h( 'a.plain-link', {
+              href: DOI_LINK_BASE_URL + doi,
+              target: '_blank'
+            }, `DOI: ${doi}` )
+          ]) : null,
+          contactList ? h('small.mute', contactList) : null,
           h( TextEditableComponent, {
-            className: 'full-width',
+            fullWidth: true,
             doc,
             fieldName: 'paperId',
             value: paperId,
-            label: h( 'span', `${paperIdIssue.message}` ),
+            label: h('small.mute', `${paperId} `),
             params: [ { op: 'replace', path: 'article' } ]
           })
-        ];
+      ];
 
-      } else {
-        const { authors: { contacts, abbreviation }, title, reference, pmid, doi } = doc.citation();
-        const contactList = _.isArray( contacts ) && contacts.map( contact => `${contact.email} <${contact.name}>` ).join(', ');
-        const { paperId } = doc.provided();
-
-        items =  [
-            h( 'strong', [
-              h( 'a.plain-link.section-item-emphasize', {
-                href: PUBMED_LINK_BASE_URL + pmid,
-                target: '_blank'
-              }, title )
-            ]),
-            h('small.mute', `${abbreviation}. ${reference}` ),
-            h( 'small.mute', [
-              h( 'a.plain-link', {
-                href: DOI_LINK_BASE_URL + doi,
-                target: '_blank'
-              }, `DOI: ${doi}` )
-            ]),
-            h('small.mute', contactList),
-            h( TextEditableComponent, {
-              fullWidth: true,
-              doc,
-              fieldName: 'paperId',
-              value: paperId,
-              label: h('small.mute', `${paperId} `),
-              params: [ { op: 'replace', path: 'article' } ]
-            })
-          ];
+      if( hasIssue( doc, 'paperId' ) ){
+        const { paperId: paperIdIssue } = doc.issues();
+        const err = h( 'div', {
+          className: makeClassList({ 'issue': true })
+        }, `${paperIdIssue.error.name}: ${paperIdIssue.message}` );
+        items.push( err );
       }
 
       return h( 'div.document-management-document-section', [

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -400,9 +400,12 @@ const fillDocArticle = async ( doc, overwrite = false ) => {
   } else {
     let error;
     const withHttpErr = [ pm, cr ].find( byStatusError );
-    if( withHttpErr ){
-      // HTTPStatusError occurred
+    if( withHttpErr ){ // HTTPStatusError occurred
       error = withHttpErr.reason;
+      if( doc.article() != null ){
+        // Fallback to existing record
+        record = doc.article();
+      }
     } else {
       // Not found
       error = pm.reason || cr.reason;

--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -43,6 +43,7 @@ const docsToUpdate = async () => {
  *
  */
 const updateArticle = async () => {
+  const overwrite = true;
   const chunkify = ( arr, chunkSize = 3 ) => {
     const res = [];
     for (let i = 0; i < arr.length; i += chunkSize) {
@@ -57,7 +58,7 @@ const updateArticle = async () => {
     logger.info( `Updating data for ${docs.length} documents`);
     let chunks = chunkify( docs );
     for( const chunk of chunks ){
-      await Promise.all( chunk.map( fillDocArticle ) );
+      await Promise.all( chunk.map( doc => fillDocArticle( doc, overwrite ) ) );
       await Promise.all( chunk.map( fillDocAuthorProfiles ) );
     }
 

--- a/src/styles/document-management.css
+++ b/src/styles/document-management.css
@@ -25,6 +25,9 @@
   & .complete {
     color: var(--completeColor);
   }
+  & .issue {
+    color: var(--invalidColor);
+  }
 }
 
 .document-management-hidden {
@@ -99,9 +102,6 @@
   color: var(--fadedColor);
 }
 
-.document-management-document-section-label.issue {
-  color: var(--invalidColor);
-}
 
 .document-management-document-section-items {
   display: flex;


### PR DESCRIPTION
This contains minor changes to the way articles are filled and admin:

- [x] CRON should use the author provided paper ID (i.e. title) to update the Document article metadata
- [X] Network errors should fall back to existing article metadata
- [x] Admin console article title field should indicate if there is an existing title + error, rather than just error 

Refs #1281 