### PR TITLE
Admin: Flag entity-related issues

### DIFF
--- a/src/client/components/document-management-components.js
+++ b/src/client/components/document-management-components.js
@@ -315,20 +315,9 @@ class DocumentManagementDocumentComponent extends React.Component {
     // Document Header & Footer
     const getDocumentHeader = doc => {
       return h( 'div.document-management-document-section.meta', [
-        h( 'div.document-management-document-section-items', [
-          h( 'div', [
-            h( 'i.material-icons.hide-by-default.invalid', {
-              className: makeClassList({ 'show': hasIssues( doc ) })
-            }, 'warning' ),
-            // h( 'i.material-icons.hide-by-default.complete', {
-            //   className: makeClassList({ 'show': doc.submitted() || doc.isPublic() })
-            // }, 'check_circle' ),
-            h( 'i.material-icons.hide-by-default.mute', {
-              className: makeClassList({ 'show': doc.trashed() })
-            }, 'delete' )
-          ]),
-
-        ])
+        h( 'i.material-icons.hide-by-default.invalid', {
+          className: makeClassList({ 'show': hasIssues( doc ) })
+        }, 'warning' )
       ]);
     };
 

--- a/src/model/element/complex.js
+++ b/src/model/element/complex.js
@@ -92,6 +92,10 @@ class Complex extends Entity {
     return this.remove( ele, opts );
   }
 
+  normalized(){
+    return true;
+  }
+
   json(){
     return _.assign( {}, super.json(), _.pick( this.syncher.get(), _.keys(DEFAULTS) ) );
   }

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -165,6 +165,25 @@ class Entity extends Element {
     return update;
   }
 
+  normalized(){
+    // normalized := has a name and is associated
+    const name = this.syncher.get('name');
+    return name && this.associated();
+  }
+
+  issues(){
+    const items = [];
+    if( !this.normalized() ){
+      items.push({
+        error: {
+          name: 'Normalization'
+        },
+        message: `Entity with name "${this.name()}" is not normalized`
+      });
+    }
+    return items;
+  }
+
   organism(){
     const assoc = this.association();
 

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -167,7 +167,7 @@ class Entity extends Element {
 
   normalized(){
     // normalized := has a name and is associated
-    const name = this.syncher.get('name');
+    const name = this.name();
     return name && this.associated() && this.completed();
   }
 

--- a/src/model/element/entity.js
+++ b/src/model/element/entity.js
@@ -168,7 +168,7 @@ class Entity extends Element {
   normalized(){
     // normalized := has a name and is associated
     const name = this.syncher.get('name');
-    return name && this.associated();
+    return name && this.associated() && this.completed();
   }
 
   issues(){

--- a/src/styles/document-management.css
+++ b/src/styles/document-management.css
@@ -29,6 +29,10 @@
   & .issue {
     color: var(--invalidColor);
   }
+
+  & .warning {
+    color: var(--brandColorDark);
+  }
 }
 
 .document-management-hidden {


### PR DESCRIPTION
Here I augment the admin/model to flag common entity-level issues:
  - ungrounded (non-complex) entities
  - mixed organisms (could signal orthologue issues)

Question: For convenience, I added an entity `normalized` method, but I can't recall what the difference is between `associated` and `completed`?

Refs #1286, part 'c'