### PR TITLE
More specific message for empty/no match.

### DIFF
--- a/src/client/components/element-info/entity-info.js
+++ b/src/client/components/element-info/entity-info.js
@@ -724,7 +724,8 @@ class EntityInfo extends DataComponent {
         );
       } else if( !s.loadingMatches && s.name && !s.updateDirty ){
         children.push( h('div.entity-info-match-empty', [
-        `We couldn't find  "${s.name}".  Please try renaming "${s.name}" to a clearer, perhaps more standard name.`
+          h('p', `The name "${s.name}" did not match any gene or chemical. Please try another name.`),
+          h('p', `Biofactoid accepts gene names from humans, M. musculus, R. norvegicus, S. cervisiae, D. melanogaster, E. coli, C. elegans, D. rerio, A. thaliana and SARS-CoV-2.`)
         ] ) );
       }
     }


### PR DESCRIPTION
When there is no match to a node name, keep the error message but add more detail about model scope. As before, nodes are still left blank and submission will not be blocked but Document will not proceed to public.

I went back and forth on this, but in the end, should rely on user to correct/delete this node. 

<img width="450" alt="Screenshot 2024-07-24 at 2 00 58 PM" src="https://github.com/user-attachments/assets/bc298aa1-0206-4a0e-9a8f-41c3e1a389b8">


Refs #1286