### PR TITLE
Testing organism hints

### DIFF
--- a/src/model/hint.js
+++ b/src/model/hint.js
@@ -5,11 +5,11 @@ const HINT_TYPE = Object.freeze({
 });
 const HINT_TYPES = _.flatMap(HINT_TYPE);
 
-const HINT_PASSAGE = Object.freeze({
+const PASSAGE_TYPE = Object.freeze({
     TITLE: 'title',
     ABSTRACT: 'abstract'
 });
-const HINT_PASSAGES = _.flatMap(HINT_PASSAGE);
+const PASSAGE_TYPES = _.flatMap(PASSAGE_TYPE);
 
 /*
 * Class representing a Hint.
@@ -51,7 +51,7 @@ class Hint{
 
     set type(value){
         if( value != HINT_TYPES.ORGANISM){
-            throw new Error('Invalid type' + value);
+            throw new TypeError('Invalid type' + value);
         }
         this._type = value;
     }
@@ -62,7 +62,7 @@ class Hint{
 
     set xref(value){
         if (!value.dbPrefix || !value.id){
-            throw new Error('Invalid xref' + JSON.stringify(value));
+            throw new TypeError('Invalid xref' + JSON.stringify(value));
         }
         this._xref = value;
     }
@@ -72,14 +72,14 @@ class Hint{
     }
 
     set section(value){
-        if( value != HINT_PASSAGES.TITLE && value != HINT_PASSAGES.ABSTRACT){
-            throw new Error('Invalid section' + value);
+        if( ! _.includes(PASSAGE_TYPES, value) ) {
+            throw new TypeError('Invalid section' + value);
         }
         this._section = value;
     }
 }
 export { 
     Hint, 
-    HINT_TYPES, 
-    HINT_PASSAGES 
+    HINT_TYPE,
+    PASSAGE_TYPE
 };

--- a/test/pubtator/10.1016_j.molcel.2019.03.023.json
+++ b/test/pubtator/10.1016_j.molcel.2019.03.023.json
@@ -1,0 +1,536 @@
+{
+    "_id": "31003867|None",
+    "id": "10.1016/j.molcel.2019.03.023",
+    "infons": {
+      "doi": "10.1016/j.molcel.2019.03.023",
+      "comment": "M. Musculus orthologues: ANKRD31, REC114"
+    },
+    "passages": [
+      {
+        "infons": {
+          "journal": "Mol Cell. 2019 Jun 6;74(5):1053-1068.e8. doi: 10.1016/j.molcel.2019.03.023. Epub ",
+          "year": "2019",
+          "article-id_pmc": "PMC6555648",
+          "type": "title",
+          "authors": "Boekhout M, Karasu ME, Wang J, Acquaviva L, Pratto F, Brick K, Eng DY, Xu J, Camerini-Otero RD, Patel DJ, Keeney S"
+        },
+        "offset": 0,
+        "text": "REC114 Partner ANKRD31 Controls Number, Timing, and Location of Meiotic DNA Breaks.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "2",
+            "infons": {
+              "identifier": "73673",
+              "type": "Gene",
+              "ncbi_homologene": "83546",
+              "valid": true,
+              "normalized": [
+                73673
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 73673,
+              "biotype": "gene",
+              "name": "Rec114",
+              "accession": "@GENE_REC114"
+            },
+            "text": "REC114",
+            "locations": [
+              {
+                "offset": 0,
+                "length": 6
+              }
+            ]
+          },
+          {
+            "id": "3",
+            "infons": {
+              "identifier": "625662",
+              "type": "Gene",
+              "ncbi_homologene": "110355",
+              "valid": true,
+              "normalized": [
+                625662
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 625662,
+              "biotype": "gene",
+              "name": "Ankrd31",
+              "accession": "@GENE_ANKRD31"
+            },
+            "text": "ANKRD31",
+            "locations": [
+              {
+                "offset": 15,
+                "length": 7
+              }
+            ]
+          }
+        ],
+        "relations": []
+      },
+      {
+        "infons": {
+          "type": "abstract"
+        },
+        "offset": 84,
+        "text": "Double-strand breaks (DSBs) initiate the homologous recombination that is crucial for meiotic chromosome pairing and segregation. Here, we unveil mouse ANKRD31 as a lynchpin governing multiple aspects of DSB formation. Spermatocytes lacking ANKRD31 have altered DSB locations and fail to target DSBs to the pseudoautosomal regions (PARs) of sex chromosomes. They also have delayed and/or fewer recombination sites but, paradoxically, more DSBs, suggesting DSB dysregulation. Unrepaired DSBs and pairing failures-stochastic on autosomes, nearly absolute on X and Y-cause meiotic arrest and sterility in males. Ankrd31-deficient females have reduced oocyte reserves. A crystal structure defines a pleckstrin homology (PH) domain in REC114 and its direct intermolecular contacts with ANKRD31. In vivo, ANKRD31 stabilizes REC114 association with the PAR and elsewhere. Our findings inform a model in which ANKRD31 is a scaffold anchoring REC114 and other factors to specific genomic locations, thereby regulating DSB formation.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "15",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mouse",
+            "locations": [
+              {
+                "offset": 230,
+                "length": 5
+              }
+            ]
+          },
+          {
+            "id": "16",
+            "infons": {
+              "identifier": "625662",
+              "type": "Gene",
+              "ncbi_homologene": "110355",
+              "valid": true,
+              "normalized": [
+                625662
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 625662,
+              "biotype": "gene",
+              "name": "Ankrd31",
+              "accession": "@GENE_ANKRD31"
+            },
+            "text": "ANKRD31",
+            "locations": [
+              {
+                "offset": 236,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "17",
+            "infons": {
+              "identifier": "625662",
+              "type": "Gene",
+              "ncbi_homologene": "110355",
+              "valid": true,
+              "normalized": [
+                625662
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 625662,
+              "biotype": "gene",
+              "name": "Ankrd31",
+              "accession": "@GENE_ANKRD31"
+            },
+            "text": "ANKRD31",
+            "locations": [
+              {
+                "offset": 325,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "18",
+            "infons": {
+              "identifier": "MESH:D007246",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D007246"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D007246",
+              "biotype": "disease",
+              "name": "Infertility",
+              "accession": "@DISEASE_Infertility"
+            },
+            "text": "sterility",
+            "locations": [
+              {
+                "offset": 673,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "19",
+            "infons": {
+              "identifier": "73673",
+              "type": "Gene",
+              "ncbi_homologene": "83546",
+              "valid": true,
+              "normalized": [
+                73673
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 73673,
+              "biotype": "gene",
+              "name": "Rec114",
+              "accession": "@GENE_REC114"
+            },
+            "text": "REC114",
+            "locations": [
+              {
+                "offset": 814,
+                "length": 6
+              }
+            ]
+          },
+          {
+            "id": "20",
+            "infons": {
+              "identifier": "625662",
+              "type": "Gene",
+              "ncbi_homologene": "110355",
+              "valid": true,
+              "normalized": [
+                625662
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 625662,
+              "biotype": "gene",
+              "name": "Ankrd31",
+              "accession": "@GENE_ANKRD31"
+            },
+            "text": "ANKRD31",
+            "locations": [
+              {
+                "offset": 865,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "21",
+            "infons": {
+              "identifier": "625662",
+              "type": "Gene",
+              "ncbi_homologene": "110355",
+              "valid": true,
+              "normalized": [
+                625662
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 625662,
+              "biotype": "gene",
+              "name": "Ankrd31",
+              "accession": "@GENE_ANKRD31"
+            },
+            "text": "ANKRD31",
+            "locations": [
+              {
+                "offset": 883,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "22",
+            "infons": {
+              "identifier": "73673",
+              "type": "Gene",
+              "ncbi_homologene": "83546",
+              "valid": true,
+              "normalized": [
+                73673
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 73673,
+              "biotype": "gene",
+              "name": "Rec114",
+              "accession": "@GENE_REC114"
+            },
+            "text": "REC114",
+            "locations": [
+              {
+                "offset": 902,
+                "length": 6
+              }
+            ]
+          },
+          {
+            "id": "23",
+            "infons": {
+              "identifier": "69597",
+              "type": "Gene",
+              "ncbi_homologene": "4947",
+              "valid": true,
+              "normalized": [
+                69597
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 69597,
+              "biotype": "gene",
+              "name": "Afg3l2",
+              "accession": "@GENE_AFG3L2"
+            },
+            "text": "PAR",
+            "locations": [
+              {
+                "offset": 930,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "24",
+            "infons": {
+              "identifier": "625662",
+              "type": "Gene",
+              "ncbi_homologene": "110355",
+              "valid": true,
+              "normalized": [
+                625662
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 625662,
+              "biotype": "gene",
+              "name": "Ankrd31",
+              "accession": "@GENE_ANKRD31"
+            },
+            "text": "ANKRD31",
+            "locations": [
+              {
+                "offset": 986,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "25",
+            "infons": {
+              "identifier": "73673",
+              "type": "Gene",
+              "ncbi_homologene": "83546",
+              "valid": true,
+              "normalized": [
+                73673
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 73673,
+              "biotype": "gene",
+              "name": "Rec114",
+              "accession": "@GENE_REC114"
+            },
+            "text": "REC114",
+            "locations": [
+              {
+                "offset": 1018,
+                "length": 6
+              }
+            ]
+          }
+        ],
+        "relations": []
+      }
+    ],
+    "relations": [
+      {
+        "id": "R1",
+        "infons": {
+          "score": "0.9995",
+          "role1": {
+            "identifier": "MESH:D007246",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D007246"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D007246",
+            "biotype": "disease",
+            "name": "Infertility",
+            "accession": "@DISEASE_Infertility"
+          },
+          "role2": {
+            "identifier": "625662",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              625662
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 625662,
+            "biotype": "gene",
+            "name": "Ankrd31",
+            "accession": "@GENE_ANKRD31"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "0",
+            "role": "5,4"
+          }
+        ]
+      },
+      {
+        "id": "R2",
+        "infons": {
+          "score": "0.9555",
+          "role1": {
+            "identifier": "625662",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              625662
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 625662,
+            "biotype": "gene",
+            "name": "Ankrd31",
+            "accession": "@GENE_ANKRD31"
+          },
+          "role2": {
+            "identifier": "73673",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              73673
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 73673,
+            "biotype": "gene",
+            "name": "Rec114",
+            "accession": "@GENE_REC114"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "1",
+            "role": "1,0"
+          }
+        ]
+      },
+      {
+        "id": "R3",
+        "infons": {
+          "score": "0.4854",
+          "role1": {
+            "identifier": "69597",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              69597
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 69597,
+            "biotype": "gene",
+            "name": "Afg3l2",
+            "accession": "@GENE_AFG3L2"
+          },
+          "role2": {
+            "identifier": "73673",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              73673
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 73673,
+            "biotype": "gene",
+            "name": "Rec114",
+            "accession": "@GENE_REC114"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "2",
+            "role": "10,9"
+          }
+        ]
+      },
+      {
+        "id": "R4",
+        "infons": {
+          "score": "0.9952",
+          "role1": {
+            "identifier": "625662",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              625662
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 625662,
+            "biotype": "gene",
+            "name": "Ankrd31",
+            "accession": "@GENE_ANKRD31"
+          },
+          "role2": {
+            "identifier": "69597",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              69597
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 69597,
+            "biotype": "gene",
+            "name": "Afg3l2",
+            "accession": "@GENE_AFG3L2"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "3",
+            "role": "8,10"
+          }
+        ]
+      }
+    ],
+    "pmid": 31003867,
+    "pmcid": null,
+    "meta": {},
+    "date": "2019-06-06T00:00:00Z",
+    "journal": "Mol Cell",
+    "authors": [
+      "Boekhout M",
+      "Karasu ME",
+      "Wang J",
+      "Acquaviva L",
+      "Pratto F",
+      "Brick K",
+      "Eng DY",
+      "Xu J",
+      "Camerini-Otero RD",
+      "Patel DJ",
+      "Keeney S"
+    ],
+    "relations_display": [
+      {
+        "name": "associate|@DISEASE_Infertility|@GENE_ANKRD31"
+      },
+      {
+        "name": "associate|@GENE_ANKRD31|@GENE_REC114"
+      },
+      {
+        "name": "associate|@GENE_AFG3L2|@GENE_REC114"
+      },
+      {
+        "name": "associate|@GENE_ANKRD31|@GENE_AFG3L2"
+      }
+    ]
+  }

--- a/test/pubtator/10.1016_j.molcel.2024.01.007.json
+++ b/test/pubtator/10.1016_j.molcel.2024.01.007.json
@@ -1,0 +1,497 @@
+{
+    "_id": "38309274|None",
+    "id": "10.1016/j.molcel.2024.01.007",
+    "infons": {
+      "doi": "10.1016/j.molcel.2024.01.007",
+      "comment": "Get: Missing IκBζ; mapping greek symbol"
+    },
+    "passages": [
+      {
+        "infons": {
+          "journal": "Mol Cell;2024Jan24. doi:10.1016/j.molcel.2024.01.007",
+          "year": "2024",
+          "type": "title",
+          "authors": "Alpsoy A, Wu XS, Pal S, Klingbeil O, Kumar P, El Demerdash O, Nalbant B, Vakoc CR, "
+        },
+        "offset": 0,
+        "text": "IkappaBzeta is a dual-use coactivator of NF-kappaB and POU transcription factors.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "2",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "IkappaBzeta",
+            "locations": [
+              {
+                "offset": 0,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "3",
+            "infons": {
+              "identifier": "4790",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                4790
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 4790,
+              "biotype": "gene",
+              "name": "NFKB1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 41,
+                "length": 9
+              }
+            ]
+          }
+        ],
+        "relations": []
+      },
+      {
+        "infons": {
+          "type": "abstract"
+        },
+        "offset": 82,
+        "text": "OCA-B, OCA-T1, and OCA-T2 belong to a family of coactivators that bind to POU transcription factors (TFs) to regulate gene expression in immune cells. Here, we identify IkappaBzeta (encoded by the NFKBIZ gene) as an additional coactivator of POU TFs. Although originally discovered as an inducible regulator of NF-kappaB, we show here that IkappaBzeta shares a microhomology with OCA proteins and uses this segment to bind to POU TFs and octamer-motif-containing DNA. Our functional experiments suggest that IkappaBzeta requires its interaction with POU TFs to coactivate immune-related genes. This finding is reinforced by epigenomic analysis of MYD88L265P-mutant lymphoma cells, which revealed colocalization of IkappaBzeta with the POU TF OCT2 and NF-kappaB:p50 at hundreds of DNA elements harboring octamer and kappaB motifs. These results suggest that IkappaBzeta is a transcriptional coactivator that can amplify and integrate the output of NF-kappaB and POU TFs at inducible genes in immune cells.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "17",
+            "infons": {
+              "identifier": "5450",
+              "type": "Gene",
+              "ncbi_homologene": "4543",
+              "valid": true,
+              "normalized": [
+                5450
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 5450,
+              "biotype": "gene",
+              "name": "POU2AF1",
+              "accession": "@GENE_POU2AF1"
+            },
+            "text": "OCA-B",
+            "locations": [
+              {
+                "offset": 82,
+                "length": 5
+              }
+            ]
+          },
+          {
+            "id": "18",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "IkappaBzeta",
+            "locations": [
+              {
+                "offset": 251,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "19",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "NFKBIZ",
+            "locations": [
+              {
+                "offset": 279,
+                "length": 6
+              }
+            ]
+          },
+          {
+            "id": "20",
+            "infons": {
+              "identifier": "4790",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                4790
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 4790,
+              "biotype": "gene",
+              "name": "NFKB1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 393,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "21",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "IkappaBzeta",
+            "locations": [
+              {
+                "offset": 422,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "22",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "IkappaBzeta",
+            "locations": [
+              {
+                "offset": 590,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "23",
+            "infons": {
+              "identifier": "MESH:D008223",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D008223"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D008223",
+              "biotype": "disease",
+              "name": "Lymphoma",
+              "accession": "@DISEASE_Lymphoma"
+            },
+            "text": "lymphoma",
+            "locations": [
+              {
+                "offset": 747,
+                "length": 8
+              }
+            ]
+          },
+          {
+            "id": "24",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "IkappaBzeta",
+            "locations": [
+              {
+                "offset": 796,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "25",
+            "infons": {
+              "identifier": "5452",
+              "type": "Gene",
+              "ncbi_homologene": "55674",
+              "valid": true,
+              "normalized": [
+                5452
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 5452,
+              "biotype": "gene",
+              "name": "POU2F2",
+              "accession": "@GENE_POU2F2"
+            },
+            "text": "OCT2",
+            "locations": [
+              {
+                "offset": 824,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "26",
+            "infons": {
+              "identifier": "4790",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                4790
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 4790,
+              "biotype": "gene",
+              "name": "NFKB1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 833,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "27",
+            "infons": {
+              "identifier": "4790",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                4790
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 4790,
+              "biotype": "gene",
+              "name": "NFKB1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "p50",
+            "locations": [
+              {
+                "offset": 843,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "28",
+            "infons": {
+              "identifier": "64332",
+              "type": "Gene",
+              "ncbi_homologene": "12734",
+              "valid": true,
+              "normalized": [
+                64332
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 64332,
+              "biotype": "gene",
+              "name": "NFKBIZ",
+              "accession": "@GENE_NFKBIZ"
+            },
+            "text": "IkappaBzeta",
+            "locations": [
+              {
+                "offset": 939,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "29",
+            "infons": {
+              "identifier": "4790",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                4790
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 4790,
+              "biotype": "gene",
+              "name": "NFKB1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 1029,
+                "length": 9
+              }
+            ]
+          }
+        ],
+        "relations": []
+      }
+    ],
+    "relations": [
+      {
+        "id": "R1",
+        "infons": {
+          "score": "0.9989",
+          "role1": {
+            "identifier": "5452",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              5452
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 5452,
+            "biotype": "gene",
+            "name": "POU2F2",
+            "accession": "@GENE_POU2F2"
+          },
+          "role2": {
+            "identifier": "64332",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              64332
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 64332,
+            "biotype": "gene",
+            "name": "NFKBIZ",
+            "accession": "@GENE_NFKBIZ"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "0",
+            "role": "10,9"
+          }
+        ]
+      },
+      {
+        "id": "R2",
+        "infons": {
+          "score": "0.9979",
+          "role1": {
+            "identifier": "4790",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              4790
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 4790,
+            "biotype": "gene",
+            "name": "NFKB1",
+            "accession": "@GENE_NFKB1"
+          },
+          "role2": {
+            "identifier": "64332",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              64332
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 64332,
+            "biotype": "gene",
+            "name": "NFKBIZ",
+            "accession": "@GENE_NFKBIZ"
+          },
+          "type": "Positive_Correlation"
+        },
+        "nodes": [
+          {
+            "refid": "1",
+            "role": "1,0"
+          }
+        ]
+      }
+    ],
+    "pmid": 38309274,
+    "pmcid": null,
+    "meta": {},
+    "date": "2024-01-24T00:00:00Z",
+    "journal": "Mol Cell",
+    "authors": [
+      "Alpsoy A",
+      "Wu XS",
+      "Pal S",
+      "Klingbeil O",
+      "Kumar P",
+      "El Demerdash O",
+      "Nalbant B",
+      "Vakoc CR"
+    ],
+    "relations_display": [
+      {
+        "name": "associate|@GENE_POU2F2|@GENE_NFKBIZ"
+      },
+      {
+        "name": "positive_correlate|@GENE_NFKB1|@GENE_NFKBIZ"
+      }
+    ]
+  }

--- a/test/pubtator/10.1038_s41556-021-00642-9.json
+++ b/test/pubtator/10.1038_s41556-021-00642-9.json
@@ -1,0 +1,770 @@
+{
+    "_id": "33664495|None",
+    "id": "10.1038/s41556-021-00642-9",
+    "infons": {
+      "doi": "10.1038/s41556-021-00642-9",
+      "comment": "M. musculus orthologue: Aida, Ucp1"
+    },
+    "passages": [
+      {
+        "infons": {
+          "journal": "Nat Cell Biol. 2021 Mar;23(3):268-277. doi: 10.1038/s41556-021-00642-9. Epub 2021 ",
+          "year": "2021",
+          "type": "title",
+          "authors": "Shi M, Huang XY, Ren XY, Wei XY, Ma Y, Lin ZZ, Liu DT, Song L, Zhao TJ, Li G, Yao L, Zhu M, Zhang C, Xie C, Wu Y, Wu HM, Fan LP, Ou J, Zhan YH, Lin SY, Lin SC"
+        },
+        "offset": 0,
+        "text": "AIDA directly connects sympathetic innervation to adaptive thermogenesis by UCP1.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "2",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 0,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "3",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 76,
+                "length": 4
+              }
+            ]
+          }
+        ],
+        "relations": []
+      },
+      {
+        "infons": {
+          "type": "abstract"
+        },
+        "offset": 82,
+        "text": "The sympathetic nervous system-catecholamine-uncoupling protein 1 (UCP1) axis plays an essential role in non-shivering adaptive thermogenesis. However, whether there exists a direct effector that physically connects catecholamine signalling to UCP1 in response to acute cold is unknown. Here we report that outer mitochondrial membrane-located AIDA is phosphorylated at S161 by the catecholamine-activated protein kinase A (PKA). Phosphorylated AIDA translocates to the intermembrane space, where it binds to and activates the uncoupling activity of UCP1 by promoting cysteine oxidation of UCP1. Adipocyte-specific depletion of AIDA abrogates UCP1-dependent thermogenesis, resulting in hypothermia during acute cold exposure. Re-expression of S161A-AIDA, unlike wild-type AIDA, fails to restore the acute cold response in Aida-knockout mice. The PKA-AIDA-UCP1 axis is highly conserved in mammals, including hibernators. Denervation of the sympathetic postganglionic fibres abolishes cold-induced AIDA-dependent thermogenesis. These findings uncover a direct mechanistic link between sympathetic input and UCP1-mediated adaptive thermogenesis.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "25",
+            "infons": {
+              "identifier": "MESH:D002395",
+              "type": "Chemical",
+              "valid": true,
+              "normalized": [
+                "D002395"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D002395",
+              "biotype": "chemical",
+              "name": "Catecholamines",
+              "accession": "@CHEMICAL_Catecholamines"
+            },
+            "text": "catecholamine",
+            "locations": [
+              {
+                "offset": 113,
+                "length": 13
+              }
+            ]
+          },
+          {
+            "id": "26",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 149,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "27",
+            "infons": {
+              "identifier": "MESH:D002395",
+              "type": "Chemical",
+              "valid": true,
+              "normalized": [
+                "D002395"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D002395",
+              "biotype": "chemical",
+              "name": "Catecholamines",
+              "accession": "@CHEMICAL_Catecholamines"
+            },
+            "text": "catecholamine",
+            "locations": [
+              {
+                "offset": 298,
+                "length": 13
+              }
+            ]
+          },
+          {
+            "id": "28",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 326,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "29",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 426,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "30",
+            "infons": {
+              "identifier": "tmVar:p|Allele|S|161;VariantGroup:0;OriginalGene:108909;CorrespondingGene:64853;CorrespondingSpecies:10090",
+              "type": "Variant",
+              "valid": true,
+              "subtype": "ProteinMutation",
+              "database": "litvar",
+              "original_genes_ids": [
+                108909
+              ],
+              "original_gene_id": 108909,
+              "gene_ids": [
+                64853
+              ],
+              "gene_id": 64853,
+              "species_ids": [
+                10090
+              ],
+              "species_id": 10090,
+              "rsids": [],
+              "normalized": [
+                "#64853#",
+                "#64853#"
+              ],
+              "normalized_id": "#64853#",
+              "biotype": "variant",
+              "name": "#64853#",
+              "accession": null
+            },
+            "text": "S161",
+            "locations": [
+              {
+                "offset": 452,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "31",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 527,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "32",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 632,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "33",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 672,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "34",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 710,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "35",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 725,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "36",
+            "infons": {
+              "identifier": "MESH:D007035",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D007035"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D007035",
+              "biotype": "disease",
+              "name": "Hypothermia",
+              "accession": "@DISEASE_Hypothermia"
+            },
+            "text": "hypothermia",
+            "locations": [
+              {
+                "offset": 768,
+                "length": 11
+              }
+            ]
+          },
+          {
+            "id": "37",
+            "infons": {
+              "identifier": "tmVar:p|SUB|S|161|A;HGVS:p.S161A;VariantGroup:0;OriginalGene:108909;CorrespondingGene:64853;CorrespondingSpecies:10090",
+              "type": "Variant",
+              "valid": true,
+              "subtype": "ProteinMutation",
+              "database": "litvar",
+              "hgvs": "p.S161A",
+              "original_genes_ids": [
+                108909
+              ],
+              "original_gene_id": 108909,
+              "gene_ids": [
+                64853
+              ],
+              "gene_id": 64853,
+              "species_ids": [
+                10090
+              ],
+              "species_id": 10090,
+              "rsids": [],
+              "normalized": [
+                "#64853#p.S161A",
+                "#64853#"
+              ],
+              "normalized_id": "#64853#p.S161A",
+              "biotype": "variant",
+              "name": "p.S161A",
+              "accession": "@VARIANT_p.S161A_AIDA_human"
+            },
+            "text": "S161A",
+            "locations": [
+              {
+                "offset": 825,
+                "length": 5
+              }
+            ]
+          },
+          {
+            "id": "38",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 831,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "39",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 854,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "40",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "Aida",
+            "locations": [
+              {
+                "offset": 904,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "41",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mice",
+            "locations": [
+              {
+                "offset": 918,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "42",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 932,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "43",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 937,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "44",
+            "infons": {
+              "identifier": "108909",
+              "type": "Gene",
+              "ncbi_homologene": "11268",
+              "valid": true,
+              "normalized": [
+                108909
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 108909,
+              "biotype": "gene",
+              "name": "Aida",
+              "accession": "@GENE_AIDA"
+            },
+            "text": "AIDA",
+            "locations": [
+              {
+                "offset": 1078,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "45",
+            "infons": {
+              "identifier": "22227",
+              "type": "Gene",
+              "ncbi_homologene": "22524",
+              "valid": true,
+              "normalized": [
+                22227
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 22227,
+              "biotype": "gene",
+              "name": "Ucp1",
+              "accession": "@GENE_UCP1"
+            },
+            "text": "UCP1",
+            "locations": [
+              {
+                "offset": 1187,
+                "length": 4
+              }
+            ]
+          }
+        ],
+        "relations": []
+      }
+    ],
+    "relations": [
+      {
+        "id": "R1",
+        "infons": {
+          "score": "0.7694",
+          "role1": {
+            "identifier": "108909",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              108909
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 108909,
+            "biotype": "gene",
+            "name": "Aida",
+            "accession": "@GENE_AIDA"
+          },
+          "role2": {
+            "identifier": "22227",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              22227
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 22227,
+            "biotype": "gene",
+            "name": "Ucp1",
+            "accession": "@GENE_UCP1"
+          },
+          "type": "Positive_Correlation"
+        },
+        "nodes": [
+          {
+            "refid": "0",
+            "role": "0,1"
+          }
+        ]
+      },
+      {
+        "id": "R2",
+        "infons": {
+          "score": "0.9975",
+          "role1": {
+            "identifier": "MESH:D007035",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D007035"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D007035",
+            "biotype": "disease",
+            "name": "Hypothermia",
+            "accession": "@DISEASE_Hypothermia"
+          },
+          "role2": {
+            "identifier": "108909",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              108909
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 108909,
+            "biotype": "gene",
+            "name": "Aida",
+            "accession": "@GENE_AIDA"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "1",
+            "role": "13,11"
+          }
+        ]
+      },
+      {
+        "id": "R3",
+        "infons": {
+          "score": "0.9889",
+          "role1": {
+            "identifier": "MESH:D002395",
+            "type": "Chemical",
+            "valid": true,
+            "normalized": [
+              "D002395"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D002395",
+            "biotype": "chemical",
+            "name": "Catecholamines",
+            "accession": "@CHEMICAL_Catecholamines"
+          },
+          "role2": {
+            "identifier": "22227",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              22227
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 22227,
+            "biotype": "gene",
+            "name": "Ucp1",
+            "accession": "@GENE_UCP1"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "2",
+            "role": "2,3"
+          }
+        ]
+      }
+    ],
+    "pmid": 33664495,
+    "pmcid": null,
+    "meta": {},
+    "date": "2021-03-01T00:00:00Z",
+    "journal": "Nat Cell Biol",
+    "authors": [
+      "Shi M",
+      "Huang XY",
+      "Ren XY",
+      "Wei XY",
+      "Ma Y",
+      "Lin ZZ",
+      "Liu DT",
+      "Song L",
+      "Zhao TJ",
+      "Li G",
+      "Yao L",
+      "Zhu M",
+      "Zhang C",
+      "Xie C",
+      "Wu Y",
+      "Wu HM",
+      "Fan LP",
+      "Ou J",
+      "Zhan YH",
+      "Lin SY",
+      "Lin SC"
+    ],
+    "relations_display": [
+      {
+        "name": "positive_correlate|@GENE_AIDA|@GENE_UCP1"
+      },
+      {
+        "name": "associate|@DISEASE_Hypothermia|@GENE_AIDA"
+      },
+      {
+        "name": "associate|@CHEMICAL_Catecholamines|@GENE_UCP1"
+      }
+    ]
+  }

--- a/test/pubtator/10.1126_scisignal.abf3535.json
+++ b/test/pubtator/10.1126_scisignal.abf3535.json
@@ -1,0 +1,1482 @@
+{
+    "_id": "34546791|None",
+    "id": "10.1126/scisignal.abf3535",
+    "infons": {
+      "doi": "10.1126/scisignal.abf3535",
+      "comment": "Synonym + ortholog: p50, p65; red-herring: NF-kappaB; title organism; IL-1beta totally buried"
+    },
+    "passages": [
+      {
+        "infons": {
+          "journal": "Sci Signal. 2021 Sep 21;14(701):eabf3535. doi: 10.1126/scisignal.abf3535. Epub ",
+          "year": "2021",
+          "article-id_pmc": "PMC8734558",
+          "type": "title",
+          "authors": "Catheline SE, Bell RD, Oluoch LS, James MN, Escalera-Rivera K, Maynard RD, Chang ME, Dean C, Botto E, Ketz JP, Boyce BF, Zuscik MJ, Jonason JH"
+        },
+        "offset": 0,
+        "text": "IKKbeta-NF-kappaB signaling in adult chondrocytes promotes the onset of age-related osteoarthritis in mice.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "4",
+            "infons": {
+              "identifier": "16150",
+              "type": "Gene",
+              "ncbi_homologene": "7782",
+              "valid": true,
+              "normalized": [
+                16150
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16150,
+              "biotype": "gene",
+              "name": "Ikbkb",
+              "accession": "@GENE_IKBKB"
+            },
+            "text": "IKKbeta",
+            "locations": [
+              {
+                "offset": 0,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "5",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 8,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "6",
+            "infons": {
+              "identifier": "MESH:D010003",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D010003"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D010003",
+              "biotype": "disease",
+              "name": "Osteoarthritis",
+              "accession": "@DISEASE_Osteoarthritis"
+            },
+            "text": "osteoarthritis",
+            "locations": [
+              {
+                "offset": 84,
+                "length": 14
+              }
+            ]
+          },
+          {
+            "id": "7",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mice",
+            "locations": [
+              {
+                "offset": 102,
+                "length": 4
+              }
+            ]
+          }
+        ],
+        "relations": []
+      },
+      {
+        "infons": {
+          "type": "abstract"
+        },
+        "offset": 108,
+        "text": "Canonical nuclear factor kappaB (NF-kappaB) signaling mediated by homo- and heterodimers of the NF-kappaB subunits p65 (RELA) and p50 (NFKB1) is associated with age-related pathologies and with disease progression in posttraumatic models of osteoarthritis (OA). Here, we established that NF-kappaB signaling in articular chondrocytes increased with age, concomitant with the onset of spontaneous OA in wild-type mice. Chondrocyte-specific expression of a constitutively active form of inhibitor of kappaB kinase beta (IKKbeta) in young adult mice accelerated the onset of the OA-like phenotype observed in aging wild-type mice, including degenerative changes in the articular cartilage, synovium, and menisci. Both in vitro and in vivo, chondrocytes expressing activated IKKbeta had a proinflammatory secretory phenotype characterized by markers typically associated with the senescence-associated secretory phenotype (SASP). Expression of these factors was differentially regulated by p65, which contains a transactivation domain, and p50, which does not. Whereas the loss of p65 blocked the induction of genes encoding SASP factors in chondrogenic cells treated with interleukin-1beta (IL-1beta) in vitro, the loss of p50 enhanced the IL-1beta-induced expression of some SASP factors. The loss of p50 further exacerbated cartilage degeneration in mice with chondrocyte-specific IKKbeta activation. Overall, our data reveal that IKKbeta-mediated activation of p65 can promote OA onset and that p50 may limit cartilage degeneration in settings of joint inflammation including advanced age.",
+        "sentences": [],
+        "annotations": [
+          {
+            "id": "45",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 141,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "46",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 204,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "47",
+            "infons": {
+              "identifier": "19697",
+              "type": "Gene",
+              "ncbi_homologene": "32064",
+              "valid": true,
+              "normalized": [
+                19697
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 19697,
+              "biotype": "gene",
+              "name": "Rela",
+              "accession": "@GENE_RELA"
+            },
+            "text": "p65",
+            "locations": [
+              {
+                "offset": 223,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "48",
+            "infons": {
+              "identifier": "19697",
+              "type": "Gene",
+              "ncbi_homologene": "32064",
+              "valid": true,
+              "normalized": [
+                19697
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 19697,
+              "biotype": "gene",
+              "name": "Rela",
+              "accession": "@GENE_RELA"
+            },
+            "text": "RELA",
+            "locations": [
+              {
+                "offset": 228,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "49",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "p50",
+            "locations": [
+              {
+                "offset": 238,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "50",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NFKB1",
+            "locations": [
+              {
+                "offset": 243,
+                "length": 5
+              }
+            ]
+          },
+          {
+            "id": "51",
+            "infons": {
+              "identifier": "MESH:D010003",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D010003"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D010003",
+              "biotype": "disease",
+              "name": "Osteoarthritis",
+              "accession": "@DISEASE_Osteoarthritis"
+            },
+            "text": "osteoarthritis",
+            "locations": [
+              {
+                "offset": 349,
+                "length": 14
+              }
+            ]
+          },
+          {
+            "id": "52",
+            "infons": {
+              "identifier": "MESH:D010003",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D010003"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D010003",
+              "biotype": "disease",
+              "name": "Osteoarthritis",
+              "accession": "@DISEASE_Osteoarthritis"
+            },
+            "text": "OA",
+            "locations": [
+              {
+                "offset": 365,
+                "length": 2
+              }
+            ]
+          },
+          {
+            "id": "53",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "NF-kappaB",
+            "locations": [
+              {
+                "offset": 396,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "54",
+            "infons": {
+              "identifier": "MESH:D010003",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D010003"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D010003",
+              "biotype": "disease",
+              "name": "Osteoarthritis",
+              "accession": "@DISEASE_Osteoarthritis"
+            },
+            "text": "OA",
+            "locations": [
+              {
+                "offset": 504,
+                "length": 2
+              }
+            ]
+          },
+          {
+            "id": "55",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mice",
+            "locations": [
+              {
+                "offset": 520,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "56",
+            "infons": {
+              "identifier": "16150",
+              "type": "Gene",
+              "ncbi_homologene": "7782",
+              "valid": true,
+              "normalized": [
+                16150
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16150,
+              "biotype": "gene",
+              "name": "Ikbkb",
+              "accession": "@GENE_IKBKB"
+            },
+            "text": "inhibitor of kappaB kinase beta",
+            "locations": [
+              {
+                "offset": 593,
+                "length": 31
+              }
+            ]
+          },
+          {
+            "id": "57",
+            "infons": {
+              "identifier": "16150",
+              "type": "Gene",
+              "ncbi_homologene": "7782",
+              "valid": true,
+              "normalized": [
+                16150
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16150,
+              "biotype": "gene",
+              "name": "Ikbkb",
+              "accession": "@GENE_IKBKB"
+            },
+            "text": "IKKbeta",
+            "locations": [
+              {
+                "offset": 626,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "58",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mice",
+            "locations": [
+              {
+                "offset": 650,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "59",
+            "infons": {
+              "identifier": "MESH:D010003",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D010003"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D010003",
+              "biotype": "disease",
+              "name": "Osteoarthritis",
+              "accession": "@DISEASE_Osteoarthritis"
+            },
+            "text": "OA",
+            "locations": [
+              {
+                "offset": 684,
+                "length": 2
+              }
+            ]
+          },
+          {
+            "id": "60",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mice",
+            "locations": [
+              {
+                "offset": 730,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "61",
+            "infons": {
+              "identifier": "MESH:D009402",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D009402"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D009402",
+              "biotype": "disease",
+              "name": "Nephrosis Lipoid",
+              "accession": "@DISEASE_Nephrosis_Lipoid"
+            },
+            "text": "changes",
+            "locations": [
+              {
+                "offset": 759,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "62",
+            "infons": {
+              "identifier": "MESH:D002357",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D002357"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D002357",
+              "biotype": "disease",
+              "name": "Cartilage Diseases",
+              "accession": "@DISEASE_Cartilage_Diseases"
+            },
+            "text": "cartilage",
+            "locations": [
+              {
+                "offset": 784,
+                "length": 9
+              }
+            ]
+          },
+          {
+            "id": "63",
+            "infons": {
+              "identifier": "16150",
+              "type": "Gene",
+              "ncbi_homologene": "7782",
+              "valid": true,
+              "normalized": [
+                16150
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16150,
+              "biotype": "gene",
+              "name": "Ikbkb",
+              "accession": "@GENE_IKBKB"
+            },
+            "text": "IKKbeta",
+            "locations": [
+              {
+                "offset": 879,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "64",
+            "infons": {
+              "type": "Disease",
+              "valid": false,
+              "normalized_id": null,
+              "biotype": "disease"
+            },
+            "text": "proinflammatory",
+            "locations": [
+              {
+                "offset": 893,
+                "length": 15
+              }
+            ]
+          },
+          {
+            "id": "65",
+            "infons": {
+              "identifier": "19697",
+              "type": "Gene",
+              "ncbi_homologene": "32064",
+              "valid": true,
+              "normalized": [
+                19697
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 19697,
+              "biotype": "gene",
+              "name": "Rela",
+              "accession": "@GENE_RELA"
+            },
+            "text": "p65",
+            "locations": [
+              {
+                "offset": 1094,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "66",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "p50",
+            "locations": [
+              {
+                "offset": 1144,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "67",
+            "infons": {
+              "identifier": "19697",
+              "type": "Gene",
+              "ncbi_homologene": "32064",
+              "valid": true,
+              "normalized": [
+                19697
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 19697,
+              "biotype": "gene",
+              "name": "Rela",
+              "accession": "@GENE_RELA"
+            },
+            "text": "p65",
+            "locations": [
+              {
+                "offset": 1185,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "68",
+            "infons": {
+              "identifier": "16176",
+              "type": "Gene",
+              "ncbi_homologene": "481",
+              "valid": true,
+              "normalized": [
+                16176
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16176,
+              "biotype": "gene",
+              "name": "Il1b",
+              "accession": "@GENE_IL1B"
+            },
+            "text": "interleukin-1beta",
+            "locations": [
+              {
+                "offset": 1277,
+                "length": 17
+              }
+            ]
+          },
+          {
+            "id": "69",
+            "infons": {
+              "identifier": "16176",
+              "type": "Gene",
+              "ncbi_homologene": "481",
+              "valid": true,
+              "normalized": [
+                16176
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16176,
+              "biotype": "gene",
+              "name": "Il1b",
+              "accession": "@GENE_IL1B"
+            },
+            "text": "IL-1beta",
+            "locations": [
+              {
+                "offset": 1296,
+                "length": 8
+              }
+            ]
+          },
+          {
+            "id": "70",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "p50",
+            "locations": [
+              {
+                "offset": 1328,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "71",
+            "infons": {
+              "identifier": "16176",
+              "type": "Gene",
+              "ncbi_homologene": "481",
+              "valid": true,
+              "normalized": [
+                16176
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16176,
+              "biotype": "gene",
+              "name": "Il1b",
+              "accession": "@GENE_IL1B"
+            },
+            "text": "IL-1beta",
+            "locations": [
+              {
+                "offset": 1345,
+                "length": 8
+              }
+            ]
+          },
+          {
+            "id": "72",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "p50",
+            "locations": [
+              {
+                "offset": 1407,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "73",
+            "infons": {
+              "identifier": "MESH:D002357",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D002357"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D002357",
+              "biotype": "disease",
+              "name": "Cartilage Diseases",
+              "accession": "@DISEASE_Cartilage_Diseases"
+            },
+            "text": "cartilage degeneration",
+            "locations": [
+              {
+                "offset": 1431,
+                "length": 22
+              }
+            ]
+          },
+          {
+            "id": "74",
+            "infons": {
+              "identifier": "10090",
+              "type": "Species",
+              "valid": true,
+              "normalized": [
+                10090
+              ],
+              "database": "ncbi_taxonomy",
+              "normalized_id": 10090,
+              "biotype": "species",
+              "name": "10090",
+              "accession": null
+            },
+            "text": "mice",
+            "locations": [
+              {
+                "offset": 1457,
+                "length": 4
+              }
+            ]
+          },
+          {
+            "id": "75",
+            "infons": {
+              "identifier": "16150",
+              "type": "Gene",
+              "ncbi_homologene": "7782",
+              "valid": true,
+              "normalized": [
+                16150
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16150,
+              "biotype": "gene",
+              "name": "Ikbkb",
+              "accession": "@GENE_IKBKB"
+            },
+            "text": "IKKbeta",
+            "locations": [
+              {
+                "offset": 1488,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "76",
+            "infons": {
+              "identifier": "16150",
+              "type": "Gene",
+              "ncbi_homologene": "7782",
+              "valid": true,
+              "normalized": [
+                16150
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 16150,
+              "biotype": "gene",
+              "name": "Ikbkb",
+              "accession": "@GENE_IKBKB"
+            },
+            "text": "IKKbeta",
+            "locations": [
+              {
+                "offset": 1538,
+                "length": 7
+              }
+            ]
+          },
+          {
+            "id": "77",
+            "infons": {
+              "identifier": "19697",
+              "type": "Gene",
+              "ncbi_homologene": "32064",
+              "valid": true,
+              "normalized": [
+                19697
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 19697,
+              "biotype": "gene",
+              "name": "Rela",
+              "accession": "@GENE_RELA"
+            },
+            "text": "p65",
+            "locations": [
+              {
+                "offset": 1569,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "78",
+            "infons": {
+              "identifier": "MESH:D010003",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D010003"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D010003",
+              "biotype": "disease",
+              "name": "Osteoarthritis",
+              "accession": "@DISEASE_Osteoarthritis"
+            },
+            "text": "OA",
+            "locations": [
+              {
+                "offset": 1585,
+                "length": 2
+              }
+            ]
+          },
+          {
+            "id": "79",
+            "infons": {
+              "identifier": "18033",
+              "type": "Gene",
+              "ncbi_homologene": "2971",
+              "valid": true,
+              "normalized": [
+                18033
+              ],
+              "database": "ncbi_gene",
+              "normalized_id": 18033,
+              "biotype": "gene",
+              "name": "Nfkb1",
+              "accession": "@GENE_NFKB1"
+            },
+            "text": "p50",
+            "locations": [
+              {
+                "offset": 1603,
+                "length": 3
+              }
+            ]
+          },
+          {
+            "id": "80",
+            "infons": {
+              "identifier": "MESH:D002357",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D002357"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D002357",
+              "biotype": "disease",
+              "name": "Cartilage Diseases",
+              "accession": "@DISEASE_Cartilage_Diseases"
+            },
+            "text": "cartilage degeneration",
+            "locations": [
+              {
+                "offset": 1617,
+                "length": 22
+              }
+            ]
+          },
+          {
+            "id": "81",
+            "infons": {
+              "identifier": "MESH:D007249",
+              "type": "Disease",
+              "valid": true,
+              "normalized": [
+                "D007249"
+              ],
+              "database": "ncbi_mesh",
+              "normalized_id": "D007249",
+              "biotype": "disease",
+              "name": "Inflammation",
+              "accession": "@DISEASE_Inflammation"
+            },
+            "text": "joint inflammation",
+            "locations": [
+              {
+                "offset": 1655,
+                "length": 18
+              }
+            ]
+          }
+        ],
+        "relations": []
+      }
+    ],
+    "relations": [
+      {
+        "id": "R1",
+        "infons": {
+          "score": "0.9995",
+          "role1": {
+            "identifier": "MESH:D010003",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D010003"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D010003",
+            "biotype": "disease",
+            "name": "Osteoarthritis",
+            "accession": "@DISEASE_Osteoarthritis"
+          },
+          "role2": {
+            "identifier": "18033",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              18033
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 18033,
+            "biotype": "gene",
+            "name": "Nfkb1",
+            "accession": "@GENE_NFKB1"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "0",
+            "role": "2,1"
+          }
+        ]
+      },
+      {
+        "id": "R2",
+        "infons": {
+          "score": "0.9992",
+          "role1": {
+            "identifier": "MESH:D002357",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D002357"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D002357",
+            "biotype": "disease",
+            "name": "Cartilage Diseases",
+            "accession": "@DISEASE_Cartilage_Diseases"
+          },
+          "role2": {
+            "identifier": "16150",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              16150
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 16150,
+            "biotype": "gene",
+            "name": "Ikbkb",
+            "accession": "@GENE_IKBKB"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "1",
+            "role": "21,15"
+          }
+        ]
+      },
+      {
+        "id": "R3",
+        "infons": {
+          "score": "0.9993",
+          "role1": {
+            "identifier": "16150",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              16150
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 16150,
+            "biotype": "gene",
+            "name": "Ikbkb",
+            "accession": "@GENE_IKBKB"
+          },
+          "role2": {
+            "identifier": "19697",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              19697
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 19697,
+            "biotype": "gene",
+            "name": "Rela",
+            "accession": "@GENE_RELA"
+          },
+          "type": "Positive_Correlation"
+        },
+        "nodes": [
+          {
+            "refid": "2",
+            "role": "35,36"
+          }
+        ]
+      },
+      {
+        "id": "R4",
+        "infons": {
+          "score": "0.9279",
+          "role1": {
+            "identifier": "18033",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              18033
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 18033,
+            "biotype": "gene",
+            "name": "Nfkb1",
+            "accession": "@GENE_NFKB1"
+          },
+          "role2": {
+            "identifier": "19697",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              19697
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 19697,
+            "biotype": "gene",
+            "name": "Rela",
+            "accession": "@GENE_RELA"
+          },
+          "type": "Bind"
+        },
+        "nodes": [
+          {
+            "refid": "3",
+            "role": "4,6"
+          }
+        ]
+      },
+      {
+        "id": "R5",
+        "infons": {
+          "score": "0.997",
+          "role1": {
+            "identifier": "MESH:D002357",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D002357"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D002357",
+            "biotype": "disease",
+            "name": "Cartilage Diseases",
+            "accession": "@DISEASE_Cartilage_Diseases"
+          },
+          "role2": {
+            "identifier": "18033",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              18033
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 18033,
+            "biotype": "gene",
+            "name": "Nfkb1",
+            "accession": "@GENE_NFKB1"
+          },
+          "type": "Negative_Correlation"
+        },
+        "nodes": [
+          {
+            "refid": "4",
+            "role": "32,31"
+          }
+        ]
+      },
+      {
+        "id": "R6",
+        "infons": {
+          "score": "0.9272",
+          "role1": {
+            "identifier": "16150",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              16150
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 16150,
+            "biotype": "gene",
+            "name": "Ikbkb",
+            "accession": "@GENE_IKBKB"
+          },
+          "role2": {
+            "identifier": "18033",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              18033
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 18033,
+            "biotype": "gene",
+            "name": "Nfkb1",
+            "accession": "@GENE_NFKB1"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "5",
+            "role": "0,1"
+          }
+        ]
+      },
+      {
+        "id": "R7",
+        "infons": {
+          "score": "0.9059",
+          "role1": {
+            "identifier": "16176",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              16176
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 16176,
+            "biotype": "gene",
+            "name": "Il1b",
+            "accession": "@GENE_IL1B"
+          },
+          "role2": {
+            "identifier": "18033",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              18033
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 18033,
+            "biotype": "gene",
+            "name": "Nfkb1",
+            "accession": "@GENE_NFKB1"
+          },
+          "type": "Negative_Correlation"
+        },
+        "nodes": [
+          {
+            "refid": "6",
+            "role": "27,29"
+          }
+        ]
+      },
+      {
+        "id": "R8",
+        "infons": {
+          "score": "0.9978",
+          "role1": {
+            "identifier": "MESH:D010003",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D010003"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D010003",
+            "biotype": "disease",
+            "name": "Osteoarthritis",
+            "accession": "@DISEASE_Osteoarthritis"
+          },
+          "role2": {
+            "identifier": "16150",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              16150
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 16150,
+            "biotype": "gene",
+            "name": "Ikbkb",
+            "accession": "@GENE_IKBKB"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "7",
+            "role": "2,0"
+          }
+        ]
+      },
+      {
+        "id": "R9",
+        "infons": {
+          "score": "0.9995",
+          "role1": {
+            "identifier": "MESH:D010003",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D010003"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D010003",
+            "biotype": "disease",
+            "name": "Osteoarthritis",
+            "accession": "@DISEASE_Osteoarthritis"
+          },
+          "role2": {
+            "identifier": "19697",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              19697
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 19697,
+            "biotype": "gene",
+            "name": "Rela",
+            "accession": "@GENE_RELA"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "8",
+            "role": "10,6"
+          }
+        ]
+      },
+      {
+        "id": "R10",
+        "infons": {
+          "score": "0.9199",
+          "role1": {
+            "identifier": "MESH:D007249",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D007249"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D007249",
+            "biotype": "disease",
+            "name": "Inflammation",
+            "accession": "@DISEASE_Inflammation"
+          },
+          "role2": {
+            "identifier": "18033",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              18033
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 18033,
+            "biotype": "gene",
+            "name": "Nfkb1",
+            "accession": "@GENE_NFKB1"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "9",
+            "role": "40,38"
+          }
+        ]
+      },
+      {
+        "id": "R11",
+        "infons": {
+          "score": "0.986",
+          "role1": {
+            "identifier": "MESH:D009402",
+            "type": "Disease",
+            "valid": true,
+            "normalized": [
+              "D009402"
+            ],
+            "database": "ncbi_mesh",
+            "normalized_id": "D009402",
+            "biotype": "disease",
+            "name": "Nephrosis Lipoid",
+            "accession": "@DISEASE_Nephrosis_Lipoid"
+          },
+          "role2": {
+            "identifier": "16150",
+            "type": "Gene",
+            "valid": true,
+            "normalized": [
+              16150
+            ],
+            "database": "ncbi_gene",
+            "normalized_id": 16150,
+            "biotype": "gene",
+            "name": "Ikbkb",
+            "accession": "@GENE_IKBKB"
+          },
+          "type": "Association"
+        },
+        "nodes": [
+          {
+            "refid": "10",
+            "role": "20,15"
+          }
+        ]
+      }
+    ],
+    "pmid": 34546791,
+    "pmcid": null,
+    "meta": {},
+    "date": "2021-09-21T00:00:00Z",
+    "journal": "Sci Signal",
+    "authors": [
+      "Catheline SE",
+      "Bell RD",
+      "Oluoch LS",
+      "James MN",
+      "Escalera-Rivera K",
+      "Maynard RD",
+      "Chang ME",
+      "Dean C",
+      "Botto E",
+      "Ketz JP",
+      "Boyce BF",
+      "Zuscik MJ",
+      "Jonason JH"
+    ],
+    "relations_display": [
+      {
+        "name": "associate|@DISEASE_Osteoarthritis|@GENE_NFKB1"
+      },
+      {
+        "name": "associate|@DISEASE_Cartilage_Diseases|@GENE_IKBKB"
+      },
+      {
+        "name": "positive_correlate|@GENE_IKBKB|@GENE_RELA"
+      },
+      {
+        "name": "interact|@GENE_NFKB1|@GENE_RELA"
+      },
+      {
+        "name": "inhibit|@DISEASE_Cartilage_Diseases|@GENE_NFKB1"
+      },
+      {
+        "name": "associate|@GENE_IKBKB|@GENE_NFKB1"
+      },
+      {
+        "name": "negative_correlate|@GENE_IL1B|@GENE_NFKB1"
+      },
+      {
+        "name": "associate|@DISEASE_Osteoarthritis|@GENE_IKBKB"
+      },
+      {
+        "name": "associate|@DISEASE_Osteoarthritis|@GENE_RELA"
+      },
+      {
+        "name": "associate|@DISEASE_Inflammation|@GENE_NFKB1"
+      },
+      {
+        "name": "associate|@DISEASE_Nephrosis_Lipoid|@GENE_IKBKB"
+      }
+    ]
+  }

--- a/test/pubtator/10.15252_embj.2023113616.json
+++ b/test/pubtator/10.15252_embj.2023113616.json
@@ -1,0 +1,236 @@
+{
+	"_id": "37317646|None",
+	"id": "10.15252/embj.2023113616",
+	"infons": {
+    "doi": "10.15252/embj.2023113616",
+    "comment": "Human, fly and worm (multiple, erroneous IDs) where human is not priority and others are equal"
+  },
+	"passages": [
+		{
+			"infons": {
+				"journal": "EMBO J;2023Jun15 113616. doi:10.15252/embj.2023113616",
+				"year": "2023",
+				"article-id_pmc": "PMC10425847",
+				"type": "title",
+				"authors": "Dobbelaere J, Su TY, Erdi B, Schleiffer A, Dammermann A, "
+			},
+			"offset": 0,
+			"text": "A phylogenetic profiling approach identifies novel ciliogenesis genes in Drosophila and C. elegans.",
+			"sentences": [],
+			"annotations": [
+				{
+					"id": "2",
+					"infons": {
+						"identifier": "7227",
+						"type": "Species",
+						"valid": true,
+						"normalized": [
+							7227
+						],
+						"database": "ncbi_taxonomy",
+						"normalized_id": 7227,
+						"biotype": "species",
+						"name": "7227",
+						"accession": null
+					},
+					"text": "Drosophila",
+					"locations": [
+						{
+							"offset": 73,
+							"length": 10
+						}
+					]
+				},
+				{
+					"id": "3",
+					"infons": {
+						"identifier": "6239;252961;314391;316080",
+						"type": "Species",
+						"valid": true,
+						"normalized": [
+							6239
+						],
+						"database": "ncbi_taxonomy",
+						"normalized_id": 6239,
+						"biotype": "species",
+						"name": "6239",
+						"accession": null
+					},
+					"text": "C. elegans",
+					"locations": [
+						{
+							"offset": 88,
+							"length": 10
+						}
+					]
+				}
+			],
+			"relations": []
+		},
+		{
+			"infons": {
+				"type": "abstract"
+			},
+			"offset": 100,
+			"text": "Cilia are cellular projections that perform sensory and motile functions in eukaryotic cells. A defining feature of cilia is that they are evolutionarily ancient, yet not universally conserved. In this study, we have used the resulting presence and absence pattern in the genomes of diverse eukaryotes to identify a set of 386 human genes associated with cilium assembly or motility. Comprehensive tissue-specific RNAi in Drosophila and mutant analysis in C. elegans revealed signature ciliary defects for 70-80% of novel genes, a percentage similar to that for known genes within the cluster. Further characterization identified different phenotypic classes, including a set of genes related to the cartwheel component Bld10/CEP135 and two highly conserved regulators of cilium biogenesis. We propose this dataset defines the core set of genes required for cilium assembly and motility across eukaryotes and presents a valuable resource for future studies of cilium biology and associated disorders.",
+			"sentences": [],
+			"annotations": [
+				{
+					"id": "10",
+					"infons": {
+						"identifier": "9606",
+						"type": "Species",
+						"valid": true,
+						"normalized": [
+							9606
+						],
+						"database": "ncbi_taxonomy",
+						"normalized_id": 9606,
+						"biotype": "species",
+						"name": "9606",
+						"accession": null
+					},
+					"text": "human",
+					"locations": [
+						{
+							"offset": 427,
+							"length": 5
+						}
+					]
+				},
+				{
+					"id": "11",
+					"infons": {
+						"identifier": "7227",
+						"type": "Species",
+						"valid": true,
+						"normalized": [
+							7227
+						],
+						"database": "ncbi_taxonomy",
+						"normalized_id": 7227,
+						"biotype": "species",
+						"name": "7227",
+						"accession": null
+					},
+					"text": "Drosophila",
+					"locations": [
+						{
+							"offset": 522,
+							"length": 10
+						}
+					]
+				},
+				{
+					"id": "12",
+					"infons": {
+						"identifier": "6239;252961;314391;316080",
+						"type": "Species",
+						"valid": true,
+						"normalized": [
+							6239
+						],
+						"database": "ncbi_taxonomy",
+						"normalized_id": 6239,
+						"biotype": "species",
+						"name": "6239",
+						"accession": null
+					},
+					"text": "C. elegans",
+					"locations": [
+						{
+							"offset": 556,
+							"length": 10
+						}
+					]
+				},
+				{
+					"id": "13",
+					"infons": {
+						"identifier": "MESH:D002925",
+						"type": "Disease",
+						"valid": true,
+						"normalized": [
+							"D002925"
+						],
+						"database": "ncbi_mesh",
+						"normalized_id": "D002925",
+						"biotype": "disease",
+						"name": "Ciliary Motility Disorders",
+						"accession": "@DISEASE_Ciliary_Motility_Disorders"
+					},
+					"text": "ciliary defects",
+					"locations": [
+						{
+							"offset": 586,
+							"length": 15
+						}
+					]
+				},
+				{
+					"id": "14",
+					"infons": {
+						"identifier": "39647",
+						"type": "Gene",
+						"ncbi_homologene": "45709",
+						"valid": true,
+						"normalized": [
+							39647
+						],
+						"database": "ncbi_gene",
+						"normalized_id": 39647,
+						"biotype": "gene",
+						"name": "Cep135",
+						"accession": "@GENE_CEP135"
+					},
+					"text": "Bld10",
+					"locations": [
+						{
+							"offset": 820,
+							"length": 5
+						}
+					]
+				},
+				{
+					"id": "15",
+					"infons": {
+						"identifier": "9662",
+						"type": "Gene",
+						"ncbi_homologene": "45709",
+						"valid": true,
+						"normalized": [
+							9662
+						],
+						"database": "ncbi_gene",
+						"normalized_id": 9662,
+						"biotype": "gene",
+						"name": "CEP135",
+						"accession": "@GENE_CEP135"
+					},
+					"text": "CEP135",
+					"locations": [
+						{
+							"offset": 826,
+							"length": 6
+						}
+					]
+				}
+			],
+			"relations": []
+		}
+	],
+	"relations": [],
+	"pmid": 37317646,
+	"pmcid": null,
+	"meta": {},
+	"date": "2023-06-15T00:00:00Z",
+	"journal": "EMBO J",
+	"authors": [
+		"Dobbelaere J",
+		"Su TY",
+		"Erdi B",
+		"Schleiffer A",
+		"Dammermann A"
+	],
+	"relations_display": []
+}

--- a/test/pubtator/pubtator.js
+++ b/test/pubtator/pubtator.js
@@ -1,0 +1,25 @@
+import { pubtator_2 } from './10.1016_j.molcel.2019.03.023.json';
+import { pubtator_4 } from './10.1016_j.molcel.2024.01.007.json';
+import { pubtator_5 } from './10.1038_s41556-021-00642-9.json';
+import { pubtator_6 } from './10.1126_scisignal.abf3535.json';
+import { pubtator_7 } from './10.15252_embj.2023113616.json';
+
+/** 
+ * bioCDocuments
+ * 
+ * This is an array of object documents that have set of fields { _id, infons, passages, relations, pmid, etc. }
+ * A passage is and array of 2 objects, each object is either of type: { title or abstract }, and has an 
+ * annotations array of objects where each object indicates the id and the type of the bioentity (i.e gene, species, etc).
+*/
+const bioCDocuments = [
+    //0..1
+    pubtator_2, // pmid: 31003867 | 0 organism hints in title { } | 1 organism hints in abstract: { 10090 aka (Mus musculus): 1 } | text: [ [] , ["mouse"] ]
+    //0..0
+    pubtator_4, // pmid: 38309274 | 0 organism hints in title { } | 0 organism hints in abstract: { } | text: [ [] , [] ]
+    //0..1
+    pubtator_5, // pmid: 33664495 | 0 organism hints in title { } | 1 organism hints in abstract: { 10090 aka (Mus musculus): 1 } | text: [ [] , ["mice"] ]
+    //1..*
+    pubtator_6, // pmid: 34546791 | 1 organism hints in title { 10090 aka (Mus musculus): 1 } | 4 organism hints in abstract: { 10090 aka (Mus musculus): 1 } | text: [ ["mice"] , ["mice" , "mice" , "mice" , "mice"] ]
+    //*..*
+    pubtator_7  // pmid: 37317646 | 2 organism hints in title { 7227 aka (Drosophila melanogaster): 1 , 6239 aka (Caeonorhabditis elegans): 1 } | 3 organism hints in abstract: { 9606 aka (Homo sapiens): 1 , 7227 aka (Drosophila melanogaster): 1 , 6239 aka (Caeonorhabditis elegans): 1 } | text: [ [ "Drosophila" , "C. elegans"] , [ "human" , "Drosophila" , "C. elegans" ] ]                                
+  ];


### PR DESCRIPTION
Testing multiple JSON files that have been retrieved from Pubtator API to obtain organisms from them accurately involves ensuring the following test cases are covered:

- [ ] Presence of organism annotations
- [ ] Non-zero hints
- [ ] Correct hint instances