### PR TITLE
Fetch hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Services:
 - `ORCID_PUBLIC_API_BASE_URL` : url for version of [ORCID](https://orcid.org/) public API
 - `NO_ABSTRACT_HANDLING` : labels directing how to sort documents missing query text. 'text' (default): autogenerate text from templates; 'date': sort by date and ignore text.
 - `CROSSREF_API_BASE_URL` : url for [Crossref Unified Resource API](https://api.crossref.org/)
+- `NCBI_BASE_URL` : url for the NCBI/NLM/NIH
+- `PUBTATOR_API_PATH` : url path for the PubTator3 web service API
 
 Links:
 

--- a/src/config.js
+++ b/src/config.js
@@ -74,6 +74,8 @@ export const SEMANTIC_SEARCH_BASE_URL = env('SEMANTIC_SEARCH_BASE_URL', 'https:/
 export const ORCID_BASE_URL = env('ORCID_BASE_URL', 'https://orcid.org/');
 export const ORCID_PUBLIC_API_BASE_URL = env('ORCID_PUBLIC_API_BASE_URL', 'https://pub.orcid.org/v3.0/');
 export const CROSSREF_API_BASE_URL = env('CROSSREF_API_BASE_URL', 'https://api.crossref.org/');
+export const NCBI_BASE_URL = env('NCBI_NLM_NIH_BASE_URL', 'https://www.ncbi.nlm.nih.gov/');
+export const PUBTATOR_API_PATH = env('PUBTATOR_API_PATH', 'research/pubtator3-api/publications/export/');
 
 // Links
 export const UNIPROT_LINK_BASE_URL = env('UNIPROT_LINK_BASE_URL', 'http://www.uniprot.org/uniprot/');

--- a/test/pubtator/pubtator.js
+++ b/test/pubtator/pubtator.js
@@ -14,6 +14,7 @@ import pubtator_6 from './10.1016_j.molcel.2024.01.007.json';
 import pubtator_7 from './10.15252_embj.2023113616.json';
 import pubtator_8 from './pubtator_8.json';
 import { NCBI_BASE_URL } from '../../src/config.js';
+import { HTTPStatusError } from '../../src/util/fetch.js';
 
 /**
  * bioCDocuments
@@ -218,26 +219,35 @@ describe('pubtator', function () {
       }); // BioC Document
     }); // forEach
   }); // map
-  
+
   describe('get', function(){
-    it('Should be null when no body returned', async function(){
-      let pmid = '38496625';
-      var path = new RegExp( pmid );
+    it('Should reject if bad request', async function(){
+      const pmid = '39131402';
+      const path = new RegExp( pmid );
       nock( NCBI_BASE_URL )
         .get( path )
-        .reply( 200 );
-      let bioCDocument = await pubtator.get( pmid );
-      expect( bioCDocument ).to.be.null;
+        .reply( 400, {
+          "detail": "Could not retrieve publications"
+        });
+
+      return pubtator.get( pmid )
+        .catch( error => {
+          expect( error ).to.be.an.instanceof( HTTPStatusError );
+          expect( error.response.status ).to.equal( 400 );
+        });
     });
 
-    it('Should exist when a body is returned', async function(){
+    it('Should return data when valid request', async function(){
       let pmid = '28041912';
       var path = new RegExp( pmid );
       nock( NCBI_BASE_URL )
         .get( path )
         .reply( 200, { foo: 'bar' } );
-      let bioCDocument = await pubtator.get( pmid );
-      expect( bioCDocument ).to.exist;
+
+      return pubtator.get( pmid )
+        .then( data => {
+          expect( data ).to.exist;
+        });
     });
   }); // get
 
@@ -245,16 +255,6 @@ describe('pubtator', function () {
     it('Should be null when invalid publicationXref provided', async function(){
       let bioCDocument = await pubtator.hints( { dbPrefix: 'bar', id: 'foo'} );
       expect( bioCDocument ).to.be.null;
-    });
-
-    it('Should exist when a body is returned', async function(){
-      let pmid = '28041912';
-      var path = new RegExp( pmid );
-      nock( NCBI_BASE_URL )
-        .get( path )
-        .reply( 200, { foo: 'bar' } );
-      let bioCDocument = await pubtator.get( pmid );
-      expect( bioCDocument ).to.exist;
     });
   }); // hints
 }); // pubtator

--- a/test/pubtator/pubtator.js
+++ b/test/pubtator/pubtator.js
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
 import _ from 'lodash';
+import nock from 'nock';
 
 import { Hint, HINT_TYPE, SECTION } from '../../src/model/hint.js';
-import map from '../../src/server/routes/api/document/hint/pubtator.js';
+import pubtator from '../../src/server/routes/api/document/hint/pubtator.js';
 
 import pubtator_1 from './10.1016_j.molcel.2016.11.034.json';
 import pubtator_2 from './10.1016_j.molcel.2019.03.023.json';
@@ -12,6 +13,7 @@ import pubtator_5 from './10.1126_scisignal.abf3535.json';
 import pubtator_6 from './10.1016_j.molcel.2024.01.007.json';
 import pubtator_7 from './10.15252_embj.2023113616.json';
 import pubtator_8 from './pubtator_8.json';
+import { NCBI_BASE_URL } from '../../src/config.js';
 
 /**
  * bioCDocuments
@@ -44,7 +46,7 @@ describe('pubtator', function () {
         let hints;
 
         before(() => {
-          hints = map(bioCDocument);
+          hints = pubtator.map(bioCDocument);
         });
 
         it('Should map to a non-zero list', function () {
@@ -216,4 +218,43 @@ describe('pubtator', function () {
       }); // BioC Document
     }); // forEach
   }); // map
+  
+  describe('get', function(){
+    it('Should be null when no body returned', async function(){
+      let pmid = '38496625';
+      var path = new RegExp( pmid );
+      nock( NCBI_BASE_URL )
+        .get( path )
+        .reply( 200 );
+      let bioCDocument = await pubtator.get( pmid );
+      expect( bioCDocument ).to.be.null;
+    });
+
+    it('Should exist when a body is returned', async function(){
+      let pmid = '28041912';
+      var path = new RegExp( pmid );
+      nock( NCBI_BASE_URL )
+        .get( path )
+        .reply( 200, { foo: 'bar' } );
+      let bioCDocument = await pubtator.get( pmid );
+      expect( bioCDocument ).to.exist;
+    });
+  }); // get
+
+  describe('hints', function(){
+    it('Should be null when invalid publicationXref provided', async function(){
+      let bioCDocument = await pubtator.hints( { dbPrefix: 'bar', id: 'foo'} );
+      expect( bioCDocument ).to.be.null;
+    });
+
+    it('Should exist when a body is returned', async function(){
+      let pmid = '28041912';
+      var path = new RegExp( pmid );
+      nock( NCBI_BASE_URL )
+        .get( path )
+        .reply( 200, { foo: 'bar' } );
+      let bioCDocument = await pubtator.get( pmid );
+      expect( bioCDocument ).to.exist;
+    });
+  }); // hints
 }); // pubtator


### PR DESCRIPTION
### Key changes on the hint service:
- PubTator API path is now configurable
- get a BioCDocument from the PubTator
- A simple wrapper to retrieve Hints from PubTator