### PR TITLE
Title matching tests

### DIFF
--- a/src/styles/citation.css
+++ b/src/styles/citation.css
@@ -17,14 +17,14 @@
     }
   }
 
-  & li:after {
+  & li::after {
     content: '\00b7';
     margin: 0 0.5em;
   }
-  li:last-child:after { content: none; }
+  li:last-child::after { content: none; }
 }
 
-.citation  .citation-flags {
+.citation .citation-flags {
   margin: 0.5em 0;
 
   & .citation-flag {

--- a/src/util/article.js
+++ b/src/util/article.js
@@ -25,6 +25,10 @@ const doesMatch = ( title, other ) => {
   return title === other || _.includes( title, other ) || _.includes( other, title );
 };
 
+// PubMed appears to transform LEFT (U+2018) and RIGHT (U+2019) SINGLE QUOTATION MARKs to APOSTROPHE (U+0027)
+// Crossref does not apoear to do this
+const apostrophize = str => str.replace(/[\u2018|\u2019]/g, '\'');
+
 /**
  * Match a title string against a candidate
  *
@@ -38,7 +42,8 @@ function testTitle( title, other ) {
     .map( lowerCase )
     .map( undash )
     .map( unformat )
-    .map( deburr );
+    .map( deburr )
+    .map( apostrophize );
   return doesMatch( title, other );
 }
 

--- a/test/util/article.js
+++ b/test/util/article.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-// import _ from 'lodash';
 
 import { testTitle } from '../../src/util/article.js';
 
@@ -94,9 +93,16 @@ describe('article', function () {
 
     describe('Markup', function () {
 
-      it('Should drop HTML tags ', function () {
+      it('Should drop HTML tags', function () {
         const title = '<i>Trans</i>regulation of an odorant binding protein by a proto-Y chromosome affects male courtship in house fly';
         const other = 'Transregulation of an odorant binding protein by a proto-Y chromosome affects male courtship in house fly';
+        const isSimilar = testTitle(title, other);
+        expect( isSimilar ).to.be.true;
+      });
+
+      it('Should drop escaped HTML tags', function () {
+        const title = 'Yerba mate (Ilex paraguariensis) genome provides new insights into convergent evolution of caffeine biosynthesis';
+        const other = 'Yerba mate (<i>Ilex paraguariensis<\/i>) genome provides new insights into convergent evolution of caffeine biosynthesis';
         const isSimilar = testTitle(title, other);
         expect( isSimilar ).to.be.true;
       });
@@ -121,6 +127,18 @@ describe('article', function () {
       it('Should be true when other includes title and vice versa', function () {
         const title = '[Clinical Study of Ibrutinib Combined with Venetoclax Regimen in the Treatment of Relapsed/Refractory Diffuse Large B-Cell Lymphoma]';
         const other = '[Clinical Study of Ibrutinib Combined with Venetoclax Regimen in the Treatment of Relapsed/Refractory Diffuse Large B-Cell Lymphoma]';
+        let isSimilar = testTitle(title, other);
+        expect( isSimilar ).to.be.true;
+      });
+
+    }); // Includes
+
+    describe('Incorrect replacement of apostrophe', function () {
+
+      it('Should be true when apostrophes are misused', function () {
+        const title = 'Saccharomyces cerevisiae Rev7 promotes non-homologous end-joining by blocking Mre11 nuclease and Rad50’s ATPase activities and homologous recombination';
+        const other = 'Saccharomyces cerevisiae Rev7 promotes non-homologous end-joining by blocking Mre11 nuclease and Rad50\'s ATPase activities and homologous recombination';
+
         let isSimilar = testTitle(title, other);
         expect( isSimilar ).to.be.true;
       });

--- a/test/util/article.js
+++ b/test/util/article.js
@@ -133,12 +133,18 @@ describe('article', function () {
 
     }); // Includes
 
-    describe('Incorrect replacement of apostrophe', function () {
+    describe('Single quatation and apostrophe', function () {
 
-      it('Should be true when apostrophes are misused', function () {
+      it('Should be true when right single quotations are replaced by apostrophes', function () {
         const title = 'Saccharomyces cerevisiae Rev7 promotes non-homologous end-joining by blocking Mre11 nuclease and Rad50’s ATPase activities and homologous recombination';
         const other = 'Saccharomyces cerevisiae Rev7 promotes non-homologous end-joining by blocking Mre11 nuclease and Rad50\'s ATPase activities and homologous recombination';
+        let isSimilar = testTitle(title, other);
+        expect( isSimilar ).to.be.true;
+      });
 
+      it('Should be true when nested right single quotations are replaced by apostrophes', function () {
+        const title = 'Just say ‘I don’t know’: Understanding information stagnation during a highly ambiguous visual search task';
+        const other = 'Just say \'I don\'t know\': Understanding information stagnation during a highly ambiguous visual search task';
         let isSimilar = testTitle(title, other);
         expect( isSimilar ).to.be.true;
       });


### PR DESCRIPTION
Edge case in title match: PubMed appears to normalize all quotation marks as apostrophes. Crossref does perform any modifications. 

Also, left over css lint from #1314.

Refs #1297