### PR TITLE
Fix Sciwheel from breaking formatting of entity synonyms

### DIFF
--- a/src/styles/highlighter.css
+++ b/src/styles/highlighter.css
@@ -1,3 +1,7 @@
 .highlighter-term {
   background-color: rgba(255, 255, 0, 0.2);
 }
+
+.highlighter {
+  display: inline-block;
+}


### PR DESCRIPTION
With Sciwheel installed, the synonyms are broken.  This patch fixes it.

See screenshot:

<img width="467" alt="Screenshot 2025-01-29 at 16 45 08" src="https://github.com/user-attachments/assets/274cc8a9-48f6-4bf5-99e7-039f1737ff36" />


