### PR TITLE
Allow updates to Document article only under certain conditions

### DIFF
--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -400,6 +400,7 @@ const fillDocArticle = async ( doc, overwrite = false ) => {
     //TODO - case where a manual update of the title occurs
     // In this case, we DO want to override an existing article.
     // this is unlike cron update, where we don't want to break existing articles
+    // e.g. preprint, version vs publication.
 
     // Fallback to an existing article
     const article = doc.article();

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -396,18 +396,24 @@ const fillDocArticle = async ( doc, overwrite = false ) => {
     await doc.issues({ paperId: null });
 
   } else {
-    let error;
-    const withHttpErr = [ pm, cr ].find( byStatusError );
-    if( withHttpErr ){ // HTTPStatusError occurred
-      error = withHttpErr.reason;
-      if( doc.article() != null ){
-        // Fallback to existing record
-        record = doc.article();
-      }
-    } else {
-      // Not found
-      error = pm.reason || cr.reason;
+
+    //TODO - case where a manual update of the title occurs
+    // In this case, we DO want to override an existing article.
+    // this is unlike cron update, where we don't want to break existing articles
+
+    // Fallback to an existing article
+    const article = doc.article();
+    if( article ){
+      record = article;
     }
+
+    // Prioritize HTTPStatusError
+    let error = pm.reason || cr.reason;
+    const withHttpErr = [ pm, cr ].find( byStatusError );
+    if( withHttpErr ){
+      error = withHttpErr.reason;
+    }
+
     await doc.issues({ paperId: { error, message: error.message } });
   }
 

--- a/src/server/routes/api/document/index.js
+++ b/src/server/routes/api/document/index.js
@@ -349,7 +349,7 @@ const fillDocCorrespondence = async doc => {
   }
 };
 
-const fillDocArticle = async ( doc, overwrite = true ) => {
+const fillDocArticle = async ( doc, fallback = false ) => {
   const isFound = ({ status }) => status === 'fulfilled';
   const notFound = ({ status, reason }) => status === 'rejected' && reason.name === ArticleIDError.name;
   const byStatusError = ({ status, reason }) => status === 'rejected' && reason.name === HTTPStatusError.name;
@@ -393,20 +393,18 @@ const fillDocArticle = async ( doc, overwrite = true ) => {
 
   } else {
 
+    // Prioritize an HTTP error when one exists
     let error = pm.reason || cr.reason;
-
-    // Check for an HTTP error
     const withHttpErr = [ pm, cr ].find( byStatusError );
-    const hasHttpErr = !_.isNil( withHttpErr );
-    if( hasHttpErr ){
+    if( withHttpErr ){
       error = withHttpErr.reason;
     }
 
-    // Fallback to an existing article under certain conditions
+    // Fallback to an existing article when explicitly instructed
     const article = doc.article();
     const hasArticle = !_.isNil( article );
-    const shouldReplace = overwrite && hasArticle && !hasHttpErr;
-    if( shouldReplace ){
+    const useExisting = fallback && hasArticle;
+    if( useExisting ){
       record = article;
     }
 

--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -43,7 +43,7 @@ const docsToUpdate = async () => {
  *
  */
 const updateArticle = async () => {
-  const overwrite = true;
+  const overwrite = false;
   const chunkify = ( arr, chunkSize = 3 ) => {
     const res = [];
     for (let i = 0; i < arr.length; i += chunkSize) {

--- a/src/server/routes/api/document/update.js
+++ b/src/server/routes/api/document/update.js
@@ -43,7 +43,7 @@ const docsToUpdate = async () => {
  *
  */
 const updateArticle = async () => {
-  const overwrite = false;
+  const fallback = true;
   const chunkify = ( arr, chunkSize = 3 ) => {
     const res = [];
     for (let i = 0; i < arr.length; i += chunkSize) {
@@ -58,7 +58,7 @@ const updateArticle = async () => {
     logger.info( `Updating data for ${docs.length} documents`);
     let chunks = chunkify( docs );
     for( const chunk of chunks ){
-      await Promise.all( chunk.map( doc => fillDocArticle( doc, overwrite ) ) );
+      await Promise.all( chunk.map( doc => fillDocArticle( doc, fallback ) ) );
       await Promise.all( chunk.map( fillDocAuthorProfiles ) );
     }
 


### PR DESCRIPTION
This PR concerns filling/updating a Document's `article`, in particular, only allowing the CRON job to replace the article  when it legitimately finds a new article. In this PR, DO NOT allow a automatic (CRON) update to replace `article` on any failure stemming from (a) no matching database (e.g. PubMed) record found  or (b) HTTP error. 

I'm also attaching here a RethinkDB  dump with useful test cases for updating articles, and pasting in a README to make testing easier. 

Refs #1323

[factoid_dump_2025-03-19_update-tests.tar.gz](https://github.com/user-attachments/files/19369267/factoid_dump_2025-03-19_update-tests.tar.gz)
[README.md](https://github.com/user-attachments/files/19369268/README.md)
