### PR TITLE
Preprint match tweaks

### DIFF
--- a/src/server/routes/api/document/crossref/api.js
+++ b/src/server/routes/api/document/crossref/api.js
@@ -34,7 +34,7 @@ const checkResultStatus = json => {
 const search = (q, opts) => {
   const DEFAULT_WORKS_PARAMS = {
     'query.bibliographic': undefined, //query field for: citation look up, includes titles, authors, ISSNs and publication years
-    'rows': 5
+    'rows': 10
   };
   const formatSearchHits = json => {
     const searchHits =  _.get( json, ['message', 'items'] );

--- a/src/server/routes/api/document/crossref/works.js
+++ b/src/server/routes/api/document/crossref/works.js
@@ -67,7 +67,8 @@ const findPreprint = async paperId => {
   const VALID_PUBLISHERS = new Set([
     'Cold Spring Harbor Laboratory',
     'eLife Sciences Publications, Ltd',
-    'Research Square Platform LLC'
+    'Research Square Platform LLC',
+    'Springer Science and Business Media LLC'
   ]);
   const isPreprint = ({ type, subtype }) => VALID_SUBTYPES.has( subtype ) && VALID_TYPES.has( type );
   const isRecognizedPublisher = ({ publisher }) => VALID_PUBLISHERS.has( publisher );


### PR DESCRIPTION
Minor changes to preprint support

- Allow new/additional `publisher` for Research Square (Nature Springer's preprint archive)
- Grab a few more search records to sort through

Refs #1322